### PR TITLE
Added where(Option[SQLSyntax]), or(Option[SQLSyntax]), and(Option[SQLSyntax]) to SQLSyntax

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
@@ -43,9 +43,14 @@ class SQLSyntax private[scalikejdbc] (val value: String, val parameters: Seq[Any
 
   def where = sqls"${this} where"
   def where(where: SQLSyntax): SQLSyntax = sqls"${this} where ${where}"
+  def where(whereOpt: Option[SQLSyntax]): SQLSyntax = whereOpt.fold(this)(where(_))
 
   def and = sqls"${this} and"
+  def and(sqlPart: SQLSyntax): SQLSyntax = sqls"$this and ($sqlPart)"
+  def and(andOpt: Option[SQLSyntax]): SQLSyntax = andOpt.fold(this)(and(_))
   def or = sqls"${this} or"
+  def or(sqlPart: SQLSyntax): SQLSyntax = sqls"$this or ($sqlPart)"
+  def or(orOpt: Option[SQLSyntax]): SQLSyntax = orOpt.fold(this)(or(_))
 
   def roundBracket(inner: SQLSyntax) = sqls"$this ($inner)"
 
@@ -182,6 +187,7 @@ class SQLSyntax private[scalikejdbc] (val value: String, val parameters: Seq[Any
   def stripMargin: SQLSyntax = new SQLSyntax(value.stripMargin, parameters)
 
   def stripMargin(marginChar: Char): SQLSyntax = new SQLSyntax(value.stripMargin(marginChar), parameters)
+
 }
 
 /**
@@ -248,6 +254,14 @@ object SQLSyntax {
 
   val where: SQLSyntax = SQLSyntax.empty.where
   def where(where: SQLSyntax): SQLSyntax = SQLSyntax.empty.where(where)
+  def where(whereOpt: Option[SQLSyntax]): SQLSyntax = SQLSyntax.empty.where(whereOpt)
+
+  def and: SQLSyntax = SQLSyntax.empty.and
+  def and(sqlPart: SQLSyntax): SQLSyntax = SQLSyntax.empty.and(sqlPart)
+  def and(andOpt: Option[SQLSyntax]): SQLSyntax = SQLSyntax.empty.and(andOpt)
+  def or: SQLSyntax = SQLSyntax.empty.or
+  def or(sqlPart: SQLSyntax): SQLSyntax = SQLSyntax.empty.or(sqlPart)
+  def or(orOpt: Option[SQLSyntax]): SQLSyntax = SQLSyntax.empty.or(orOpt)
 
   def eq(column: SQLSyntax, value: Any): SQLSyntax = SQLSyntax.empty.eq(column, value)
   def ne(column: SQLSyntax, value: Any): SQLSyntax = SQLSyntax.empty.ne(column, value)

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
@@ -313,11 +313,45 @@ class SQLSyntaxSpec extends FlatSpec with Matchers {
     s.parameters should equal(Seq(123))
   }
 
+  it should "have #where(Option[SQLSyntax])" in {
+    {
+      val id = 123
+      val s = SQLSyntax.where(Some(sqls"id = ${id}"))
+      s.value should equal(" where id = ?")
+      s.parameters should equal(Seq(123))
+    }
+    {
+      val s = SQLSyntax.where(None)
+      s.value should equal("")
+      s.parameters should equal(Seq())
+    }
+  }
+
   it should "have #and" in {
     val (id, name) = (123, "Alice")
     val s = SQLSyntax.eq(sqls"id", id).and.eq(sqls"name", name)
     s.value should equal(" id = ? and name = ?")
     s.parameters should equal(Seq(123, "Alice"))
+  }
+  it should "have #and(SQLSyntax)" in {
+    val (id, name) = (123, "Alice")
+    val s = SQLSyntax.eq(sqls"id", id).and(SQLSyntax.eq(sqls"name", name))
+    s.value should equal(" id = ? and ( name = ?)")
+    s.parameters should equal(Seq(123, "Alice"))
+  }
+  it should "have #and(Option[SQLSyntax])" in {
+    {
+      val (id, name) = (123, "Alice")
+      val s = SQLSyntax.eq(sqls"id", id).and(Some(SQLSyntax.eq(sqls"name", name)))
+      s.value should equal(" id = ? and ( name = ?)")
+      s.parameters should equal(Seq(123, "Alice"))
+    }
+    {
+      val id = 123
+      val s = SQLSyntax.eq(sqls"id", id).and(None)
+      s.value should equal(" id = ?")
+      s.parameters should equal(Seq(123))
+    }
   }
 
   it should "have #or" in {
@@ -325,6 +359,26 @@ class SQLSyntaxSpec extends FlatSpec with Matchers {
     val s = SQLSyntax.eq(sqls"id", id).or.eq(sqls"name", name)
     s.value should equal(" id = ? or name = ?")
     s.parameters should equal(Seq(123, "Alice"))
+  }
+  it should "have #or(SQLSyntax)" in {
+    val (id, name) = (123, "Alice")
+    val s = SQLSyntax.eq(sqls"id", id).or(SQLSyntax.eq(sqls"name", name))
+    s.value should equal(" id = ? or ( name = ?)")
+    s.parameters should equal(Seq(123, "Alice"))
+  }
+  it should "have #or(Option[SQLSyntax])" in {
+    {
+      val (id, name) = (123, "Alice")
+      val s = SQLSyntax.eq(sqls"id", id).or(Some(SQLSyntax.eq(sqls"name", name)))
+      s.value should equal(" id = ? or ( name = ?)")
+      s.parameters should equal(Seq(123, "Alice"))
+    }
+    {
+      val id = 123
+      val s = SQLSyntax.eq(sqls"id", id).or(None)
+      s.value should equal(" id = ?")
+      s.parameters should equal(Seq(123))
+    }
   }
 
   it should "have #roundBracket" in {

--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
@@ -204,15 +204,15 @@ trait QueryDSLFeature { self: SQLInterpolationFeature with SQLSyntaxSupportFeatu
       with PagingSQLBuilder[A]
       with GroupBySQLBuilder[A] {
 
-    def and: ConditionSQLBuilder[A] = ConditionSQLBuilder[A](sqls"${sql} and")
+    def and: ConditionSQLBuilder[A] = ConditionSQLBuilder[A](sql.and)
 
     // Never append 'and' if sqlPart is empty.
-    def and(sqlPart: Option[SQLSyntax]): ConditionSQLBuilder[A] = ConditionSQLBuilder[A] { sqlPart.map(part => sqls"${sql} and (${part})").getOrElse(sql) }
+    def and(sqlPart: Option[SQLSyntax]): ConditionSQLBuilder[A] = ConditionSQLBuilder[A](sql.and(sqlPart))
 
-    def or: ConditionSQLBuilder[A] = ConditionSQLBuilder[A](sqls"${sql} or")
+    def or: ConditionSQLBuilder[A] = ConditionSQLBuilder[A](sql.or)
 
     // Never append 'or' if sqlPart is empty.
-    def or(sqlPart: Option[SQLSyntax]): ConditionSQLBuilder[A] = ConditionSQLBuilder[A] { sqlPart.map(part => sqls"${sql} or (${part})").getOrElse(sql) }
+    def or(sqlPart: Option[SQLSyntax]): ConditionSQLBuilder[A] = ConditionSQLBuilder[A](sql.or(sqlPart))
 
     def not: ConditionSQLBuilder[A] = ConditionSQLBuilder[A](sqls"${sql} not")
 
@@ -454,7 +454,7 @@ trait QueryDSLFeature { self: SQLInterpolationFeature with SQLSyntaxSupportFeatu
     def where(where: SQLSyntax): ConditionSQLBuilder[A] = ConditionSQLBuilder[A](sqls"${toSQLSyntax} ${sqls.where(where)}")
 
     // Never append 'where' if whereOpt is empty.
-    def where(whereOpt: Option[SQLSyntax]): ConditionSQLBuilder[A] = whereOpt.map(w => this.where(w)).getOrElse(ConditionSQLBuilder[A](toSQLSyntax))
+    def where(whereOpt: Option[SQLSyntax]): ConditionSQLBuilder[A] = ConditionSQLBuilder[A](sqls"${toSQLSyntax} ${sqls.where(whereOpt)}")
 
     // ---
     // common functions


### PR DESCRIPTION
### Motivation

* We want to use dynamic criteria building by `sqls.toAndConditionOpt`
* We can not use QueryDSL because we need to use vendor specific syntax. so we use SQL Interpolation.
* We want to write as follows

    ```scala
sql"""
  SELECT
    snip...
  ${sqls.where(sqls.toAndConditionOpt(cond1, cond2, cond3))}
  GROU BY
    snip...
"""
```