### PR TITLE
bind parameter of Array[Byte]

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
@@ -80,6 +80,7 @@ case class StatementExecutor(underlying: PreparedStatement, template: String, si
         case p: BigDecimal => underlying.setBigDecimal(i, p.bigDecimal)
         case p: Boolean => underlying.setBoolean(i, p)
         case p: Byte => underlying.setByte(i, p)
+        case p: Array[Byte] => underlying.setBytes(i, p)
         case p: java.sql.Date => underlying.setDate(i, p)
         case p: Double => underlying.setDouble(i, p)
         case p: Float => underlying.setFloat(i, p)


### PR DESCRIPTION
When I use parameter of Array[Byte], following log is outputted.
`The parameter hoge is bound as an Object.`
This PR will mute it and skip process in PreparedStatement#setObject.
