### PR TITLE
Close default connection when ConnectionPool#close is called with no argument.

### DIFF
--- a/scalikejdbc-library/src/main/scala/scalikejdbc/ConnectionPool.scala
+++ b/scalikejdbc-library/src/main/scala/scalikejdbc/ConnectionPool.scala
@@ -127,7 +127,7 @@ object ConnectionPool extends LogSupport {
    * Close a pool by name
    * @param name pool name
    */
-  def close(name: Any): Unit = {
+  def close(name: Any = DEFAULT_NAME): Unit = {
     pools.synchronized {
       val removed = pools.remove(name)
       removed.foreach { pool => pool.close() }

--- a/scalikejdbc-library/src/test/scala/scalikejdbc/ConnectionPoolSpec.scala
+++ b/scalikejdbc-library/src/test/scala/scalikejdbc/ConnectionPoolSpec.scala
@@ -23,7 +23,17 @@ class ConnectionPoolSpec extends FlatSpec with ShouldMatchers {
   it should "be available" in {
     val poolSettings = new ConnectionPoolSettings(initialSize = 50, maxSize = 50)
     ConnectionPool.singleton(url, user, password, poolSettings)
-    ConnectionPool.add('unused, url, user, password, poolSettings)
+    ConnectionPool.borrow() should not be (null)
+    ConnectionPool.add('secondary, url, user, password, poolSettings)
+    ConnectionPool.borrow('secondary) should not be (null)
+
+    // close default connection
+    ConnectionPool.close()
+    intercept[java.lang.IllegalStateException] { ConnectionPool.borrow() }
+
+    // close secondary connection
+    ConnectionPool.close('secondary)
+    intercept[java.lang.IllegalStateException] { ConnectionPool.borrow('secondary) }
   }
 
   it should "be acceptable external ConnectionPoolFactory" in {


### PR DESCRIPTION
Now, default connection is closed with `ConnectionPool#close('default)` or `ConnectionPool#close(ConnectionPool.DEFAULT_NAME)`.
It seems to be more natural that default connection is closed with `ConnectionPool#close()`.
