### PR TITLE
commons-dbcp2 support

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -94,6 +94,8 @@ object ScalikeJDBCProjects extends Build {
           "joda-time"               %  "joda-time"       % "2.3"             % "compile",
           "org.joda"                %  "joda-convert"    % "1.6"             % "compile",
           // scope: provided
+          // commons-dbcp2 will be the default CP implementation since ScalikeJDBC 2.1
+          "org.apache.commons"      %  "commons-dbcp2"   % "2.0.1"           % "provided",
           "com.jolbox"              %  "bonecp"          % "0.8.0.RELEASE"   % "provided",
           // scope: test
           "com.zaxxer"              %  "HikariCP"        % "1.3.8"           % "test",

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/Commons2ConnectionPool.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/Commons2ConnectionPool.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014 scalikejdbc.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package scalikejdbc
+
+import javax.sql.DataSource
+import java.sql.Connection
+import org.apache.commons.dbcp2.PoolingDataSource
+import org.apache.commons.dbcp2.PoolableConnection
+import org.apache.commons.dbcp2.PoolableConnectionFactory
+import org.apache.commons.dbcp2.DriverManagerConnectionFactory
+import org.apache.commons.pool2.impl.GenericObjectPool
+
+/**
+ * Commons DBCP Connection Pool
+ *
+ * @see http://commons.apache.org/dbcp/
+ */
+class Commons2ConnectionPool(
+  override val url: String,
+  override val user: String,
+  password: String,
+  override val settings: ConnectionPoolSettings = ConnectionPoolSettings())
+    extends ConnectionPool(url, user, password, settings) {
+
+  private[this] val _poolFactory = new PoolableConnectionFactory(
+    new DriverManagerConnectionFactory(url, user, password), null)
+
+  private[this] val _pool: GenericObjectPool[PoolableConnection] = new GenericObjectPool(_poolFactory)
+  _poolFactory.setPool(_pool)
+
+  _pool.setMinIdle(settings.initialSize)
+  _pool.setMaxIdle(settings.maxSize)
+  _pool.setBlockWhenExhausted(true)
+  _pool.setMaxTotal(settings.maxSize)
+  _pool.setMaxWaitMillis(settings.connectionTimeoutMillis)
+  _pool.setTestOnBorrow(true)
+
+  private[this] val _dataSource: DataSource = new PoolingDataSource(_pool)
+
+  override def dataSource: DataSource = _dataSource
+
+  override def borrow(): Connection = dataSource.getConnection()
+
+  override def numActive: Int = _pool.getNumActive
+
+  override def numIdle: Int = _pool.getNumIdle
+
+  override def maxActive: Int = _pool.getMaxTotal
+
+  override def maxIdle: Int = _pool.getMaxIdle
+
+  override def close(): Unit = _pool.close()
+
+}
+

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/Commons2ConnectionPoolFactory.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/Commons2ConnectionPoolFactory.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 scalikejdbc.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package scalikejdbc
+
+/**
+ * Connection Pool Factory
+ *
+ * @see http://commons.apache.org/dbcp/
+ */
+object Commons2ConnectionPoolFactory extends ConnectionPoolFactory {
+
+  override def apply(
+    url: String, user: String, password: String, settings: ConnectionPoolSettings = ConnectionPoolSettings()) = {
+    new Commons2ConnectionPool(url, user, password, settings)
+  }
+
+}

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
@@ -32,6 +32,8 @@ object ConnectionPool extends LogSupport {
   type CPFactory = ConnectionPoolFactory
 
   val DEFAULT_NAME: Symbol = 'default
+  // TODO commons-dbcp2 will be the default implementation since ScalikeJDBC 2.1
+  val DEFAULT_CONNECTION_POOL_FACTORY = CommonsConnectionPoolFactory
 
   private[this] val pools = new MutableMap[Any, ConnectionPool]()
 
@@ -82,7 +84,7 @@ object ConnectionPool extends LogSupport {
    * @param settings Settings
    */
   def add(name: Any, url: String, user: String, password: String,
-    settings: CPSettings = ConnectionPoolSettings())(implicit factory: CPFactory = CommonsConnectionPoolFactory) {
+    settings: CPSettings = ConnectionPoolSettings())(implicit factory: CPFactory = DEFAULT_CONNECTION_POOL_FACTORY) {
 
     import scalikejdbc.JDBCUrl._
 
@@ -178,7 +180,7 @@ object ConnectionPool extends LogSupport {
    * @param settings Settings
    */
   def singleton(url: String, user: String, password: String,
-    settings: CPSettings = ConnectionPoolSettings())(implicit factory: CPFactory = CommonsConnectionPoolFactory): Unit = {
+    settings: CPSettings = ConnectionPoolSettings())(implicit factory: CPFactory = DEFAULT_CONNECTION_POOL_FACTORY): Unit = {
     add(DEFAULT_NAME, url, user, password, settings)(factory)
     log.debug("Registered singleton connection pool : " + get().toString())
   }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPoolFactoryRepository.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPoolFactoryRepository.scala
@@ -21,11 +21,13 @@ package scalikejdbc
 object ConnectionPoolFactoryRepository {
 
   val COMMONS_DBCP = "commons-dbcp"
+  val COMMONS_DBCP2 = "commons-dbcp2"
   val BONECP = "bonecp"
 
   private[this] val factories = new scala.collection.concurrent.TrieMap[String, ConnectionPoolFactory]()
 
   factories.update(COMMONS_DBCP, CommonsConnectionPoolFactory)
+  factories.update(COMMONS_DBCP2, Commons2ConnectionPoolFactory)
   factories.update(BONECP, BoneCPConnectionPoolFactory)
 
   /**

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DB.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DB.scala
@@ -52,6 +52,7 @@ trait DBConnection extends LogSupport with LoanPattern {
   def isTxAlreadyStarted: Boolean = conn != null && !conn.getAutoCommit
 
   private def newTx(conn: Connection): Tx = {
+    conn.setReadOnly(false)
     if (isTxNotActive || isTxAlreadyStarted) {
       throw new IllegalStateException(ErrorMessage.CANNOT_START_A_NEW_TRANSACTION)
     }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/Tx.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/Tx.scala
@@ -27,7 +27,10 @@ class Tx(val conn: Connection) {
   /**
    * Begins this transaction.
    */
-  def begin(): Unit = conn.setAutoCommit(false)
+  def begin(): Unit = {
+    conn.setReadOnly(false)
+    conn.setAutoCommit(false)
+  }
 
   /**
    * Commits this transaction.


### PR DESCRIPTION
Though commons-dbcp2 is still young, it should be the default CP implementation since ScalikeJDBC 2.1 if it works fine.

FYI:

http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.apache.commons%22%20AND%20a%3A%22commons-dbcp2%22
