### PR TITLE
Improve logging to include connection pool factory name

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
@@ -88,9 +88,9 @@ object ConnectionPool extends LogSupport {
 
     import scalikejdbc.JDBCUrl._
 
-    val _factory = Option(settings.connectionPoolFactoryName).flatMap { name =>
-      ConnectionPoolFactoryRepository.get(name)
-    }.getOrElse(factory)
+    val (_factory, factoryName) = Option(settings.connectionPoolFactoryName).flatMap { name =>
+      ConnectionPoolFactoryRepository.get(name).map(f => (f, name))
+    }.getOrElse((factory, "<default>"))
 
     // register new pool or replace existing pool
     pools.synchronized {
@@ -118,7 +118,7 @@ object ConnectionPool extends LogSupport {
       oldPoolOpt.foreach(pool => abandonOldPool(name, pool))
     }
 
-    log.debug("Registered connection pool : " + get(name).toString())
+    log.debug(s"Registered connection pool : ${get(name)} using factory : $factoryName")
   }
 
   private[this] def abandonOldPool(name: Any, oldPool: ConnectionPool) = {


### PR DESCRIPTION
I switched the connection pool implementation for my app to commons-dbcp2, but it's hard to tell whether the change has actually taken effect.

Improved the log message to output the name of the connection pool factory, so we can easily check which connection pool implementation is being used.
