### PR TITLE
Mark ParameterBinder.value as deprecated

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
@@ -35,6 +35,7 @@ trait ParameterBinder[A] {
   /**
    * Parameter value.
    */
+  @deprecated("This unused field will be removed", since = "2.2.4")
   def value: A
 
   /**


### PR DESCRIPTION
It's not required for scalikejdbc-core.