### PR TITLE
[cli] Added setup script for Windows.

### DIFF
--- a/scalikejdbc-cli/scripts/setup.bat
+++ b/scalikejdbc-cli/scripts/setup.bat
@@ -107,8 +107,8 @@ if exist "%dbconsole_command%" ( del /f /q "%dbconsole_command%" )
 >>"%dbconsole_command%" echo exit /b 0
 >>"%dbconsole_command%" echo.
 >>"%dbconsole_command%" echo :run_sbt
->>"%dbconsole_command%" echo   call java -Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=384M ^^
->>"%dbconsole_command%" echo     -jar %%~dp0/sbt-launch.jar ^^
+>>"%dbconsole_command%" echo   call java -Xms512M -Xmx512M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=384M ^^
+>>"%dbconsole_command%" echo     -jar "%%~dp0\sbt-launch.jar" ^^
 >>"%dbconsole_command%" echo     -Dscalikejdbc-cli.config.profile=%%_profile%% ^^
 >>"%dbconsole_command%" echo     %%1
 >>"%dbconsole_command%" echo exit /b 0


### PR DESCRIPTION
I just created a Windows  installation script for dbconsole. 

---

`setup.sh`を参考に、dbconsoleのWindows用インストールスクリプトを作成しました。

以下の環境で確認しています。
- Windows 7 64bit
- Windows 8 64bit

Windows標準コマンドに`wget`相当のものが無いため、バッチファイルに、ファイルをダウンロードするJScriptを埋め込んで対応しています。

環境変数の設定も、`.bash_profile`相当のものがないため、手動で環境変数`Path`に、インストール先のパスを設定してもらうように表示しています。
