### PR TITLE
Make `in` clause acceptable empty value. 

### DIFF
--- a/scalikejdbc-interpolation-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
+++ b/scalikejdbc-interpolation-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
@@ -67,62 +67,104 @@ class SQLSyntax private[scalikejdbc] (val value: String, val parameters: Seq[Any
   def isNotNull(column: SQLSyntax) = sqls"${this} ${column} is not null"
   def between(column: SQLSyntax, a: Any, b: Any) = sqls"${this} ${column} between ${a} and ${b}"
 
-  def in(column: SQLSyntax, values: Seq[Any]) = sqls"${this} ${column} in (${values})"
-  def notIn(column: SQLSyntax, values: Seq[Any]) = sqls"${this} ${column} not in (${values})"
+  def in(column: SQLSyntax, values: Seq[Any]) = {
+    if (values.isEmpty)
+      sqls"${this} FALSE"
+    else
+      sqls"${this} ${column} in (${values})"
+  }
+  def notIn(column: SQLSyntax, values: Seq[Any]) = {
+    if (values.isEmpty)
+      sqls"${this} TRUE"
+    else
+      sqls"${this} ${column} not in (${values})"
+  }
 
   def in(column: SQLSyntax, subQuery: SQLSyntax) = sqls"${this} ${column} in (${subQuery})"
   def notIn(column: SQLSyntax, subQuery: SQLSyntax) = sqls"${this} ${column} not in (${subQuery})"
 
   def in(columns: (SQLSyntax, SQLSyntax), valueSeqs: Seq[(Any, Any)]) = {
-    val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value})")
-    val values = csv(valueSeqs.map { case (v1, v2) => sqls"($v1, $v2)" }: _*)
-    val inClause = sqls"${column} in (${values})"
-    sqls"${this} ${inClause}"
+    if (valueSeqs.isEmpty) {
+      sqls"${this} FALSE"
+    } else {
+      val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value})")
+      val values = csv(valueSeqs.map { case (v1, v2) => sqls"($v1, $v2)" }: _*)
+      val inClause = sqls"${column} in (${values})"
+      sqls"${this} ${inClause}"
+    }
   }
   def notIn(columns: (SQLSyntax, SQLSyntax), valueSeqs: Seq[(Any, Any)]) = {
-    val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value})")
-    val values = csv(valueSeqs.map { case (v1, v2) => sqls"($v1, $v2)" }: _*)
-    val inClause = sqls"${column} not in (${values})"
-    sqls"${this} ${inClause}"
+    if (valueSeqs.isEmpty) {
+      sqls"${this} TRUE"
+    } else {
+      val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value})")
+      val values = csv(valueSeqs.map { case (v1, v2) => sqls"($v1, $v2)" }: _*)
+      val inClause = sqls"${column} not in (${values})"
+      sqls"${this} ${inClause}"
+    }
   }
 
   def in(columns: (SQLSyntax, SQLSyntax, SQLSyntax), valueSeqs: Seq[(Any, Any, Any)]) = {
-    val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value}, ${columns._3.value})")
-    val values = csv(valueSeqs.map { case (v1, v2, v3) => sqls"($v1, $v2, $v3)" }: _*)
-    val inClause = sqls"${column} in (${values})"
-    sqls"${this} ${inClause}"
+    if (valueSeqs.isEmpty) {
+      sqls"${this} FALSE"
+    } else {
+      val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value}, ${columns._3.value})")
+      val values = csv(valueSeqs.map { case (v1, v2, v3) => sqls"($v1, $v2, $v3)" }: _*)
+      val inClause = sqls"${column} in (${values})"
+      sqls"${this} ${inClause}"
+    }
   }
   def notIn(columns: (SQLSyntax, SQLSyntax, SQLSyntax), valueSeqs: Seq[(Any, Any, Any)]) = {
-    val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value}, ${columns._3.value})")
-    val values = csv(valueSeqs.map { case (v1, v2, v3) => sqls"($v1, $v2, $v3)" }: _*)
-    val inClause = sqls"${column} not in (${values})"
-    sqls"${this} ${inClause}"
+    if (valueSeqs.isEmpty) {
+      sqls"${this} TRUE"
+    } else {
+      val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value}, ${columns._3.value})")
+      val values = csv(valueSeqs.map { case (v1, v2, v3) => sqls"($v1, $v2, $v3)" }: _*)
+      val inClause = sqls"${column} not in (${values})"
+      sqls"${this} ${inClause}"
+    }
   }
 
   def in(columns: (SQLSyntax, SQLSyntax, SQLSyntax, SQLSyntax), valueSeqs: Seq[(Any, Any, Any, Any)]) = {
-    val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value}, ${columns._3.value}, ${columns._4.value})")
-    val values = csv(valueSeqs.map { case (v1, v2, v3, v4) => sqls"($v1, $v2, $v3, $v4)" }: _*)
-    val inClause = sqls"${column} in (${values})"
-    sqls"${this} ${inClause}"
+    if (valueSeqs.isEmpty) {
+      sqls"${this} FALSE"
+    } else {
+      val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value}, ${columns._3.value}, ${columns._4.value})")
+      val values = csv(valueSeqs.map { case (v1, v2, v3, v4) => sqls"($v1, $v2, $v3, $v4)" }: _*)
+      val inClause = sqls"${column} in (${values})"
+      sqls"${this} ${inClause}"
+    }
   }
   def notIn(columns: (SQLSyntax, SQLSyntax, SQLSyntax, SQLSyntax), valueSeqs: Seq[(Any, Any, Any, Any)]) = {
-    val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value}, ${columns._3.value}, ${columns._4.value})")
-    val values = csv(valueSeqs.map { case (v1, v2, v3, v4) => sqls"($v1, $v2, $v3, $v4)" }: _*)
-    val inClause = sqls"${column} not in (${values})"
-    sqls"${this} ${inClause}"
+    if (valueSeqs.isEmpty) {
+      sqls"${this} TRUE"
+    } else {
+      val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value}, ${columns._3.value}, ${columns._4.value})")
+      val values = csv(valueSeqs.map { case (v1, v2, v3, v4) => sqls"($v1, $v2, $v3, $v4)" }: _*)
+      val inClause = sqls"${column} not in (${values})"
+      sqls"${this} ${inClause}"
+    }
   }
 
   def in(columns: (SQLSyntax, SQLSyntax, SQLSyntax, SQLSyntax, SQLSyntax), valueSeqs: Seq[(Any, Any, Any, Any, Any)]) = {
-    val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value}, ${columns._3.value}, ${columns._4.value}, ${columns._5.value})")
-    val values = csv(valueSeqs.map { case (v1, v2, v3, v4, v5) => sqls"($v1, $v2, $v3, $v4, $v5)" }: _*)
-    val inClause = sqls"${column} in (${values})"
-    sqls"${this} ${inClause}"
+    if (valueSeqs.isEmpty) {
+      sqls"${this} FALSE"
+    } else {
+      val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value}, ${columns._3.value}, ${columns._4.value}, ${columns._5.value})")
+      val values = csv(valueSeqs.map { case (v1, v2, v3, v4, v5) => sqls"($v1, $v2, $v3, $v4, $v5)" }: _*)
+      val inClause = sqls"${column} in (${values})"
+      sqls"${this} ${inClause}"
+    }
   }
   def notIn(columns: (SQLSyntax, SQLSyntax, SQLSyntax, SQLSyntax, SQLSyntax), valueSeqs: Seq[(Any, Any, Any, Any, Any)]) = {
-    val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value}, ${columns._3.value}, ${columns._4.value}, ${columns._5.value})")
-    val values = csv(valueSeqs.map { case (v1, v2, v3, v4, v5) => sqls"($v1, $v2, $v3, $v4, $v5)" }: _*)
-    val inClause = sqls"${column} not in (${values})"
-    sqls"${this} ${inClause}"
+    if (valueSeqs.isEmpty) {
+      sqls"${this} TRUE"
+    } else {
+      val column = SQLSyntax(s"(${columns._1.value}, ${columns._2.value}, ${columns._3.value}, ${columns._4.value}, ${columns._5.value})")
+      val values = csv(valueSeqs.map { case (v1, v2, v3, v4, v5) => sqls"($v1, $v2, $v3, $v4, $v5)" }: _*)
+      val inClause = sqls"${column} not in (${values})"
+      sqls"${this} ${inClause}"
+    }
   }
 
   def like(column: SQLSyntax, value: String) = sqls"${this} ${column} like ${value}"

--- a/scalikejdbc-interpolation-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
+++ b/scalikejdbc-interpolation-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
@@ -86,20 +86,43 @@ class SQLSyntaxSpec extends FlatSpec with Matchers {
     s.parameters should equal(Seq(1, 2, 3))
   }
 
+  it should "have #in with empty" in {
+    val s = SQLSyntax.in(sqls"id", Seq())
+    s.value should equal(" FALSE")
+    s.parameters should equal(Seq())
+  }
+
   it should "have #in for 2 columns" in {
     val s = SQLSyntax.in((sqls"id", sqls"name"), Seq((1, "Alice"), (2, "Bob")))
     s.value should equal(" (id, name) in ((?, ?), (?, ?))")
     s.parameters should equal(Seq(1, "Alice", 2, "Bob"))
   }
+
+  it should "have #in for 2 columns with empty" in {
+    val s = SQLSyntax.in((sqls"id", sqls"name"), Seq())
+    s.value should equal(" FALSE")
+    s.parameters should equal(Seq())
+  }
+
   it should "have #in for 3 columns" in {
     val s = SQLSyntax.in((sqls"id", sqls"name", sqls"age"), Seq((1, "Alice", 20), (2, "Bob", 23)))
     s.value should equal(" (id, name, age) in ((?, ?, ?), (?, ?, ?))")
     s.parameters should equal(Seq(1, "Alice", 20, 2, "Bob", 23))
   }
+  it should "have #in for 3 columns with empty" in {
+    val s = SQLSyntax.in((sqls"id", sqls"name", sqls"age"), Seq())
+    s.value should equal(" FALSE")
+    s.parameters should equal(Seq())
+  }
   it should "have #in for 4 columns" in {
     val s = SQLSyntax.in((sqls"id", sqls"name", sqls"age", sqls"foo"), Seq((1, "Alice", 20, "bar"), (2, "Bob", 23, "baz")))
     s.value should equal(" (id, name, age, foo) in ((?, ?, ?, ?), (?, ?, ?, ?))")
     s.parameters should equal(Seq(1, "Alice", 20, "bar", 2, "Bob", 23, "baz"))
+  }
+  it should "have #in for 4 columns with empty" in {
+    val s = SQLSyntax.in((sqls"id", sqls"name", sqls"age", sqls"foo"), Seq())
+    s.value should equal(" FALSE")
+    s.parameters should equal(Seq())
   }
   it should "have #in for 5 columns" in {
     val time = DateTime.now
@@ -107,11 +130,22 @@ class SQLSyntaxSpec extends FlatSpec with Matchers {
     s.value should equal(" (id, name, age, foo, created_at) in ((?, ?, ?, ?, ?), (?, ?, ?, ?, ?))")
     s.parameters should equal(Seq(1, "Alice", 20, "bar", null, 2, "Bob", 23, "baz", time))
   }
+  it should "have #in for 5 columns with empty" in {
+    val time = DateTime.now
+    val s = SQLSyntax.in((sqls"id", sqls"name", sqls"age", sqls"foo", sqls"created_at"), Seq())
+    s.value should equal(" FALSE")
+    s.parameters should equal(Seq())
+  }
 
   it should "have #notIn" in {
     val s = SQLSyntax.notIn(sqls"id", Seq(1, 2, 3))
     s.value should equal(" id not in (?, ?, ?)")
     s.parameters should equal(Seq(1, 2, 3))
+  }
+  it should "have #notIn woth empty" in {
+    val s = SQLSyntax.notIn(sqls"id", Seq())
+    s.value should equal(" TRUE")
+    s.parameters should equal(Seq())
   }
 
   it should "have #notIn for 2 columns" in {
@@ -119,21 +153,42 @@ class SQLSyntaxSpec extends FlatSpec with Matchers {
     s.value should equal(" (id, name) not in ((?, ?), (?, ?))")
     s.parameters should equal(Seq(1, "Alice", 2, "Bob"))
   }
+  it should "have #notIn for 2 columns with empty" in {
+    val s = SQLSyntax.notIn((sqls"id", sqls"name"), Seq())
+    s.value should equal(" TRUE")
+    s.parameters should equal(Seq())
+  }
   it should "have #notIn for 3 columns" in {
     val s = SQLSyntax.notIn((sqls"id", sqls"name", sqls"age"), Seq((1, "Alice", 20), (2, "Bob", 23)))
     s.value should equal(" (id, name, age) not in ((?, ?, ?), (?, ?, ?))")
     s.parameters should equal(Seq(1, "Alice", 20, 2, "Bob", 23))
+  }
+  it should "have #notIn for 3 columns with empty" in {
+    val s = SQLSyntax.notIn((sqls"id", sqls"name", sqls"age"), Seq())
+    s.value should equal(" TRUE")
+    s.parameters should equal(Seq())
   }
   it should "have #notIn for 4 columns" in {
     val s = SQLSyntax.notIn((sqls"id", sqls"name", sqls"age", sqls"foo"), Seq((1, "Alice", 20, "bar"), (2, "Bob", 23, "baz")))
     s.value should equal(" (id, name, age, foo) not in ((?, ?, ?, ?), (?, ?, ?, ?))")
     s.parameters should equal(Seq(1, "Alice", 20, "bar", 2, "Bob", 23, "baz"))
   }
+  it should "have #notIn for 4 columns with empty" in {
+    val s = SQLSyntax.notIn((sqls"id", sqls"name", sqls"age", sqls"foo"), Seq())
+    s.value should equal(" TRUE")
+    s.parameters should equal(Seq())
+  }
   it should "have #notIn for 5 columns" in {
     val time = DateTime.now
     val s = SQLSyntax.notIn((sqls"id", sqls"name", sqls"age", sqls"foo", sqls"created_at"), Seq((1, "Alice", 20, "bar", null), (2, "Bob", 23, "baz", time)))
     s.value should equal(" (id, name, age, foo, created_at) not in ((?, ?, ?, ?, ?), (?, ?, ?, ?, ?))")
     s.parameters should equal(Seq(1, "Alice", 20, "bar", null, 2, "Bob", 23, "baz", time))
+  }
+  it should "have #notIn for 5 columns with empty" in {
+    val time = DateTime.now
+    val s = SQLSyntax.notIn((sqls"id", sqls"name", sqls"age", sqls"foo", sqls"created_at"), Seq())
+    s.value should equal(" TRUE")
+    s.parameters should equal(Seq())
   }
 
   it should "have #in with subQuery" in {

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -309,12 +309,36 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
           inClauseResults.map(_.id) should equal(List(14, 15, 21, 22))
         }
         {
+          val inClauseResults = withSQL {
+            select.from(Order as o)
+              .where.in(o.id, Seq())
+              .orderBy(o.id)
+          }.map(Order(o)).list.apply()
+          inClauseResults.map(_.id) should equal(List())
+        }
+        {
           val notInClauseResults = withSQL {
             select.from(Order as o)
               .where.notIn(o.id, Seq(14, 15, 22, 23, 24, 25, 26))
               .orderBy(o.id)
           }.map(Order(o)).list.apply()
           notInClauseResults.map(_.id) should equal(List(11, 12, 13, 21))
+        }
+        {
+          val notInClauseResults = withSQL {
+            select.from(Order as o)
+              .where.notIn(o.id, Seq())
+              .orderBy(o.id)
+          }.map(Order(o)).list.apply()
+          notInClauseResults.map(_.id) should equal(List(11, 12, 13, 14, 15, 21, 22, 23, 24, 25, 26))
+        }
+        {
+          val notInClauseResults = withSQL {
+            select.from(Order as o)
+              .where.not.in(o.id, Seq())
+              .orderBy(o.id)
+          }.map(Order(o)).list.apply()
+          notInClauseResults.map(_.id) should equal(List(11, 12, 13, 14, 15, 21, 22, 23, 24, 25, 26))
         }
         {
           val inClauseResults = withSQL {
@@ -342,12 +366,36 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
           inClauseResults.map(_.id) should equal(List(11, 21))
         }
         {
+          val inClauseResults = withSQL {
+            select.from(Order as o)
+              .where.in((o.id, o.productId), Seq())
+              .orderBy(o.id)
+          }.map(Order(o)).list.apply()
+          inClauseResults.map(_.id) should equal(List())
+        }
+        {
           val notInClauseResults = withSQL {
             select.from(Order as o)
               .where.notIn((o.id, o.productId), Seq((11, 1), (12, 2), (13, 1), (14, 1), (15, 1), (21, 2)))
               .orderBy(o.id)
           }.map(Order(o)).list.apply()
           notInClauseResults.map(_.id) should equal(List(12, 22, 23, 24, 25, 26))
+        }
+        {
+          val notInClauseResults = withSQL {
+            select.from(Order as o)
+              .where.notIn((o.id, o.productId), Seq())
+              .orderBy(o.id)
+          }.map(Order(o)).list.apply()
+          notInClauseResults.map(_.id) should equal(List(11, 12, 13, 14, 15, 21, 22, 23, 24, 25, 26))
+        }
+        {
+          val notInClauseResults = withSQL {
+            select.from(Order as o)
+              .where.not.in((o.id, o.productId), Seq())
+              .orderBy(o.id)
+          }.map(Order(o)).list.apply()
+          notInClauseResults.map(_.id) should equal(List(11, 12, 13, 14, 15, 21, 22, 23, 24, 25, 26))
         }
 
         // like search


### PR DESCRIPTION
On QueryDSL, `in` clause ignore empty value naturally.

``` scala
{
  val inClauseResults = withSQL {
    select.from(Order as o)
      .where.in(o.id, Seq())
      .orderBy(o.id)
  }.map(Order(o)).list.apply()
  inClauseResults.map(_.id) should equal(List())  // empty result
}
{
  val notInClauseResults = withSQL {
    select.from(Order as o)
      .where.notIn(o.id, Seq())
      .orderBy(o.id)
  }.map(Order(o)).list.apply()
  notInClauseResults.map(_.id) should equal(List(11, 12, 13, 14, 15, 21, 22, 23, 24, 25, 26)) // all results
}
```
