### PR TITLE
Add SQLSyntax#roundBracket

### DIFF
--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -137,7 +137,9 @@ object MimaSettings {
     )} ++ Seq(
       // since 2.2.5
       exclude[MissingMethodProblem]("scalikejdbc.mapper.CodeGenerator.scalikejdbc$mapper$CodeGenerator$$toCamelCase"),
-      exclude[MissingMethodProblem]("scalikejdbc.mapper.CodeGenerator.scalikejdbc$mapper$CodeGenerator$$toProperCase")
+      exclude[MissingMethodProblem]("scalikejdbc.mapper.CodeGenerator.scalikejdbc$mapper$CodeGenerator$$toProperCase"),
+      // since 2.2.7
+      exclude[MissingMethodProblem]("scalikejdbc.QueryDSLFeature#ConditionSQLBuilder.roundBracket")
     )
   }
 

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
@@ -47,6 +47,8 @@ class SQLSyntax private[scalikejdbc] (val value: String, val parameters: Seq[Any
   def and = sqls"${this} and"
   def or = sqls"${this} or"
 
+  def roundBracket(inner: SQLSyntax) = sqls"$this ($inner)"
+
   def eq(column: SQLSyntax, value: Any): SQLSyntax = {
     value match {
       case null | None => sqls"${this} ${column} is null"

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
@@ -327,6 +327,15 @@ class SQLSyntaxSpec extends FlatSpec with Matchers {
     s.parameters should equal(Seq(123, "Alice"))
   }
 
+  it should "have #roundBracket" in {
+    val (id, name, age) = (123, "Alice", 12)
+    val s = SQLSyntax.eq(sqls"id", id).and.roundBracket(
+      SQLSyntax.eq(sqls"name", name).or.eq(sqls"age", age)
+    )
+    s.value should equal(" id = ? and ( name = ? or age = ?)")
+    s.parameters should equal(Seq(123, "Alice", 12))
+  }
+
   it should "have #toAndConditionOpt (Some)" in {
     val (id, name) = (123, "Alice")
     val s = SQLSyntax.toAndConditionOpt(Some(sqls"id = ${id}"), Some(sqls"name = ${name} or name is null")).get

--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
@@ -281,6 +281,8 @@ trait QueryDSLFeature { self: SQLInterpolationFeature with SQLSyntaxSupportFeatu
       ConditionSQLBuilder[A](sqls"${sql} (${insidePart(emptyBuilder).toSQLSyntax})")
     }
 
+    def roundBracket(inner: SQLSyntax): ConditionSQLBuilder[A] = ConditionSQLBuilder[A](sql.roundBracket(inner))
+
     /**
      * Appends SQLSyntax directly.
      * e.g. select.from(User as u).where.eq(u.id, 123).append(sqls"order by ${u.id} desc")

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -261,6 +261,7 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
         preferredClients.size should equal(2)
         preferredClients should equal(List((2, 360), (1, 440)))
 
+        // test withRoundBracket(ConditionSQLBuilder => ConditionSQLBuilder)
         val bracketTestResults = withSQL {
           select(o.result.id)
             .from(Order as o)
@@ -271,6 +272,18 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
         }.map(_.int(o.resultName.id)).list.apply()
 
         bracketTestResults should equal(List(11, 12, 13, 14, 15, 26))
+
+        // test roundBracket(SQLSyntax)
+        val bracketTestResults2 = withSQL {
+          select(o.result.id)
+            .from(Order as o)
+            .where.roundBracket(
+              sqls.eq(o.productId, 1).and.isNotNull(o.accountId)
+            ).or.isNull(o.accountId)
+            .orderBy(o.id)
+        }.map(_.int(o.resultName.id)).list.apply()
+
+        bracketTestResults2 should equal(List(11, 12, 13, 14, 15, 26))
 
         {
           val productId = Some(1)


### PR DESCRIPTION
It's handy to represent SQLSyntax like `c1=? and (c2=? or c3=?)`.

Is it better to name it as `roundBracket()`? Query DSL uses the name `withRoundBracket`.
