### PR TITLE
Enable read config with defaults

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -29,6 +29,7 @@ object ScalikeJDBCProjects extends Build {
     Seq(
       exclude[MissingMethodProblem]("scalikejdbc.DBConnection.futureLocalTx"),
       exclude[MissingMethodProblem]("scalikejdbc.LoanPattern.futureUsing"),
+      exclude[MissingMethodProblem]("scalikejdbc.config.TypesafeConfigReaderWithEnv"),
       exclude[MissingMethodProblem]("scalikejdbc.DBSession.fetchSize"),
       exclude[MissingMethodProblem]("scalikejdbc.DBSession.scalikejdbc$DBSession$$_fetchSize_="),
       exclude[MissingMethodProblem]("scalikejdbc.DBSession.scalikejdbc$DBSession$$_fetchSize"),

--- a/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfigReaderWithEnv.scala
+++ b/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfigReaderWithEnv.scala
@@ -15,6 +15,8 @@
  */
 package scalikejdbc.config
 
+import com.typesafe.config.{ ConfigFactory, Config }
+
 /**
  * Typesafe config reader with env prefix.
  */
@@ -24,4 +26,9 @@ case class TypesafeConfigReaderWithEnv(envValue: String)
     with EnvPrefix {
 
   override val env = Option(envValue)
+
+  override lazy val config: Config = {
+    val topLevelConfig = ConfigFactory.load()
+    topLevelConfig.getConfig(envValue).withFallback(topLevelConfig)
+  }
 }

--- a/scalikejdbc-config/src/test/resources/application.conf
+++ b/scalikejdbc-config/src/test/resources/application.conf
@@ -3,13 +3,15 @@ db.default.driver="org.h2.Driver"
 db.default.user="sa"
 db.default.password="secret"
 
-db.default.migration.locations=["development.default"]
+settings {
+  db.default.poolInitialSize=5
+  db.default.poolMaxSize=7
+  db.default.poolConnectionTimeoutMillis=1000
+  db.default.poolValidationQuery="select 1 as one"
+  db.default.poolFactoryName="commons-dbcp"
+}
 
-db.default.poolInitialSize=5
-db.default.poolMaxSize=7
-db.default.poolConnectionTimeoutMillis=1000
-db.default.poolValidationQuery="select 1 as one"
-db.default.poolFactoryName="commons-dbcp"
+db.default.migration.locations=["development.default"]
 
 db.foo.url="jdbc:h2:mem:test2"
 db.foo.driver="org.h2.Driver"
@@ -71,3 +73,12 @@ dev2 {
   }
 }
 
+db.topLevelDefaults.url="jdbc:h2:mem:topLevelDefaults"
+db.topLevelDefaults.driver="org.h2.Driver"
+db.topLevelDefaults.user="xxx"
+db.topLevelDefaults.password="yyy"
+
+prod {
+  db.topLevelDefaults.user="app"
+  db.topLevelDefaults.password="password"
+}

--- a/scalikejdbc-config/src/test/scala/scalikejdbc/config/DBsSpec.scala
+++ b/scalikejdbc-config/src/test/scala/scalikejdbc/config/DBsSpec.scala
@@ -28,6 +28,14 @@ class DBsSpec extends FunSpec with Matchers {
         res should be(Some(1))
         DBs.close('foo)
       }
+      it("should setup env & top level config") {
+        DBs.setup('topLevelDefaults)
+        val res = NamedDB('topLevelDefaults) readOnly { implicit session =>
+          SQL("SELECT 1 as one").map(rs => rs.int("one")).single.apply()
+        }
+        res should be(Some(1))
+        DBs.close('topLevelDefaults)
+      }
       describe("When an unknown database name is passed") {
         it("throws Configuration Exception") {
           intercept[ConfigurationException] {


### PR DESCRIPTION
This pull request enables to read configs with defaults like this:

```
db.default.driver="org.h2.Driver"
db.default.user="app_user"

dev {
  db.default.url="jdbc:h2:dev"
  db.default.password="pwd"
}
test {
  db.default.url="jdbc:h2:test"
  db.default.password="pwd"
}
prod {
  db.default.driver="org.postgresql.Driver"
  db.default.url="jdbc:postgresql://localhost:5432/scalikejdbc"
  db.default.password=${?DATABASE_PASSWORD}
}
```
