### PR TITLE
Configurable warm up time for new connection pools

### DIFF
--- a/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfigReader.scala
+++ b/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfigReader.scala
@@ -22,7 +22,7 @@ trait TypesafeConfigReader extends NoEnvPrefix with LogSupport { self: TypesafeC
 
   private val attributeNames = Seq(
     "url", "driver", "user", "username", "password",
-    "poolInitialSize", "poolMaxSize", "poolConnectionTimeoutMillis", "connectionTimeoutMillis", "poolValidationQuery", "poolFactoryName")
+    "poolInitialSize", "poolMaxSize", "poolConnectionTimeoutMillis", "connectionTimeoutMillis", "poolValidationQuery", "poolFactoryName", "poolWarmUpTimeMillis")
 
   def readAsMap(dbName: Symbol = ConnectionPool.DEFAULT_NAME): Map[String, String] = try {
     val configMap: MutableMap[String, String] = MutableMap.empty
@@ -89,7 +89,8 @@ trait TypesafeConfigReader extends NoEnvPrefix with LogSupport { self: TypesafeC
       connectionTimeoutMillis = readTimeoutMillis().getOrElse(default.connectionTimeoutMillis),
       validationQuery = configMap.get("poolValidationQuery").getOrElse(default.validationQuery),
       connectionPoolFactoryName = configMap.get("poolFactoryName").getOrElse(default.connectionPoolFactoryName),
-      driverName = configMap.get("driver").orNull[String]
+      driverName = configMap.get("driver").orNull[String],
+      warmUpTime = configMap.get("poolWarmUpTimeMillis").map(_.toLong).getOrElse(default.warmUpTime)
     )
   }
 

--- a/scalikejdbc-config/src/test/resources/application.conf
+++ b/scalikejdbc-config/src/test/resources/application.conf
@@ -9,6 +9,7 @@ settings {
   db.default.poolConnectionTimeoutMillis=1000
   db.default.poolValidationQuery="select 1 as one"
   db.default.poolFactoryName="commons-dbcp"
+  db.default.poolWarmUpTimeMillis=10
 }
 
 db.default.migration.locations=["development.default"]
@@ -23,6 +24,7 @@ db.foo.poolMaxSize=2
 db.foo.connectionTimeoutMillis=2000 # poolConnectionTimeoutMillis is used instead
 db.foo.poolConnectionTimeoutMillis=1000
 db.foo.poolValidationQuery="select 1 as foo"
+db.foo.poolWarmUpTimeMillis=10
 
 db.bar.url="jdbc:h2:mem:test3"
 db.bar.driver="org.h2.Driver"
@@ -33,6 +35,7 @@ db.bar.poolInitialSize=2
 db.bar.poolMaxSize=3
 db.bar.connectionTimeoutMillis=1000 # deprecated setting
 db.bar.poolValidationQuery="select 1 as bar"
+db.bar.poolWarmUpTimeMillis=10
 
 db.baz.url="jdbc:h2:mem:test4"
 db.baz.driver="org.h2.Driver"

--- a/scalikejdbc-config/src/test/scala/scalikejdbc/config/TypesafeConfigReaderSpec.scala
+++ b/scalikejdbc-config/src/test/scala/scalikejdbc/config/TypesafeConfigReaderSpec.scala
@@ -79,7 +79,8 @@ class TypesafeConfigReaderSpec extends FunSpec with Matchers {
           "poolMaxSize" -> "2",
           "connectionTimeoutMillis" -> "2000",
           "poolConnectionTimeoutMillis" -> "1000",
-          "poolValidationQuery" -> "select 1 as foo"
+          "poolValidationQuery" -> "select 1 as foo",
+          "poolWarmUpTimeMillis" -> "10"
         )
         TypesafeConfigReader.readAsMap('foo) should be(expected)
       }
@@ -122,7 +123,8 @@ class TypesafeConfigReaderSpec extends FunSpec with Matchers {
           "driver" -> "org.h2.Driver",
           "url" -> "jdbc:h2:mem:dev-foo",
           "user" -> "dev-foo",
-          "password" -> "secret2"
+          "password" -> "secret2",
+          "poolWarmUpTimeMillis" -> "10"
         )
         val configReader = new TypesafeConfigReaderWithEnv("dev")
         configReader.readAsMap('foo) should be(expected)
@@ -159,17 +161,17 @@ class TypesafeConfigReaderSpec extends FunSpec with Matchers {
     describe("#readConnectionPoolSettings") {
 
       it("should read configuration and return as ConnectionPoolSettings") {
-        val expected = ConnectionPoolSettings(5, 7, 1000L, "select 1 as one", "commons-dbcp", "org.h2.Driver")
+        val expected = ConnectionPoolSettings(5, 7, 1000L, "select 1 as one", "commons-dbcp", "org.h2.Driver", 10L)
         TypesafeConfigReaderWithEnv("settings").readConnectionPoolSettings() should be(expected)
       }
 
       it("should read configuration for foo db and return as ConnectionPoolSettings") {
-        val expected = ConnectionPoolSettings(1, 2, 1000L, "select 1 as foo", null, "org.h2.Driver")
+        val expected = ConnectionPoolSettings(1, 2, 1000L, "select 1 as foo", null, "org.h2.Driver", 10L)
         TypesafeConfigReader.readConnectionPoolSettings('foo) should be(expected)
       }
 
       it("should read configuration for bar db and return as ConnectionPoolSettings") {
-        val expected = ConnectionPoolSettings(2, 3, 1000L, "select 1 as bar", null, "org.h2.Driver")
+        val expected = ConnectionPoolSettings(2, 3, 1000L, "select 1 as bar", null, "org.h2.Driver", 10L)
         TypesafeConfigReader.readConnectionPoolSettings('bar) should be(expected)
       }
 

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
@@ -97,7 +97,7 @@ object ConnectionPool extends LogSupport {
       pools.update(name, pool)
 
       // wait a little because rarely NPE occurs when immediately accessed.
-      Thread.sleep(100L)
+      Thread.sleep(settings.warmUpTime)
 
       // asynchronously close the old pool if exists
       oldPoolOpt.foreach(pool => abandonOldPool(name, pool))

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPoolSettings.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPoolSettings.scala
@@ -9,5 +9,6 @@ case class ConnectionPoolSettings(
   connectionTimeoutMillis: Long = 5000L,
   validationQuery: String = null,
   connectionPoolFactoryName: String = null,
-  driverName: String = null)
+  driverName: String = null,
+  warmUpTime: Long = 100L)
 


### PR DESCRIPTION
Following up on a [discussion on the mailing-list](https://groups.google.com/forum/#!topic/scalikejdbc-users-group/-YrtO4tz2JI) a couple of weeks back, I decided to make the time to wait after adding a connection pool to scalikejdbc configurable through a new `poolWarmUpTime`-setting in the database config.

I decided to make this setting on the connection pool level instead of in `GlobalSettings` because it might very well be something that makes sense to configure differently based on the connection pool being used.