### PR TITLE
import to remove warning

### DIFF
--- a/scalikejdbc-library/src/main/scala/scalikejdbc/LoanPattern.scala
+++ b/scalikejdbc-library/src/main/scala/scalikejdbc/LoanPattern.scala
@@ -15,6 +15,7 @@
  */
 package scalikejdbc
 
+import scala.language.reflectiveCalls
 import util.control.Exception._
 
 /**

--- a/scalikejdbc-library/src/main/scala/scalikejdbc/RelationalSQL.scala
+++ b/scalikejdbc-library/src/main/scala/scalikejdbc/RelationalSQL.scala
@@ -17,6 +17,7 @@ package scalikejdbc
 
 import scalikejdbc.SQL.Output
 import scala.collection.mutable.LinkedHashMap
+import scala.language.higherKinds
 
 //------------------------------------
 // One-to-one / One-to-many

--- a/scalikejdbc-library/src/main/scala/scalikejdbc/SQLTemplateParser.scala
+++ b/scalikejdbc-library/src/main/scala/scalikejdbc/SQLTemplateParser.scala
@@ -15,6 +15,7 @@
  */
 package scalikejdbc
 
+import scala.language.implicitConversions
 import scala.util.parsing.combinator.JavaTokenParsers
 
 /**

--- a/scalikejdbc-library/src/main/scala/scalikejdbc/StringSQLRunner.scala
+++ b/scalikejdbc-library/src/main/scala/scalikejdbc/StringSQLRunner.scala
@@ -15,6 +15,7 @@
  */
 package scalikejdbc
 
+import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 /**

--- a/scalikejdbc-library/src/main/scala/scalikejdbc/package.scala
+++ b/scalikejdbc-library/src/main/scala/scalikejdbc/package.scala
@@ -16,6 +16,7 @@
 import java.sql.{ Timestamp => sqlTimestamp, Time => sqlTime, Date => sqlDate }
 import java.util.{ Calendar, Date => utilDate }
 import org.joda.time._
+import scala.language.implicitConversions
 
 /**
  * ScalikeJDBC - SQL-Based DB Access Library for Scala

--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
@@ -16,6 +16,7 @@
 package scalikejdbc.mapper
 
 import scalikejdbc._
+import scala.language.implicitConversions
 import java.util.Locale.{ ENGLISH => en }
 
 /**

--- a/scalikejdbc-mapper-generator/src/main/scala/scalikejdbc/mapper/SbtPlugin.scala
+++ b/scalikejdbc-mapper-generator/src/main/scala/scalikejdbc/mapper/SbtPlugin.scala
@@ -17,6 +17,7 @@ package scalikejdbc.mapper
 
 import sbt._
 import sbt.Keys._
+import scala.language.reflectiveCalls
 import util.control.Exception._
 import java.io.FileNotFoundException
 import java.util.Locale.{ ENGLISH => en }


### PR DESCRIPTION
TODO
inputTask is deprecated. so, it is better to use Def.inputTask in SbtPlugin.scala
