### PR TITLE
Fix column names retrieval when same table in multiple (include 'public') schema (PostgreSQL)

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,7 +7,7 @@ object ScalikeJDBCProjects extends Build {
 
   // [NOTE] Execute the following to bump version
   // sbt "g version 1.3.8-SNAPSHOT"
-  lazy val _version = "2.2.0"
+  lazy val _version = "2.2.1-SNAPSHOT"
   lazy val compatibleVersion = "2.1.4"
 
   lazy val _organization = "org.scalikejdbc"


### PR DESCRIPTION
When same table as below in 'public' and other schema exist, loaded column names are mixed due to ScalikeJDBC implementation.
- public.accounts
- legacy.accounts
