### PR TITLE
Changed TypesafeConfigReader#readJDBCSettings to accept null user and password

### DIFF
--- a/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfigReader.scala
+++ b/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfigReader.scala
@@ -85,9 +85,9 @@ trait TypesafeConfigReader { self: TypesafeConfig =>
     (for {
       driver <- configMap.get("driver")
       url <- configMap.get("url")
-      user <- configMap.get("user")
-      password <- configMap.get("password")
     } yield {
+      val user = configMap.get("user").orNull[String]
+      val password = configMap.get("password").orNull[String]
       JDBCSettings(driver, url, user, password)
     }) getOrElse {
       throw new ConfigurationException("Configuration error for database " + dbName + ". " + configMap.toString)

--- a/scalikejdbc-config/src/test/resources/application.conf
+++ b/scalikejdbc-config/src/test/resources/application.conf
@@ -27,8 +27,6 @@ db.bar.poolValidationQuery="select 1 as bar"
 
 db.baz.url="jdbc:h2:mem:test4"
 db.baz.driver="org.h2.Driver"
-db.baz.user="sa4"
-db.baz.password="secret4"
 
 scalikejdbc.global.loggingSQLAndTime.enabled=true
 scalikejdbc.global.loggingSQLAndTime.logLevel=debug

--- a/scalikejdbc-config/src/test/scala/scalikejdbc/config/TypesafeConfigReaderSpec.scala
+++ b/scalikejdbc-config/src/test/scala/scalikejdbc/config/TypesafeConfigReaderSpec.scala
@@ -33,6 +33,13 @@ class TypesafeConfigReaderSpec extends FunSpec with ShouldMatchers {
         TypesafeConfigReader.readJDBCSettings('foo) should be (expected)
       }
 
+      describe ("When user and password is not specified in application.conf") {
+        it ("should return JDBCSettings the user and password of which is null") {
+          val expected = JDBCSettings("org.h2.Driver", "jdbc:h2:mem:test4", null, null)
+          TypesafeConfigReader.readJDBCSettings('baz) should be (expected)
+        }
+      }
+
       describe ("When configuration file is empty") {
         it ("throws Configuration Exception") {
           intercept[ConfigurationException] {


### PR DESCRIPTION
Null user and password is accepted depending on the settings of databases.
When the user and password is not specified, `TypesafeConfigReader#readJDBCSettings` returns `JDBCSettings` the user and password of which is null.
