### PR TITLE
[cli] dbconsole_config use $EDITOR instead of vi

### DIFF
--- a/scalikejdbc-cli/scripts/setup.sh
+++ b/scalikejdbc-cli/scripts/setup.sh
@@ -23,7 +23,7 @@ fi
 
 echo '#!/bin/sh
 cd `dirname $0`
-vi ~/bin/scalikejdbc-cli/config.properties
+${EDITOR:=vi} ~/bin/scalikejdbc-cli/config.properties
 ' > ${DBCONSOLE_CONFIG_COMMAND}
 
 echo '#!/bin/sh


### PR DESCRIPTION
Open config.properties with user's favorite editor.
