### PR TITLE
Switch the default connection pool implementation to commons-dbcp2 since 2.3

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -119,16 +119,15 @@ object ScalikeJDBCProjects extends Build {
       libraryDependencies ++= {
         Seq(
           // scope: compile
-          "commons-dbcp"            %  "commons-dbcp"    % "1.4"             % "compile",
+          "org.apache.commons"      %  "commons-dbcp2"   % "2.1.1"           % "compile",
           "org.slf4j"               %  "slf4j-api"       % _slf4jApiVersion  % "compile",
           "joda-time"               %  "joda-time"       % "2.9"             % "compile",
           "org.joda"                %  "joda-convert"    % "1.8.1"           % "compile",
           // scope: provided
-          // commons-dbcp2 will be the default CP implementation since ScalikeJDBC 2.1
-          "org.apache.commons"      %  "commons-dbcp2"   % "2.0.+"           % "provided",
+          "commons-dbcp"            %  "commons-dbcp"    % "1.4"             % "provided",
           "com.jolbox"              %  "bonecp"          % "0.8.0.RELEASE"   % "provided",
           // scope: test
-          "com.zaxxer"              %  "HikariCP"        % "1.4.+"           % "test",
+          "com.zaxxer"              %  "HikariCP"        % "2.4.2"           % "test",
           "ch.qos.logback"          %  "logback-classic" % _logbackVersion   % "test",
           "org.hibernate"           %  "hibernate-core"  % _hibernateVersion % "test",
           "org.mockito"             %  "mockito-all"     % "1.10.+"          % "test"

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
@@ -6,9 +6,9 @@ import java.sql.Connection
 /**
  * Connection Pool
  *
- * Using Commons DBCP internally.
+ * The default implementation uses Commons DBCP 2 internally.
  *
- * @see [[http://commons.apache.org/dbcp/]]
+ * @see [[https://commons.apache.org/proper/commons-dbcp/]]
  */
 object ConnectionPool extends LogSupport {
 
@@ -17,8 +17,7 @@ object ConnectionPool extends LogSupport {
   type CPFactory = ConnectionPoolFactory
 
   val DEFAULT_NAME: Symbol = 'default
-  // TODO commons-dbcp2 will be the default implementation since ScalikeJDBC 2.1
-  val DEFAULT_CONNECTION_POOL_FACTORY = CommonsConnectionPoolFactory
+  val DEFAULT_CONNECTION_POOL_FACTORY = Commons2ConnectionPoolFactory
 
   private[this] val pools = new MutableMap[Any, ConnectionPool]()
 


### PR DESCRIPTION
This pull request moves the default implementation of `ConnectionPool` from commons-dbcp to commons-dbcp2. 

This is just the default one. Choosing other cool implementations such as HikariCP by switching `ConnectionPoolFactory` are also available as the same before.

http://scalikejdbc.org/documentation/connection-pool.html#using-another-connectionpool-implementation