### PR TITLE
Compile error when there is no ExecutionContext using TxBoundary.Future._

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/TxBoundary.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/TxBoundary.scala
@@ -41,10 +41,16 @@ object TxBoundary {
     }
   }
 
+  /** This class will tell library users about missing implicit value by compilation error with the explanatory method name. */
+  private[scalikejdbc] sealed abstract class TxBoundaryMissingImplicits {
+    implicit def `"!!! Please read the following error message shown as method name. !!!"`[A]: TxBoundary[A] = sys.error("Don't use this method.")
+    implicit def `"To activate TxBoundary.Future, scala.concurrent.ExecutionContext value in implicit scope is required here."`[A]: TxBoundary[A] = sys.error("Don't use this method.")
+  }
+
   /**
    * Future TxBoundary type class instance.
    */
-  object Future {
+  object Future extends TxBoundaryMissingImplicits {
 
     implicit def futureTxBoundary[A](implicit ec: ExecutionContext) = new TxBoundary[Future[A]] {
       def finishTx(result: Future[A], tx: Tx): Future[A] = {

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/TxBoundaryMissingImplicitsSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/TxBoundaryMissingImplicitsSpec.scala
@@ -1,0 +1,24 @@
+package scalikejdbc
+
+import org.scalatest._
+
+class TxBoundaryMissingImplicitsSpec extends FlatSpec with Matchers {
+
+  behavior of "TxBoundary.Future"
+
+  it should "compile when there is an ExecutionContext in scope" in {
+    """
+    import scala.concurrent.ExecutionContext.Implicits.global 
+    import TxBoundary.Future._
+    DB.localTx(session => scala.concurrent.Future.successful(1))
+    """ should compile
+  }
+
+  it should "not compile when there is no ExecutionContext in scope" in {
+    """
+    import TxBoundary.Future._
+    DB.localTx(session => scala.concurrent.Future.successful(1))
+    """ shouldNot compile
+  }
+
+}


### PR DESCRIPTION
## Motivation

```scala
import TxBoundary.Future._
DB.localTx(session => scala.concurrent.Future.successful(1))
```

this code can be compiled. However this localTx does not use FutureTxBoundary.
Because there is no ExecutionContext instance in implicit scope.

this is a pit fall.

