### PR TITLE
avoid NoSuchElementException if column is empty

### DIFF
--- a/scalikejdbc-library/src/main/scala/scalikejdbc/metadata/Table.scala
+++ b/scalikejdbc-library/src/main/scala/scalikejdbc/metadata/Table.scala
@@ -45,6 +45,9 @@ case class Table(name: String,
    * @return describe style string value
    */
   def toDescribeStyleString: String = {
+    if (columns.isEmpty) {
+      return "table " + name + " does not have any columns"
+    }
 
     def withoutCRLF(str: String): String = {
       if (str == null) null


### PR DESCRIPTION
```
java.util.NoSuchElementException: head of empty list
        at scala.collection.immutable.Nil$.head(List.scala:402)
        at scala.collection.immutable.Nil$.head(List.scala:399)
        at scalikejdbc.metadata.Table.toDescribeStyleString(Table.scala:68)
        at scalikejdbc.DB$$anonfun$describe$1.apply(DB.scala:796)
        at scalikejdbc.DB$$anonfun$describe$1.apply(DB.scala:796)
        at scala.Option.map(Option.scala:133)
        at scalikejdbc.DB.describe(DB.scala:796)
        at scalikejdbc.DB$.describe(DB.scala:318)
```
