### PR TITLE
Modify SQLSyntax.join() for performance improvement

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
@@ -224,12 +224,15 @@ object SQLSyntax {
 
   def unapply(syntax: SQLSyntax): Option[(String, Seq[Any])] = Some((syntax.value, syntax.parameters))
 
-  def join(parts: Seq[SQLSyntax], delimiter: SQLSyntax, spaceBeforeDelimier: Boolean = true): SQLSyntax = parts.foldLeft(SQLSyntax.empty) {
-    case (sql, part) if !sql.isEmpty && !part.isEmpty =>
-      if (spaceBeforeDelimier) sqls"${sql} ${delimiter} ${part}"
-      else sqls"${sql}${delimiter} ${part}"
-    case (sql, part) if sql.isEmpty && !part.isEmpty => part
-    case (sql, _) => sql
+  def join(parts: Seq[SQLSyntax], delimiter: SQLSyntax, spaceBeforeDelimier: Boolean = true): SQLSyntax = {
+    val sep = if (spaceBeforeDelimier) {
+      sqls" ${delimiter} "
+    } else {
+      sqls"${delimiter} "
+    }
+    val value = parts.map(_.value).mkString(sep)
+    val parameters = parts.flatMap(_.parameters)
+    apply(value, parameters)
   }
   def csv(parts: SQLSyntax*): SQLSyntax = join(parts, sqls",", false)
 


### PR DESCRIPTION
```scala
    val parts = (1 to 10000).map { id =>
      sqls"id=${id}"
    }
    val s = System.nanoTime()
    SQLSyntax.join(parts, sqls"and")
    println(System.nanoTime() - s)
```

* before
```
954555000
945003000
953343000
```

* after
```
6893000
5919000
6705000
```