### PR TITLE
ParameterBinder to enable customizing StatementExecutor#bindParams

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014 scalikejdbc.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package scalikejdbc
+
+import java.sql.PreparedStatement
+
+/**
+ * ParameterBinder which enables customizing StatementExecutor#binParams.
+ *
+ * {{{
+ * val bytes = Array[Byte](1,2,3, ...)
+ * val in = ByteArrayInputStream(bytes)
+ * val bin = ParameterBinder(
+ *   value = in,
+ *   binder = (stmt, idx) => stmt.setBinaryStream(idx, in, bytes.length)
+ * )
+ * sql"insert into table (bin) values (${bin})".update.apply()
+ * }}}
+ */
+trait ParameterBinder[A] {
+
+  /**
+   * Parameter value.
+   */
+  def value: A
+
+  /**
+   * Applies parameter to PreparedStatement.
+   */
+  def apply(stmt: PreparedStatement, idx: Int): Unit
+
+}
+
+/**
+ * ParameterBinder factory.
+ */
+object ParameterBinder {
+
+  /**
+   * Factory method for ParameterBinder.
+   */
+  def apply[A](value: A, binder: (PreparedStatement, Int) => Unit): ParameterBinder[A] = {
+    val _v = value
+    new ParameterBinder[A] {
+      override def value: A = _v
+      override def apply(stmt: PreparedStatement, idx: Int): Unit = binder.apply(stmt, idx)
+    }
+  }
+
+}
+

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
@@ -76,6 +76,7 @@ case class StatementExecutor(underlying: PreparedStatement, template: String, si
     for ((param, idx) <- paramsWithIndices; i = idx + 1) {
       param match {
         case null => underlying.setObject(i, null)
+        case binder: ParameterBinder[_] => binder.apply(underlying, i)
         case p: java.sql.Array => underlying.setArray(i, p)
         case p: BigDecimal => underlying.setBigDecimal(i, p.bigDecimal)
         case p: Boolean => underlying.setBoolean(i, p)

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DBSessionSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DBSessionSpec.scala
@@ -7,6 +7,7 @@ import org.joda.time.DateTime
 import java.util.Calendar
 import java.sql._
 import scala.concurrent.ExecutionContext
+import java.io.{ InputStream, ByteArrayInputStream }
 
 class DBSessionSpec extends FlatSpec with Matchers with BeforeAndAfter with Settings with LogSupport
     with LoanPattern with UnixTimeInMillisConverterImplicits {
@@ -481,7 +482,7 @@ class DBSessionSpec extends FlatSpec with Matchers with BeforeAndAfter with Sett
             {
               import org.joda.time._
               SQL("select * from dbsessionspec_dateTimeValues where timestamp_value = ?").bind(timestamp).map {
-                rs => (rs.localDate("date_value"), rs.localTime("time_value"), rs.dateTime("timestamp_value"), rs.localDateTime("timestamp_value"))
+                rs => (rs.jodaLocalDate("date_value"), rs.jodaLocalTime("time_value"), rs.jodaDateTime("timestamp_value"), rs.jodaLocalDateTime("timestamp_value"))
               }.first().apply().map {
                 case (d: LocalDate, t: LocalTime, ts: DateTime, ldt: LocalDateTime) =>
 
@@ -716,7 +717,7 @@ class DBSessionSpec extends FlatSpec with Matchers with BeforeAndAfter with Sett
                 vInt = rs.intOpt("v_int"),
                 vLong = rs.longOpt("v_long"),
                 vShort = rs.shortOpt("v_short"),
-                vTimestamp = rs.dateTimeOpt("v_timestamp")
+                vTimestamp = rs.jodaDateTimeOpt("v_timestamp")
               )
           }.single.apply())
 
@@ -901,6 +902,34 @@ class DBSessionSpec extends FlatSpec with Matchers with BeforeAndAfter with Sett
         } finally {
           try {
             SQL("drop table dbsession_issue_218").execute.apply()
+          } catch {
+            case e: Exception => e.printStackTrace
+          }
+        }
+    }
+  }
+
+  it should "work with ParameterBinder" in {
+    DB autoCommit {
+      implicit session =>
+        try {
+          try {
+            SQL("create table dbsession_work_with_parameter_binder (id bigint generated always as identity, data blob)").execute.apply()
+          } catch {
+            case e: Exception =>
+              // PostgreSQL doesn't have blob
+              SQL("create table dbsession_work_with_parameter_binder (id bigint auto_increment, data bytea)").execute.apply()
+          }
+          val bytes = scala.Array[Byte](1, 2, 3, 4, 5, 6, 7)
+          val in = new ByteArrayInputStream(bytes)
+          val v = ParameterBinder[InputStream](
+            value = in,
+            binder = (stmt: PreparedStatement, idx: Int) => stmt.setBinaryStream(idx, in, bytes.length)
+          )
+          SQL("insert into dbsession_work_with_parameter_binder (data) values (?)").bind(v).update.apply()
+        } finally {
+          try {
+            SQL("drop table dbsession_work_with_parameter_binder").execute.apply()
           } catch {
             case e: Exception => e.printStackTrace
           }


### PR DESCRIPTION
#### Motivation

@shunjikonishi 's feedback:
https://gist.github.com/shunjikonishi/1eb278c314327af26922

PostgreSQL JDBC driver expects length of binary data when calling `#setBinaryStream`. Currently, ScalikeJDBC users cannot pass extra values when binding params to PreparedStatement.
#### Solution

Just using `ParameterBinder` instead of raw value.

``` scala
val bytes = Array[Byte](1, 2, 3, 4, 5, 6, 7)
val in = new ByteArrayInputStream(bytes)
val v = ParameterBinder[InputStream](
  value = in,
  binder = (stmt: PreparedStatement, idx: Int) => {
    stmt.setBinaryStream(idx, in, bytes.length)
  }
)
sql"insert into table_name (data) values (${v})".update.apply()
```
#### Review Points
- Better names?
- Better solution?

I'd like to merge this PR within days before ScalikeJDBC 2.0.0 release.
