### PR TITLE
Modify SQLSyntax.join() for retrieve delimiter's parameters if exists

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
@@ -231,8 +231,12 @@ object SQLSyntax {
       s"${delimiter.value} "
     }
     val value = parts.map(_.value).mkString(sep)
-    val parameters = parts.tail.foldLeft(parts.headOption.fold(Seq.empty[Any])(_.parameters)) {
-      case (params, part) => params ++ delimiter.parameters ++ part.parameters
+    val parameters = if (delimiter.parameters.isEmpty) {
+      parts.flatMap(_.parameters)
+    } else {
+      parts.tail.foldLeft(parts.headOption.fold(Seq.empty[Any])(_.parameters)) {
+        case (params, part) => params ++ delimiter.parameters ++ part.parameters
+      }
     }
     apply(value, parameters)
   }


### PR DESCRIPTION
Sorry to send so many pull request at same modification...

I guess in most cases `delimiter.parameters.isEmpty` is true.