### PR TITLE
Made dynamic join enable

### DIFF
--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
@@ -363,7 +363,7 @@ trait QueryDSLFeature { self: SQLInterpolationFeature with SQLSyntaxSupportFeatu
   /**
    * SQLBuilder for select queries.
    */
-  case class SelectSQLBuilder[A](override val sql: SQLSyntax, lazyColumns: Boolean = false, resultAllProviders: List[ResultAllProvider] = Nil)
+  case class SelectSQLBuilder[A](override val sql: SQLSyntax, lazyColumns: Boolean = false, resultAllProviders: List[ResultAllProvider] = Nil, ignoreOnClause: Boolean = false)
       extends SQLBuilder[A] with SubQuerySQLBuilder[A] {
 
     private def appendResultAllProvider(table: TableAsAliasSQLSyntax, providers: List[ResultAllProvider]) = {
@@ -381,23 +381,40 @@ trait QueryDSLFeature { self: SQLInterpolationFeature with SQLSyntaxSupportFeatu
 
     def join(table: TableAsAliasSQLSyntax): SelectSQLBuilder[A] = innerJoin(table)
 
+    def join(table: Option[TableAsAliasSQLSyntax]): SelectSQLBuilder[A] =
+      table.map(join) getOrElse copy(ignoreOnClause = true)
+
     def innerJoin(table: TableAsAliasSQLSyntax): SelectSQLBuilder[A] = this.copy(
       sql = sqls"${sql} inner join ${table}",
-      resultAllProviders = appendResultAllProvider(table, resultAllProviders)
+      resultAllProviders = appendResultAllProvider(table, resultAllProviders),
+      ignoreOnClause = false
     )
+
+    def innerJoin(table: Option[TableAsAliasSQLSyntax]): SelectSQLBuilder[A] =
+      table.map(innerJoin) getOrElse copy(ignoreOnClause = true)
 
     def leftJoin(table: TableAsAliasSQLSyntax): SelectSQLBuilder[A] = this.copy(
       sql = sqls"${sql} left join ${table}",
-      resultAllProviders = appendResultAllProvider(table, resultAllProviders)
+      resultAllProviders = appendResultAllProvider(table, resultAllProviders),
+      ignoreOnClause = false
     )
+
+    def leftJoin(table: Option[TableAsAliasSQLSyntax]): SelectSQLBuilder[A] =
+      table.map(leftJoin) getOrElse copy(ignoreOnClause = true)
 
     def rightJoin(table: TableAsAliasSQLSyntax): SelectSQLBuilder[A] = this.copy(
       sql = sqls"${sql} right join ${table}",
-      resultAllProviders = appendResultAllProvider(table, resultAllProviders)
+      resultAllProviders = appendResultAllProvider(table, resultAllProviders),
+      ignoreOnClause = false
     )
 
-    def on(onClause: SQLSyntax): SelectSQLBuilder[A] = this.copy(sql = sqls"${sql} on ${onClause}")
-    def on(left: SQLSyntax, right: SQLSyntax): SelectSQLBuilder[A] = this.copy(sql = sqls"${sql} on ${left} = ${right}")
+    def rightJoin(table: Option[TableAsAliasSQLSyntax]): SelectSQLBuilder[A] =
+      table.map(rightJoin) getOrElse copy(ignoreOnClause = true)
+
+    def on(onClause: SQLSyntax): SelectSQLBuilder[A] =
+      if (ignoreOnClause) this else this.copy(sql = sqls"${sql} on ${onClause}")
+    def on(left: SQLSyntax, right: SQLSyntax): SelectSQLBuilder[A] =
+      if (ignoreOnClause) this else this.copy(sql = sqls"${sql} on ${left} = ${right}")
 
     // ---
     // sort, paging


### PR DESCRIPTION
It makes join query dynamic like `and` or where

```
case class Programmer(...)
case class Skill(...)

val (name, skill) = (Some("seratch"), Some("Scala"))

select.from(Programmer as p)
   .innerJoin(skill.map(_ => SkillProgrammer as sp)).on(p.id, sp.programmerId)
   .innerJoin(skill.map(_ => Skill as s).on(s.id, sp.skillId)
   .where(sqls.toAndConditionOpt(
     name.map(sqls.eq(p.name, _)),
     skill.map(sqls.eq(s.name, _))
   ))
```
