### PR TITLE
Performance improvement for BasicResultNameSQLSyntaxProvider

### DIFF
--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
@@ -534,6 +534,14 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
       val name = toAliasName(c.value, support)
       SQLSyntax(s"${name}${delimiterForResultName}${tableAliasName}")
     }.getOrElse(throw notFoundInColumns(tableAliasName, name))
+
+    private[this] var fields: Map[String, SQLSyntax] = Map.empty
+
+    override def field(name: String): SQLSyntax = fields.getOrElse(name, {
+      val syntax = super.field(name)
+      synchronized(fields = fields + (name -> syntax))
+      syntax
+    })
   }
 
   // subquery syntax providers

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
@@ -860,5 +860,18 @@ class SQLInterpolationSpec extends FlatSpec with Matchers with DBSettings with S
     SQLSyntaxSupport.clearAllLoadedColumns()
   }
 
+  it should "provide fast dynamic result names" in {
+    val resultName = User.syntax("u").resultName
+
+    val start = System.currentTimeMillis()
+    (1 to 10000) foreach { _ =>
+      resultName.id.value shouldBe "I_Z_U"
+      resultName.firstName.value shouldBe "FN_Z_U"
+      resultName.groupId.value shouldBe "GI_Z_U"
+    }
+    val end = System.currentTimeMillis()
+    (end - start) should be < 100L
+  }
+
 }
 


### PR DESCRIPTION
Hi,

we've just evaluated scalikejdbc as replacement for slick. However, whenever dealing with large result sets we run into serious performance issues. I've added a simple test case as part of the merge request to demonstrate the case.

Eventually we managed to track down the issue in the BasicResultNameSQLSyntaxProvider whenever dynamic fields are converted to column aliases. We'd like to suggest to store these aliases once they are created. 

Potentially it even makes sense to push this fix down into the concrete implementation of def field(name: String) 

Thanks so much for the great work! 
Best,
Moritz
