### PR TITLE
Added naming rule converter and SQLSyntaxProvider type check

### DIFF
--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLInterpolation.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLInterpolation.scala
@@ -22,9 +22,9 @@ object SQLInterpolation {
   trait SQLSyntaxSupport {
     def tableName: String
     def columns: Seq[String]
-    def syntax() = SQLSyntaxProvider(this, this.tableName)
-    def syntax(name: String) = SQLSyntaxProvider(this, name)
-    def as(provider: SQLSyntaxProvider[_]) = {
+    def syntax() = SQLSyntaxProvider[this.type](this, this.tableName)
+    def syntax(name: String) = SQLSyntaxProvider[this.type](this, name)
+    def as(provider: SQLSyntaxProvider[this.type]) = {
       if (tableName == provider.tableAliasName) { SQLSyntax(tableName) }
       else { SQLSyntax(tableName + " " + provider.tableAliasName) }
     }

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
@@ -69,12 +69,13 @@ class SQLInterpolationSpec extends FlatSpec with ShouldMatchers {
           val id = 1
           val u = User.syntax("u")
           val c = Contract.syntax("c")
+          // sql"""${User.as(c)}""" compile error!
           val contracts = sql"""
             select
               ${c.result.*}
             from
               ${User.as(u)},
-              ${Contract.as(u)}
+              ${Contract.as(c)}
             where
               ${c.id} = ${u.id}
               and ${u.id} = ${id}


### PR DESCRIPTION
### Naming roule

default naming rule is CamelCase to snake_case
### SQLSyntaxProvider type check

``` scala
val u = User.syntax("u")
val c = Contract.syntax("c")
sql"""${User.as(c)}"""  // It makes this compile error!
```
