### PR TITLE
Fix boolean values when ResultSet.getObject returns a BigDecimal 

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/TypeBinder.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/TypeBinder.scala
@@ -59,6 +59,7 @@ object TypeBinder extends LowPriorityTypeBinderImplicits with UnixTimeInMillisCo
       try s.toInt != 0
       catch { case e: NumberFormatException => !s.isEmpty }
     }.asInstanceOf[java.lang.Boolean]
+    case n: Number => (n.intValue() != 0).asInstanceOf[java.lang.Boolean]
     case v => (v != 0).asInstanceOf[java.lang.Boolean]
   }
   implicit val boolean: TypeBinder[Boolean] = nullableBoolean.map(throwExceptionIfNull(_.asInstanceOf[Boolean]))
@@ -80,6 +81,7 @@ object TypeBinder extends LowPriorityTypeBinderImplicits with UnixTimeInMillisCo
     case v if v == null => v.asInstanceOf[java.lang.Integer]
     case v: Float => v.toInt.asInstanceOf[java.lang.Integer]
     case v: Double => v.toInt.asInstanceOf[java.lang.Integer]
+    case n: Number => n.intValue()
     case v => java.lang.Integer.valueOf(v.toString)
   }
   implicit val int: TypeBinder[Int] = nullableInt.map(throwExceptionIfNull(_.asInstanceOf[Int]))
@@ -88,6 +90,7 @@ object TypeBinder extends LowPriorityTypeBinderImplicits with UnixTimeInMillisCo
     case v if v == null => v.asInstanceOf[java.lang.Long]
     case v: Float => v.toLong.asInstanceOf[java.lang.Long]
     case v: Double => v.toLong.asInstanceOf[java.lang.Long]
+    case n: Number => n.longValue()
     case v => java.lang.Long.valueOf(v.toString)
   }
   implicit val long: TypeBinder[Long] = nullableLong.map(throwExceptionIfNull(_.asInstanceOf[Long]))
@@ -99,6 +102,7 @@ object TypeBinder extends LowPriorityTypeBinderImplicits with UnixTimeInMillisCo
     case v if v == null => v.asInstanceOf[java.lang.Short]
     case v: Float => v.toShort.asInstanceOf[java.lang.Short]
     case v: Double => v.toShort.asInstanceOf[java.lang.Short]
+    case n: Number => n.shortValue()
     case v => java.lang.Short.valueOf(v.toString)
   }
   implicit val short: TypeBinder[Short] = nullableShort.map(throwExceptionIfNull(_.asInstanceOf[Short]))

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/TypeBinderSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/TypeBinderSpec.scala
@@ -44,6 +44,30 @@ class TypeBinderSpec extends FlatSpec with Matchers with MockitoSugar with UnixT
     implicitly[TypeBinder[java.util.Calendar]].apply(rs, "time") should not be (null)
   }
 
+  it should "handle result values of type java.math.BigDecimal" in {
+    val rs: ResultSet = mock[ResultSet]
+    when(rs.getObject("zero")).thenReturn(java.math.BigDecimal.ZERO, Array[Object](): _*)
+    when(rs.getObject("nonzero")).thenReturn(java.math.BigDecimal.ONE, Array[Object](): _*)
+
+    val wrapped = WrappedResultSet(rs, new ResultSetCursor(0), 0)
+    wrapped.boolean("zero") should be(false)
+    wrapped.boolean("nonzero") should be(true)
+    wrapped.booleanOpt("zero") should be(Some(false))
+    wrapped.booleanOpt("nonzero") should be(Some(true))
+    wrapped.int("zero") should be(0)
+    wrapped.int("nonzero") should be(1)
+    wrapped.intOpt("zero") should be(Some(0))
+    wrapped.intOpt("nonzero") should be(Some(1))
+    wrapped.long("zero") should be(0)
+    wrapped.long("nonzero") should be(1L)
+    wrapped.longOpt("zero") should be(Some(0L))
+    wrapped.longOpt("nonzero") should be(Some(1L))
+    wrapped.short("zero") should be(0)
+    wrapped.short("nonzero") should be(1)
+    wrapped.shortOpt("zero") should be(Some(0))
+    wrapped.shortOpt("nonzero") should be(Some(1))
+  }
+
   it should "fix issue #170" in {
     val rs: ResultSet = mock[ResultSet]
     when(rs.getObject("none")).thenReturn(null, Array[Object](): _*)


### PR DESCRIPTION
Oracle JDBC drivers can return a BigDecimal if Result.getObject is called on a numeric column.  WrappedResultSet  works OK when asking for a short/int/long value.  But boolean values are always returned as true.

Adding an extra match case for Number to the boolean TypeBinder allows this to be handled nicely.

Using the same approach for int/short/long seems sensible rather than it going to the catch-all that does something like Integer.valueOf(value.toString).
