### PR TITLE
[library] Adding #foldLeft operation

### DIFF
--- a/scalikejdbc-library/src/main/scala/scalikejdbc/DBSession.scala
+++ b/scalikejdbc-library/src/main/scala/scalikejdbc/DBSession.scala
@@ -152,6 +152,22 @@ trait DBSession extends LogSupport {
   }
 
   /**
+   * folding into one value.
+   *
+   * @param template SQL template
+   * @param params parameters
+   * @param init initial value
+   * @param f function
+   * @return folded value
+   */
+  def foldLeft[A](template: String, params: Any*)(init: A)(f: ((A, WrappedResultSet)) => A): A = {
+    using(createStatementExecutor(conn, template, params)) {
+      executor =>
+        new ResultSetTraversable(executor.executeQuery()).foldLeft(init)(f)
+    }
+  }
+
+  /**
    * Returns query result as [[scala.collection.Traversable]] object.
    *
    * @param template SQL template

--- a/scalikejdbc-library/src/main/scala/scalikejdbc/ResultSetTraversable.scala
+++ b/scalikejdbc-library/src/main/scala/scalikejdbc/ResultSetTraversable.scala
@@ -30,11 +30,20 @@ class ResultSetTraversable(rs: ResultSet) extends Traversable[WrappedResultSet] 
    * @param f function
    * @tparam U type
    */
-  def foreach[U](f: (WrappedResultSet) => U): Unit = {
+  def foreach[U](f: (WrappedResultSet) => U): Unit = foldLeft(()) { case (_, rs) => f(rs) }
+
+  /**
+   * folding results.
+   * @param f function
+   * @tparam U type
+   */
+  def foldLeft[U](init: U)(f: ((U, WrappedResultSet)) => U): U = {
+    var sentinel = init
     while (rs.next()) {
       cursor.position += 1
-      f.apply(new WrappedResultSet(rs, cursor, cursor.position))
+      sentinel = f((sentinel, new WrappedResultSet(rs, cursor, cursor.position)))
     }
+    sentinel
   }
 
 }

--- a/scalikejdbc-library/src/main/scala/scalikejdbc/SQL.scala
+++ b/scalikejdbc-library/src/main/scala/scalikejdbc/SQL.scala
@@ -229,6 +229,17 @@ abstract class SQL[A, E <: WithExtractor](sql: String)(params: Any*)(extractor: 
   }
 
   /**
+   * folding into one value
+   * @param init initial value
+   * @param op operation
+   */
+  def foldLeft[A](init: A)(op: ((A, WrappedResultSet)) => A)(implicit session: DBSession): A = session match {
+    case AutoSession => DB autoCommit (s => s.foldLeft(sql, params: _*)(init)(op))
+    case NamedAutoSession(name) => NamedDB(name) autoCommit (s => s.foldLeft(sql, params: _*)(init)(op))
+    case _ => session.foldLeft(sql, params: _*)(init)(op)
+  }
+
+  /**
    * Maps values from each [[scalikejdbc.WrappedResultSet]] object.
    * @param extractor extractor function
    * @tparam A return type


### PR DESCRIPTION
I want to folding for join queries or map building.

``` scala
type EmployeeId = Int
type GroupId = Int

val result: Map[GroupId, Set[EmployeeId]] = 
  sql"SELECT id, group_id FROM employee".foldLeft(Map.empty[GroupId, Set[EmployeeId]].withDefaultValue(Set.empty)) {
    case (map, rs) => 
      val gId = rs.int("group_id")
      val eId = rs.int("id")
      map + (gId -> (map(gid) + eId))
}
```
