### PR TITLE
Added pool connection timeout to play plugin

### DIFF
--- a/scalikejdbc-play-plugin/src/main/scala/scalikejdbc/PlayPlugin.scala
+++ b/scalikejdbc-play-plugin/src/main/scala/scalikejdbc/PlayPlugin.scala
@@ -48,7 +48,8 @@ class PlayPlugin(implicit app: Application) extends Plugin {
           val settings = ConnectionPoolSettings(
             initialSize = opt(name, "poolInitialSize").map(v => v.toInt).getOrElse(default.initialSize),
             maxSize = opt(name, "poolMaxSize").map(v => v.toInt).getOrElse(default.maxSize),
-            validationQuery = opt(name, "poolValidationQuery").getOrElse(default.validationQuery)
+            validationQuery = opt(name, "poolValidationQuery").getOrElse(default.validationQuery),
+            connectionTimeoutMillis = opt(name, "poolConnectionTimeoutMillis").map(v => v.toLong).getOrElse(default.connectionTimeoutMillis)
           )
           (require(name, "url"), opt(name, "user").getOrElse(""), opt(name, "password").getOrElse(""), settings)
         }


### PR DESCRIPTION
The timeout parameter for the pool connection settings wasn't propagated to the play plugin, so I added it.
