### PR TITLE
Add support for Set in SQL interpolation

### DIFF
--- a/scalikejdbc-interpolation-core/src/main/scala/scalikejdbc/SQLInterpolationString.scala
+++ b/scalikejdbc-interpolation-core/src/main/scala/scalikejdbc/SQLInterpolationString.scala
@@ -42,6 +42,8 @@ class SQLInterpolationString(val s: StringContext) extends AnyVal {
     case _: String => sb += '?'
     // to fix issue #215 due to unexpected Stream#addString behavior
     case s: Stream[_] => addPlaceholders(sb, s.toList) // e.g. in clause
+    // Need to convert a Set to a List before mapping to "?", otherwise we end up with a 1-element Set
+    case s: Set[_] => addPlaceholders(sb, s.toList) // e.g. in clause
     case t: Traversable[_] => t.map {
       case SQLSyntax(s, _) => s
       case _ => "?"


### PR DESCRIPTION
String interpolation gives surprising results for `Set`s.

```
scala> sqls"x in (${Set(1,2,3)})"
res5: scalikejdbc.interpolation.SQLSyntax = SQLSyntax(value: x in (?), parameters: List(1, 2, 3))

scala> sqls"x in (${Seq(1,2,3)})"
res6: scalikejdbc.interpolation.SQLSyntax = SQLSyntax(value: x in (?, ?, ?), parameters: List(1, 2, 3))
```

This is because of the following code in `SQLInterpolationString`:

```
case t: Traversable[_] => t.map {
        case SQLSyntax(s, _) => s
        case _ => "?"
      }.addString(sb, ", ") // e.g. in clause
```

(`Set(1, 2, 3).map(case _ => "?")` results in the 1-element `Set("?")`)

Fixed by adding a special case for `Set[_]`.
