### PR TITLE
Modify SQLSyntax.join() for retrieve delimiter's parameters

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
@@ -226,12 +226,14 @@ object SQLSyntax {
 
   def join(parts: Seq[SQLSyntax], delimiter: SQLSyntax, spaceBeforeDelimier: Boolean = true): SQLSyntax = {
     val sep = if (spaceBeforeDelimier) {
-      sqls" ${delimiter} "
+      s" ${delimiter.value} "
     } else {
-      sqls"${delimiter} "
+      s"${delimiter.value} "
     }
     val value = parts.map(_.value).mkString(sep)
-    val parameters = parts.flatMap(_.parameters)
+    val parameters = parts.tail.foldLeft(parts.headOption.fold(Seq.empty[Any])(_.parameters)) {
+      case (params, part) => params ++ delimiter.parameters ++ part.parameters
+    }
     apply(value, parameters)
   }
   def csv(parts: SQLSyntax*): SQLSyntax = join(parts, sqls",", false)

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
@@ -25,6 +25,14 @@ class SQLSyntaxSpec extends FlatSpec with Matchers {
     s.parameters should equal(Nil)
   }
 
+  it should "have #join for delimiter with parameters" in {
+    val (id1, id2, id3) = (1, 2, 3)
+    val (name1, name2) = ("Alice", "Bob")
+    val s = SQLSyntax.join(Seq(sqls"id=${id1} or", sqls"id=${id2} or", sqls"id=${id3}"), sqls"name=${name1} or name=${name2} or")
+    s.value should equal("id=? or name=? or name=? or id=? or name=? or name=? or id=?")
+    s.parameters should equal(Seq(1, "Alice", "Bob", 2, "Alice", "Bob", 3))
+  }
+
   it should "have #csv" in {
     val (id, name) = (123, "Alice")
     val s = SQLSyntax.csv(sqls"id = ${id}", sqls"name = ${name}")


### PR DESCRIPTION
fix #443 degrade.

I guess including the parameters into delimiter is not a common use case,
but the fact remains that it's degrade.

* after this modification

```scala
    val parts = (1 to 10000).map { id =>
      sqls"id=${id}"
    }
    val s = System.nanoTime()
    SQLSyntax.join(parts, sqls"and")
    println(System.nanoTime() - s)
```

```
436495000
416951000
414524000
```

:(