### PR TITLE
Improve SQLSyntax#eq, #ne to generate "is null" query when accepting null/None values

### DIFF
--- a/scalikejdbc-interpolation-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
+++ b/scalikejdbc-interpolation-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
@@ -60,8 +60,18 @@ class SQLSyntax private[scalikejdbc] (val value: String, val parameters: Seq[Any
   def and = sqls"${this} and"
   def or = sqls"${this} or"
 
-  def eq(column: SQLSyntax, value: Any) = sqls"${this} ${column} = ${value}"
-  def ne(column: SQLSyntax, value: Any) = sqls"${this} ${column} <> ${value}"
+  def eq(column: SQLSyntax, value: Any) = {
+    value match {
+      case null | None => sqls"${this} ${column} is null"
+      case _ => sqls"${this} ${column} = ${value}"
+    }
+  }
+  def ne(column: SQLSyntax, value: Any) = {
+    value match {
+      case null | None => sqls"${this} ${column} is not null"
+      case _ => sqls"${this} ${column} <> ${value}"
+    }
+  }
   def gt(column: SQLSyntax, value: Any) = sqls"${this} ${column} > ${value}"
   def ge(column: SQLSyntax, value: Any) = sqls"${this} ${column} >= ${value}"
   def lt(column: SQLSyntax, value: Any) = sqls"${this} ${column} < ${value}"

--- a/scalikejdbc-interpolation-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
+++ b/scalikejdbc-interpolation-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
@@ -38,6 +38,30 @@ class SQLSyntaxSpec extends FlatSpec with Matchers {
     s.parameters should equal(Seq(123))
   }
 
+  it should "have #eq for null values" in {
+    val s = SQLSyntax.eq(sqls"id", null)
+    s.value should equal(" id is null")
+    s.parameters should equal(Nil)
+  }
+
+  it should "have #eq for None values" in {
+    val s = SQLSyntax.eq(sqls"id", None)
+    s.value should equal(" id is null")
+    s.parameters should equal(Nil)
+  }
+
+  it should "have #ne for null values" in {
+    val s = SQLSyntax.ne(sqls"id", null)
+    s.value should equal(" id is not null")
+    s.parameters should equal(Nil)
+  }
+
+  it should "have #ne for None values" in {
+    val s = SQLSyntax.ne(sqls"id", None)
+    s.value should equal(" id is not null")
+    s.parameters should equal(Nil)
+  }
+
   it should "have #eq and #ne" in {
     val s = SQLSyntax.eq(sqls"id", 123).and.ne(sqls"name", "Alice")
     s.value should equal(" id = ? and name <> ?")

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -576,6 +576,12 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
         }.map(_.long(1)).single.apply().get
         noAccountIdOrderCount should equal(0)
 
+        val stmt1 = select(count).from(Order as o).where.isNull(o.accountId).toSQL.statement
+        val stmt2 = select(count).from(Order as o).where.eq(o.accountId, None).toSQL.statement
+        val stmt3 = select(count).from(Order as o).where.eq(o.accountId, null).toSQL.statement
+        stmt1 should equal(stmt2)
+        stmt2 should equal(stmt3)
+
         val orders = withSQL { QueryDSL.select.from(Order as o).where.isNotNull(o.accountId) }.map(Order(o)).list.apply()
         orders.size should be > (0)
 


### PR DESCRIPTION
I think this behaivior is reasonable because nobody expects sqls"foo = null" query in this case.
