### PR TITLE
Fix comment on SQLSyntax.toAndConditionOpt and SQLSyntax.toOrConditionOpt

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
@@ -318,8 +318,9 @@ object SQLSyntax {
    * Rerturns an optional SQLSyntax which is flatten (from option array) and joined with 'and'.
    *
    * {{{
-   *   val cond: Option[SQLSyntax] = SQLSyntax.toAndConditionOpt(Some(sqls"id = $id"), None, Some(sqls"name = $name"))
-   *   cond.get.statement // "id = ? or (name = ? or name is null)"
+   *   val (id, name) = (123, "Alice")
+   *   val cond: Option[SQLSyntax] = SQLSyntax.toAndConditionOpt(Some(sqls"id = ${id}"), None, Some(sqls"name = ${name} or name is null"))
+   *   cond.get.value // "id = ? and (name = ? or name is null)"
    *   cond.get.parameters // Seq(123, "Alice")
    * }}}
    */
@@ -332,9 +333,11 @@ object SQLSyntax {
    * Rerturns an optional SQLSyntax which is flatten (from option array) and joined with 'or'.
    *
    * {{{
-   *   val cond: Option[SQLSyntax] = SQLSyntax.toOrConditionOpt(Some(sqls"id = $id"), None, Some(sqls"name = $name"))
-   *   cond.get.statement // "id = ? or (name = ? or name is null)"
+   *   val (id, name) = (123, "Alice")
+   *   val cond: Option[SQLSyntax] = SQLSyntax.toOrConditionOpt(Some(sqls"id = ${id}"), None, Some(sqls"name = ${name} or name is null"))
+   *   cond.get.value // "id = ? or (name = ? or name is null)"
    *   cond.get.parameters // Seq(123, "Alice")
+   * }}}
    */
   def toOrConditionOpt(conditions: Option[SQLSyntax]*): Option[SQLSyntax] = {
     val cs: Seq[SQLSyntax] = conditions.flatten


### PR DESCRIPTION
These comments are different from actual result. I fixed by [test code](https://github.com/scalikejdbc/scalikejdbc/blob/cb9e41fde53927853fdbb6953384ec08806afa46/scalikejdbc-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala#L330-L354) as a reference.