### PR TITLE
Update CodeGenerator.scala

### DIFF
--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
@@ -422,7 +422,7 @@ class CodeGenerator(table: Table, specifiedClassName: Option[String] = None)(imp
      * val autoSession = AutoSession
      * }}}
      */
-    val autoSession = "  val autoSession = AutoSession" + eol
+    val autoSession = "  override val autoSession = AutoSession" + eol
 
     /**
      * {{{


### PR DESCRIPTION
A generated class is overriding autoSession in trait SQLSyntaxSupport. 
I think override modifier is needed here.
