### PR TITLE
Fix run_tests.sh to create "logs" directory if it doesn't exist.

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -7,6 +7,8 @@ cd `dirname $0`
 cd ..
 cp -p scalikejdbc-core/src/test/resources/jdbc_$1.properties scalikejdbc-core/src/test/resources/jdbc.properties
 
+mkdir -p logs
+
 sbt \
   ++2.10.5 \
   clean \


### PR DESCRIPTION
If you clone the repo there is not "logs" directory. When you try to run tests
via "run_tests.sh" script it will fail becase directory is missing
This patch should fix it.