### PR TITLE
Remove default TxBoundary typeclass instances

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DB.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DB.scala
@@ -279,6 +279,8 @@ object DB extends LoanPattern {
    * @return future result value
    */
   def futureLocalTx[A](execution: DBSession => Future[A])(implicit context: CPContext = NoCPContext, ec: ExecutionContext): Future[A] = {
+    // Enable TxBoundary implicits
+    import scalikejdbc.TxBoundary.Future._
     localTxForReturnType(execution)
   }
 

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
@@ -288,6 +288,8 @@ trait DBConnection extends LogSupport with LoanPattern {
    * @return future result
    */
   def futureLocalTx[A](execution: DBSession => Future[A])(implicit ec: ExecutionContext): Future[A] = {
+    // Enable TxBoundary implicits
+    import scalikejdbc.TxBoundary.Future._
     localTxForReturnType(execution)
   }
 

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/TxBoundary.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/TxBoundary.scala
@@ -33,28 +33,33 @@ trait TxBoundary[A] {
 }
 
 /**
- * Default TxBoundary type class instances.
+ * TxBoundary type class instances.
  * NOTE:  TxBoundary usage will be disclosed to library users since 2.2 or later.
  */
 object TxBoundary {
 
-  implicit def futureTxBoundary[A](implicit ec: ExecutionContext) = new TxBoundary[Future[A]] {
-    def finishTx(result: Future[A], tx: Tx): Future[A] = {
-      result.andThen {
-        case Success(_) => tx.commit()
-        case Failure(_) => tx.rollback()
+  /**
+   * Future TxBoundary type class instances.
+   */
+  object Future {
+
+    implicit def futureTxBoundary[A](implicit ec: ExecutionContext) = new TxBoundary[Future[A]] {
+      def finishTx(result: Future[A], tx: Tx): Future[A] = {
+        result.andThen {
+          case Success(_) => tx.commit()
+          case Failure(_) => tx.rollback()
+        }
       }
-    }
-    override def closeConnection(result: Future[A], doClose: () => Unit): Future[A] = {
-      result.andThen {
-        case _ => doClose()
+      override def closeConnection(result: Future[A], doClose: () => Unit): Future[A] = {
+        result.andThen {
+          case _ => doClose()
+        }
       }
     }
   }
 
   /**
-   * Default TxBoundary type class instances.
-   * This implicit won't be provided by default
+   * Either TxBoundary type class instances.
    */
   object Either {
 
@@ -70,8 +75,7 @@ object TxBoundary {
   }
 
   /**
-   * Default TxBoundary type class instances.
-   * This implicit won't be provided by default
+   * Try TxBoundary type class instances.
    */
   object Try {
 


### PR DESCRIPTION
In the following case, DB connection will be uselessly grasped by localTx's `TxBoundary` control if it's enabled by default since 2.2.

``` scala
DB.localTx { implicit s =>
  // works with the DB connection
  ...
  doFutureOperation()
}

def doFutureOperation()(implicit ctx: ExecutionConttext): Future[Something] = {
  Future { 
    // Assumes this block sometimes takes long time due to other operations (e.g. external API call).
    // Although this code probably should be outside of this localTx block ideally,
    // the author of code might think it's safe because this Future ops won't join the transaction
  }
}
```

If there is a risk that existing applications may be in trouble, we should keep backward compatibility after 2.2 release too.
