### PR TITLE
Fix new transaction boundary in 2.2 #302

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ object ScalikeJDBCProjects extends Build {
   // [NOTE] Execute the following to bump version
   // sbt "g version 1.3.8-SNAPSHOT"
   lazy val _version = "2.2.0-SNAPSHOT"
-  lazy val compatibleVersion = "2.1.0"
+  lazy val compatibleVersion = "2.1.4"
 
   lazy val _organization = "org.scalikejdbc"
 
@@ -27,52 +27,23 @@ object ScalikeJDBCProjects extends Build {
     import com.typesafe.tools.mima.core._
     import com.typesafe.tools.mima.core.ProblemFilters._
     Seq(
-      /*
-      // since 2.0.1
-      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.futureLocalTx"),
-      exclude[MissingMethodProblem]("scalikejdbc.LoanPattern.futureUsing"),
-      // since 2.0.5
-      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.autoClose"),
-      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.scalikejdbc$DBConnection$$autoCloseEnabled"),
-      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.scalikejdbc$DBConnection$$autoCloseEnabled_="),
-      exclude[MissingMethodProblem]("scalikejdbc.DBSession.fetchSize"),
-      exclude[MissingMethodProblem]("scalikejdbc.DBSession.scalikejdbc$DBSession$$_fetchSize_="),
-      exclude[MissingMethodProblem]("scalikejdbc.DBSession.scalikejdbc$DBSession$$_fetchSize"),
-      exclude[MissingMethodProblem]("scalikejdbc.config.TypesafeConfigReaderWithEnv"),
-      // since 2.1.0
-      exclude[MissingMethodProblem]("scalikejdbc.WrappedResultSet.dateTime"),
-      exclude[MissingMethodProblem]("scalikejdbc.WrappedResultSet.localDate"),
-      exclude[MissingMethodProblem]("scalikejdbc.WrappedResultSet.localTime"),
-      exclude[MissingMethodProblem]("scalikejdbc.WrappedResultSet.localDateTime"),
-      exclude[MissingMethodProblem]("scalikejdbc.WrappedResultSet.dateTimeOpt"),
-      exclude[MissingMethodProblem]("scalikejdbc.WrappedResultSet.localDateOpt"),
-      exclude[MissingMethodProblem]("scalikejdbc.WrappedResultSet.localTimeOpt"),
-      exclude[MissingMethodProblem]("scalikejdbc.WrappedResultSet.localDateTimeOpt"),
-      exclude[MissingTypesProblem]("scalikejdbc.mapper.GeneratorConfig$"),
-      exclude[MissingMethodProblem]("scalikejdbc.mapper.GeneratorConfig.apply"),
-      exclude[MissingMethodProblem]("scalikejdbc.mapper.GeneratorConfig.apply"),
-      exclude[MissingMethodProblem]("scalikejdbc.mapper.GeneratorConfig.copy"),
-      exclude[MissingMethodProblem]("scalikejdbc.mapper.GeneratorConfig.this")
-      */
-      // since 2.1.2
-      exclude[MissingMethodProblem]("scalikejdbc.mapper.GeneratorConfig.copy"),
-      exclude[MissingMethodProblem]("scalikejdbc.mapper.GeneratorConfig.this"),
-      exclude[MissingTypesProblem]("scalikejdbc.mapper.GeneratorConfig$"),
-      exclude[MissingMethodProblem]("scalikejdbc.mapper.GeneratorConfig.apply"),
-      // since 2.1.3
-      exclude[MissingMethodProblem]("scalikejdbc.SQLSyntaxSupportFeature#SQLSyntaxSupport.clearLoadedColumns"),
-      exclude[MissingMethodProblem]("scalikejdbc.SQLSyntaxSupportFeature.SQLSyntaxSupport"),
-      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.scalikejdbc$DBConnection$$rollbackIfThrowable"),
-      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.scalikejdbc$DBConnection$_setter_$scalikejdbc$DBConnection$$rollbackIfThrowable_="),
-      exclude[MissingMethodProblem]("scalikejdbc.DB.scalikejdbc$DBConnection$$rollbackIfThrowable"),
-      exclude[MissingMethodProblem]("scalikejdbc.DB.scalikejdbc$DBConnection$_setter_$scalikejdbc$DBConnection$$rollbackIfThrowable_="),
-      exclude[MissingMethodProblem]("scalikejdbc.NamedDB.scalikejdbc$DBConnection$$rollbackIfThrowable"),
-      exclude[MissingMethodProblem]("scalikejdbc.NamedDB.scalikejdbc$DBConnection$_setter_$scalikejdbc$DBConnection$$rollbackIfThrowable_="),
+      // since 2.2.0
+      // private[scalikejdbc] methods were removed
+      exclude[MissingMethodProblem]("scalikejdbc.DB.localTxForReturnType"),
+      exclude[MissingMethodProblem]("scalikejdbc.DB.localTxForReturnType$default$3"),
+      exclude[MissingMethodProblem]("scalikejdbc.NamedDB.localTxForReturnType"),
       exclude[MissingMethodProblem]("scalikejdbc.DBConnection.localTxForReturnType"),
-      exclude[MissingTypesProblem]("scalikejdbc.mapper.Table$"),
-      exclude[MissingMethodProblem]("scalikejdbc.mapper.Table.this"),
-      exclude[MissingMethodProblem]("scalikejdbc.mapper.Table.apply"),
-      exclude[MissingMethodProblem]("scalikejdbc.mapper.Table.copy")
+      // newly added methods
+      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.localTx"),
+      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.localTxWithConnection"),
+      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.localTx"),
+      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.localTx$default$2"),
+      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.localTxWithConnection$default$2"),
+      exclude[MissingMethodProblem]("scalikejdbc.DBConnection.localTxWithConnection"),
+      exclude[MissingMethodProblem]("scalikejdbc.DB.localTx"),
+      exclude[MissingMethodProblem]("scalikejdbc.DB.localTxWithConnection"),
+      exclude[MissingMethodProblem]("scalikejdbc.NamedDB.localTx"),
+      exclude[MissingMethodProblem]("scalikejdbc.NamedDB.localTxWithConnection")
     )
   }
 

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/TxBoundary.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/TxBoundary.scala
@@ -19,12 +19,18 @@ import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Try, Failure, Success }
 
 /**
- * This type class enable users to customize the befavior of transaction boundary(commit/rollback).
+ * This type class enable users to customize the behavior of transaction boundary(commit/rollback).
  */
 trait TxBoundary[A] {
 
+  /**
+   * Finishes the current transaction.
+   */
   def finishTx(result: A, tx: Tx): A
 
+  /**
+   * Closes the current connection if needed.
+   */
   def closeConnection(result: A, doClose: () => Unit): A = {
     doClose()
     result
@@ -34,12 +40,24 @@ trait TxBoundary[A] {
 
 /**
  * TxBoundary type class instances.
- * NOTE:  TxBoundary usage will be disclosed to library users since 2.2 or later.
  */
 object TxBoundary {
 
   /**
-   * Future TxBoundary type class instances.
+   * Exception TxBoundary type class instance.
+   */
+  object Exception {
+
+    implicit def exceptionTxBoundary[A] = new TxBoundary[A] {
+      def finishTx(result: A, tx: Tx): A = {
+        tx.commit()
+        result
+      }
+    }
+  }
+
+  /**
+   * Future TxBoundary type class instance.
    */
   object Future {
 
@@ -59,7 +77,7 @@ object TxBoundary {
   }
 
   /**
-   * Either TxBoundary type class instances.
+   * Either TxBoundary type class instance.
    */
   object Either {
 
@@ -75,7 +93,7 @@ object TxBoundary {
   }
 
   /**
-   * Try TxBoundary type class instances.
+   * Try TxBoundary type class instance.
    */
   object Try {
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DBSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DBSpec.scala
@@ -328,16 +328,16 @@ class DBSpec extends FlatSpec with Matchers with BeforeAndAfter with Settings wi
   }
 
   // --------------------
-  // localTxForReturnType
+  // localTx (former localTxForReturnType)
 
   {
     import scalikejdbc.TxBoundary.Try._
 
-    it should "execute single in localTxForReturnType block with Try" in {
+    it should "execute single in localTx (former localTxForReturnType) block with Try" in {
       val tableName = tableNamePrefix + "_singleInLocalTxForReturnType_Try"
       ultimately(TestUtils.deleteTable(tableName)) {
         TestUtils.initialize(tableName)
-        val result = DB localTxForReturnType { s =>
+        val result = DB localTx { s =>
           allCatch.withTry { s.single("select id from " + tableName + " where id = ?", 1)(rs => rs.string("id")) }
         }
         result.isSuccess should be(true)
@@ -349,54 +349,54 @@ class DBSpec extends FlatSpec with Matchers with BeforeAndAfter with Settings wi
   {
     import scalikejdbc.TxBoundary.Either._
 
-    it should "execute single in localTxForReturnType block" in {
+    it should "execute single in localTx (former localTxForReturnType) block" in {
       val tableName = tableNamePrefix + "_singleInLocalTxForReturnType"
       ultimately(TestUtils.deleteTable(tableName)) {
         TestUtils.initialize(tableName)
-        val result = DB localTxForReturnType { s =>
+        val result = DB localTx { s =>
           allCatch.either { s.single("select id from " + tableName + " where id = ?", 1)(rs => rs.string("id")) }
         }
         result should equal(Right(Some("1")))
       }
     }
 
-    it should "execute list in localTxForReturnType block" in {
+    it should "execute list in localTx (former localTxForReturnType) block" in {
       val tableName = tableNamePrefix + "_singleInLocalTxForReturnType"
       ultimately(TestUtils.deleteTable(tableName)) {
         TestUtils.initialize(tableName)
-        val result = DB localTxForReturnType { s =>
+        val result = DB localTx { s =>
           allCatch.either(s.list("select id from " + tableName + "")(rs => Some(rs.string("id"))))
         }
         result.right.get.size should equal(2)
       }
     }
 
-    it should "execute update in localTxForReturnType block" in {
+    it should "execute update in localTx (former localTxForReturnType) block" in {
       val tableName = tableNamePrefix + "_singleInLocalTxForReturnType"
       ultimately(TestUtils.deleteTable(tableName)) {
         TestUtils.initialize(tableName)
-        val count = DB localTxForReturnType { s =>
+        val count = DB localTx { s =>
           allCatch.either(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
         }
         count should equal(Right(1))
         val name = count.right.flatMap { _ =>
-          DB localTxForReturnType (s => allCatch.either(s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name"))))
+          DB localTx (s => allCatch.either(s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name"))))
         }
         name should be(Right(Some("foo")))
       }
     }
 
-    it should "not be able to rollback in localTxForReturnType block" in {
+    it should "not be able to rollback (former localTxForReturnType) in localTx block" in {
       val tableName = tableNamePrefix + "_singleInLocalTxForReturnType"
       ultimately(TestUtils.deleteTable(tableName)) {
         TestUtils.initialize(tableName)
         using(DB(ConnectionPool.borrow())) { db =>
-          val count = DB localTxForReturnType { s =>
+          val count = DB localTx { s =>
             allCatch.either(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
           }
           count should equal(Right(1))
           db.rollbackIfActive()
-          val name = DB localTxForReturnType { s =>
+          val name = DB localTx { s =>
             allCatch.either(s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name")))
           }
           name should equal(Right(Some("foo")))
@@ -405,11 +405,11 @@ class DBSpec extends FlatSpec with Matchers with BeforeAndAfter with Settings wi
       }
     }
 
-    it should "do rollback in localTxForReturnType block" in {
+    it should "do rollback in localTx (former localTxForReturnType) block" in {
       val tableName = tableNamePrefix + "_rollback"
       ultimately(TestUtils.deleteTable(tableName)) {
         TestUtils.initialize(tableName)
-        val failure = DB.localTxForReturnType[Either[Throwable, Int]] { implicit s =>
+        val failure = DB.localTx[Either[Throwable, Int]] { implicit s =>
           allCatch.either(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
             .right.flatMap(_ => allCatch.either(s.update("update foo should be rolled back")))
         }


### PR DESCRIPTION
- Add `TxBoundary` implicit parameter to `#localTx` as same as `#localTxForReturnType`
- Remove `#localTxForReturnType` (private[scalikejdbc] since 2.1.3)
