### PR TITLE
Rename #generalizedLocalTx to #localTxForReturnType

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -64,14 +64,11 @@ object ScalikeJDBCProjects extends Build {
       exclude[MissingMethodProblem]("scalikejdbc.SQLSyntaxSupportFeature.SQLSyntaxSupport"),
       exclude[MissingMethodProblem]("scalikejdbc.DBConnection.scalikejdbc$DBConnection$$rollbackIfThrowable"),
       exclude[MissingMethodProblem]("scalikejdbc.DBConnection.scalikejdbc$DBConnection$_setter_$scalikejdbc$DBConnection$$rollbackIfThrowable_="),
-      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.localTxForReturnTypeWithConnection"),
-      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.localTxForReturnType"),
-      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.localTxForWithConnection"),
-      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.localTxFor"),
       exclude[MissingMethodProblem]("scalikejdbc.DB.scalikejdbc$DBConnection$$rollbackIfThrowable"),
       exclude[MissingMethodProblem]("scalikejdbc.DB.scalikejdbc$DBConnection$_setter_$scalikejdbc$DBConnection$$rollbackIfThrowable_="),
       exclude[MissingMethodProblem]("scalikejdbc.NamedDB.scalikejdbc$DBConnection$$rollbackIfThrowable"),
-      exclude[MissingMethodProblem]("scalikejdbc.NamedDB.scalikejdbc$DBConnection$_setter_$scalikejdbc$DBConnection$$rollbackIfThrowable_=")
+      exclude[MissingMethodProblem]("scalikejdbc.NamedDB.scalikejdbc$DBConnection$_setter_$scalikejdbc$DBConnection$$rollbackIfThrowable_="),
+      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.localTxForReturnType")
     )
   }
 

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DB.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DB.scala
@@ -266,15 +266,8 @@ object DB extends LoanPattern {
    * @tparam A result type
    * @return result value
    */
-  def localTxForReturnType[A: TxBoundary](execution: DBSession => A)(implicit context: CPContext = NoCPContext): A = {
+  private[scalikejdbc] def localTxForReturnType[A: TxBoundary](execution: DBSession => A)(implicit context: CPContext = NoCPContext): A = {
     DB(connectionPool(context).borrow()).autoClose(true).localTxForReturnType(execution)
-  }
-
-  /**
-   * Shorten name of #localTxForReturnType.
-   */
-  def localTxFor[A: TxBoundary](execution: DBSession => A)(implicit context: CPContext = NoCPContext): A = {
-    localTxForReturnType[A](execution)
   }
 
   /**
@@ -302,25 +295,6 @@ object DB extends LoanPattern {
     using(connectionPool(context).borrow()) { conn =>
       DB(conn).autoClose(false).localTxWithConnection(execution)
     }
-  }
-
-  /**
-   * Begins a generalized local-tx block that returns a value easily with ConnectionPool.
-   *
-   * @param execution execution that returns a value
-   * @param context connection pool context
-   * @tparam A result type
-   * @return result value
-   */
-  def localTxForReturnTypeWithConnection[A: TxBoundary](execution: Connection => A)(implicit context: CPContext = NoCPContext): A = {
-    DB(connectionPool(context).borrow()).autoClose(true).localTxForReturnTypeWithConnection(execution)
-  }
-
-  /**
-   * Shorten name of #localTxForReturnTypeWithConnection.
-   */
-  def localTxForWithConnection[A: TxBoundary](execution: Connection => A)(implicit context: CPContext = NoCPContext): A = {
-    localTxForReturnTypeWithConnection[A](execution)
   }
 
   /**

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
@@ -264,7 +264,7 @@ trait DBConnection extends LogSupport with LoanPattern {
    * @tparam A  return type
    * @return result value
    */
-  def localTxForReturnType[A](execution: DBSession => A)(implicit boundary: TxBoundary[A]): A = {
+  private[scalikejdbc] def localTxForReturnType[A](execution: DBSession => A)(implicit boundary: TxBoundary[A]): A = {
     val doClose = if (autoCloseEnabled) () => conn.close() else () => ()
     val tx = newTx
     begin(tx)
@@ -278,13 +278,6 @@ trait DBConnection extends LogSupport with LoanPattern {
       case e: Throwable => doClose(); throw e
     }
     boundary.closeConnection(txResult, doClose)
-  }
-
-  /**
-   * Shorten name of #localTxForReturnType.
-   */
-  def localTxFor[A](execution: DBSession => A)(implicit boundary: TxBoundary[A]): A = {
-    localTxForReturnType[A](execution)
   }
 
   /**
@@ -306,20 +299,6 @@ trait DBConnection extends LogSupport with LoanPattern {
    */
   def localTxWithConnection[A](execution: Connection => A): A = {
     localTx(s => execution(s.conn))
-  }
-
-  /**
-   * Provides generalized local-tx session block.
-   * @param execution block
-   * @tparam A  return type
-   * @return result value
-   */
-  def localTxForReturnTypeWithConnection[A](execution: Connection => A)(implicit boundary: TxBoundary[A]): A = {
-    localTxForReturnType(s => execution(s.conn))
-  }
-
-  def localTxForWithConnection[A](execution: Connection => A)(implicit boundary: TxBoundary[A]): A = {
-    localTxForReturnTypeWithConnection(execution)
   }
 
   /**

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/TxBoundary.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/TxBoundary.scala
@@ -34,18 +34,9 @@ trait TxBoundary[A] {
 
 /**
  * Default TxBoundary type class instances.
+ * NOTE:  TxBoundary usage will be disclosed to library users since 2.2 or later.
  */
 object TxBoundary {
-
-  implicit def eitherTxBoundary[A, B] = new TxBoundary[Either[A, B]] {
-    def finishTx(result: Either[A, B], tx: Tx): Either[A, B] = {
-      result match {
-        case Right(_) => tx.commit()
-        case Left(_) => tx.rollback()
-      }
-      result
-    }
-  }
 
   implicit def futureTxBoundary[A](implicit ec: ExecutionContext) = new TxBoundary[Future[A]] {
     def finishTx(result: Future[A], tx: Tx): Future[A] = {
@@ -61,13 +52,37 @@ object TxBoundary {
     }
   }
 
-  implicit def tryTxBoundary[A] = new TxBoundary[Try[A]] {
-    def finishTx(result: Try[A], tx: Tx): Try[A] = {
-      result match {
-        case Success(_) => tx.commit()
-        case Failure(_) => tx.rollback()
+  /**
+   * Default TxBoundary type class instances.
+   * This implicit won't be provided by default
+   */
+  object Either {
+
+    implicit def eitherTxBoundary[L, R] = new TxBoundary[Either[L, R]] {
+      def finishTx(result: Either[L, R], tx: Tx): Either[L, R] = {
+        result match {
+          case Right(_) => tx.commit()
+          case Left(_) => tx.rollback()
+        }
+        result
       }
-      result
+    }
+  }
+
+  /**
+   * Default TxBoundary type class instances.
+   * This implicit won't be provided by default
+   */
+  object Try {
+
+    implicit def tryTxBoundary[A] = new TxBoundary[Try[A]] {
+      def finishTx(result: Try[A], tx: Tx): Try[A] = {
+        result match {
+          case Success(_) => tx.commit()
+          case Failure(_) => tx.rollback()
+        }
+        result
+      }
     }
   }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DBSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DBSpec.scala
@@ -330,147 +330,95 @@ class DBSpec extends FlatSpec with Matchers with BeforeAndAfter with Settings wi
   // --------------------
   // localTxForReturnType
 
-  it should "execute single in localTxForReturnType block" in {
-    val tableName = tableNamePrefix + "_singleInLocalTxForReturnType"
-    ultimately(TestUtils.deleteTable(tableName)) {
-      TestUtils.initialize(tableName)
-      val result = DB localTxForReturnType { s =>
-        allCatch.either { s.single("select id from " + tableName + " where id = ?", 1)(rs => rs.string("id")) }
+  {
+    import scalikejdbc.TxBoundary.Try._
+
+    it should "execute single in localTxForReturnType block with Try" in {
+      val tableName = tableNamePrefix + "_singleInLocalTxForReturnType_Try"
+      ultimately(TestUtils.deleteTable(tableName)) {
+        TestUtils.initialize(tableName)
+        val result = DB localTxForReturnType { s =>
+          allCatch.withTry { s.single("select id from " + tableName + " where id = ?", 1)(rs => rs.string("id")) }
+        }
+        result.isSuccess should be(true)
+        result.get should equal(Some("1"))
       }
-      result should equal(Right(Some("1")))
     }
   }
 
-  it should "execute list in localTxForReturnType block" in {
-    val tableName = tableNamePrefix + "_singleInLocalTxForReturnType"
-    ultimately(TestUtils.deleteTable(tableName)) {
-      TestUtils.initialize(tableName)
-      val result = DB localTxForReturnType { s =>
-        allCatch.either(s.list("select id from " + tableName + "")(rs => Some(rs.string("id"))))
-      }
-      result.right.get.size should equal(2)
-    }
-  }
+  {
+    import scalikejdbc.TxBoundary.Either._
 
-  it should "execute update in localTxForReturnType block" in {
-    val tableName = tableNamePrefix + "_singleInLocalTxForReturnType"
-    ultimately(TestUtils.deleteTable(tableName)) {
-      TestUtils.initialize(tableName)
-      val count = DB localTxForReturnType { s =>
-        allCatch.either(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
+    it should "execute single in localTxForReturnType block" in {
+      val tableName = tableNamePrefix + "_singleInLocalTxForReturnType"
+      ultimately(TestUtils.deleteTable(tableName)) {
+        TestUtils.initialize(tableName)
+        val result = DB localTxForReturnType { s =>
+          allCatch.either { s.single("select id from " + tableName + " where id = ?", 1)(rs => rs.string("id")) }
+        }
+        result should equal(Right(Some("1")))
       }
-      count should equal(Right(1))
-      val name = count.right.flatMap { _ =>
-        DB localTxForReturnType (s => allCatch.either(s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name"))))
-      }
-      name should be(Right(Some("foo")))
     }
-  }
 
-  it should "not be able to rollback in localTxForReturnType block" in {
-    val tableName = tableNamePrefix + "_singleInLocalTxForReturnType"
-    ultimately(TestUtils.deleteTable(tableName)) {
-      TestUtils.initialize(tableName)
-      using(DB(ConnectionPool.borrow())) { db =>
+    it should "execute list in localTxForReturnType block" in {
+      val tableName = tableNamePrefix + "_singleInLocalTxForReturnType"
+      ultimately(TestUtils.deleteTable(tableName)) {
+        TestUtils.initialize(tableName)
+        val result = DB localTxForReturnType { s =>
+          allCatch.either(s.list("select id from " + tableName + "")(rs => Some(rs.string("id"))))
+        }
+        result.right.get.size should equal(2)
+      }
+    }
+
+    it should "execute update in localTxForReturnType block" in {
+      val tableName = tableNamePrefix + "_singleInLocalTxForReturnType"
+      ultimately(TestUtils.deleteTable(tableName)) {
+        TestUtils.initialize(tableName)
         val count = DB localTxForReturnType { s =>
           allCatch.either(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
         }
         count should equal(Right(1))
-        db.rollbackIfActive()
-        val name = DB localTxForReturnType { s =>
-          allCatch.either(s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name")))
+        val name = count.right.flatMap { _ =>
+          DB localTxForReturnType (s => allCatch.either(s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name"))))
         }
-        name should equal(Right(Some("foo")))
-        name
+        name should be(Right(Some("foo")))
       }
     }
-  }
 
-  it should "do rollback in localTxForReturnType block" in {
-    val tableName = tableNamePrefix + "_rollback"
-    ultimately(TestUtils.deleteTable(tableName)) {
-      TestUtils.initialize(tableName)
-      val failure = DB.localTxForReturnType[Either[Throwable, Int]] { implicit s =>
-        allCatch.either(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
-          .right.flatMap(_ => allCatch.either(s.update("update foo should be rolled back")))
+    it should "not be able to rollback in localTxForReturnType block" in {
+      val tableName = tableNamePrefix + "_singleInLocalTxForReturnType"
+      ultimately(TestUtils.deleteTable(tableName)) {
+        TestUtils.initialize(tableName)
+        using(DB(ConnectionPool.borrow())) { db =>
+          val count = DB localTxForReturnType { s =>
+            allCatch.either(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
+          }
+          count should equal(Right(1))
+          db.rollbackIfActive()
+          val name = DB localTxForReturnType { s =>
+            allCatch.either(s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name")))
+          }
+          name should equal(Right(Some("foo")))
+          name
+        }
       }
-      failure should be('left)
-      val res = DB readOnly (s => s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name")))
-      res.get should not be (Some("foo"))
     }
-  }
 
-  // --------------------
-  // localTxFor
-
-  it should "execute single in localTxFor block" in {
-    val tableName = tableNamePrefix + "_singleInLocalTxFor"
-    ultimately(TestUtils.deleteTable(tableName)) {
-      TestUtils.initialize(tableName)
-      val result = DB localTxFor { s =>
-        allCatch.either { s.single("select id from " + tableName + " where id = ?", 1)(rs => rs.string("id")) }
-      }
-      result should equal(Right(Some("1")))
-    }
-  }
-
-  it should "execute list in localTxFor block" in {
-    val tableName = tableNamePrefix + "_singleInLocalTxFor"
-    ultimately(TestUtils.deleteTable(tableName)) {
-      TestUtils.initialize(tableName)
-      val result = DB localTxFor { s =>
-        allCatch.either(s.list("select id from " + tableName + "")(rs => Some(rs.string("id"))))
-      }
-      result.right.get.size should equal(2)
-    }
-  }
-
-  it should "execute update in localTxFor block" in {
-    val tableName = tableNamePrefix + "_singleInLocalTxFor"
-    ultimately(TestUtils.deleteTable(tableName)) {
-      TestUtils.initialize(tableName)
-      val count = DB localTxFor { s =>
-        allCatch.either(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
-      }
-      count should equal(Right(1))
-      val name = count.right.flatMap { _ =>
-        DB localTxFor (s => allCatch.either(s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name"))))
-      }
-      name should be(Right(Some("foo")))
-    }
-  }
-
-  it should "not be able to rollback in localTxFor block" in {
-    val tableName = tableNamePrefix + "_singleInLocalTxFor"
-    ultimately(TestUtils.deleteTable(tableName)) {
-      TestUtils.initialize(tableName)
-      using(DB(ConnectionPool.borrow())) { db =>
-        val count = DB localTxFor { s =>
+    it should "do rollback in localTxForReturnType block" in {
+      val tableName = tableNamePrefix + "_rollback"
+      ultimately(TestUtils.deleteTable(tableName)) {
+        TestUtils.initialize(tableName)
+        val failure = DB.localTxForReturnType[Either[Throwable, Int]] { implicit s =>
           allCatch.either(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
+            .right.flatMap(_ => allCatch.either(s.update("update foo should be rolled back")))
         }
-        count should equal(Right(1))
-        db.rollbackIfActive()
-        val name = DB localTxFor { s =>
-          allCatch.either(s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name")))
-        }
-        name should equal(Right(Some("foo")))
-        name
+        failure should be('left)
+        val res = DB readOnly (s => s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name")))
+        res.get should not be (Some("foo"))
       }
     }
-  }
 
-  it should "do rollback in localTxFor block" in {
-    val tableName = tableNamePrefix + "_rollback"
-    ultimately(TestUtils.deleteTable(tableName)) {
-      TestUtils.initialize(tableName)
-      val failure = DB.localTxFor[Either[Throwable, Int]] { implicit s =>
-        allCatch.either(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
-          .right.flatMap(_ => allCatch.either(s.update("update foo should be rolled back")))
-      }
-      failure should be('left)
-      val res = DB readOnly (s => s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name")))
-      res.get should not be (Some("foo"))
-    }
   }
 
   // --------------------


### PR DESCRIPTION
Since `#generalizedLocalTx` is not released yet, it's not too late to change the name. I think `#localTxForReturnType` is clearer.
### with type parameter

``` scala
//val res: Try[Int] = DB.generalizedLocalTx[Try[Int]] { session =>
val res: Try[Int] = DB.localTxForReturnType[Try[Int]] { session =>
```
### without type parameter

``` scala
//val res: Try[Int] = DB.generalizedLocalTx { session =>
val res: Try[Int] = DB.localTxForReturnType { session =>
  Try {
  }
}
```
