### PR TITLE
Added dynamic into SQLSyntaxProvider

### DIFF
--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
@@ -31,7 +31,7 @@ class SQLInterpolationSpec extends FlatSpec with ShouldMatchers {
 
           val id = 3
           val u = User.syntax("u")
-          val user = sql"select ${u.result.*} from ${User.as(u)} where ${u.c("id")} = ${id}".map {
+          val user = sql"select ${u.result.*} from ${User.as(u)} where ${u.id} = ${id}".map {
             rs => User(id = rs.int(u.result.id), name = rs.string(u.result.name))
           }.single.apply()
           user.isDefined should equal(true)


### PR DESCRIPTION
from

``` scala
          val user = sql"select ${u.result.*} from ${User.as(u)} where ${u.c("id")} = ${id}".map {
            rs => User(id = rs.int(u.result.id), name = rs.string(u.result.name))
          }.single.apply()
```

to

``` scala
          val user = sql"select ${u.result.*} from ${User.as(u)} where ${u.id} = ${id}".map {
            rs => User(id = rs.int(u.result.id), name = rs.string(u.result.name))
          }.single.apply()
```
