### PR TITLE
2.3.0 release

### DIFF
--- a/notes/2.3.0.markdown
+++ b/notes/2.3.0.markdown
@@ -1,0 +1,19 @@
+ScalikeJDBC 2.3.0 is out.
+
+Since this version, we will keep binary compatibility during 2.3.x series.
+
+When we'll bring bin-incompatible changes, they will be carried over into 2.4.x series.
+
+http://scalikejdbc.org/
+
+![ScalikeJDBC Logo](http://scalikejdbc.org/images/logo.png)
+
+### Changes
+
+ - [core] Bump minor version of libs: joda-time, slf4j-api by @seratch
+ - [core] #450 Enable specifying queryTimeout seconds for each query by @zaneli
+ - [core] #452 Add support of java.time.Instant parameters by @daring2
+ - [core] #456 Switch the default connection pool implementation to commons-dbcp2 since 2.3 by @seratch
+ - [mapper-generator-core] Remove trailing spaces from generated code by @xuwei-k
+
+Enjoy writing mostly type-safe SQL and get things done!

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,7 @@ import sbtbuildinfo.Plugin._
 
 object ScalikeJDBCProjects extends Build {
 
-  lazy val _version = "2.3.0-SNAPSHOT"
+  lazy val _version = "2.3.0"
 
   lazy val _organization = "org.scalikejdbc"
 

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -2,16 +2,34 @@ import sbt._, Keys._
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import com.typesafe.tools.mima.plugin.MimaKeys.{previousArtifact, reportBinaryIssues, binaryIssueFilters}
 
+/*
+ * MiMa settings of ScalikeJDBC libs.
+ *
+ * Since 2.3.x series, we don't exclude bin incompatibility after 2.x.0 release.
+ *
+ * see also: https://github.com/scalikejdbc/scalikejdbc/blob/master/CONTRIBUTING.md
+ */
 object MimaSettings {
 
+  // TODO: after releasing 2.3.0, the following settings must be enabled.
   val mimaSettings = Seq.empty
-  // NOTICE: Since 2.3.x series, we don't exclude bin incompatibility after 2.x.0 release.
   /*
+  // The `previousVersion` must be exactly the previous version (e.g. "2.3.1" for "2.3.2-SNAPSHOT").
+  //
+  // The following bad scenario is the reason we must obey the rule:
+  //
+  //  - your build is toward 2.3.2 release and the `previousVersion` is "2.3.0"
+  //  - you've added new methods since 2.3.1
+  //  - you're going to remove some of the methods in 2.3.2
+  //  - MiMa cannot detect such bin-incompatibility
+  //
+  val previousVersion = "2.3.0"
+
   val mimaSettings = MimaPlugin.mimaDefaultSettings ++ Seq(
     previousArtifact := {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, scalaMajor)) if scalaMajor <= 11 =>
-          Some(organization.value % s"${name.value}_${scalaBinaryVersion.value}" % "2.2.0")
+          Some(organization.value % s"${name.value}_${scalaBinaryVersion.value}" % previousVersion)
         case _ =>
           None
       }


### PR DESCRIPTION
This pull request does the following things. 2.3.0 will be out this week.

- Add 2.3.0 release note that will be published onto notes.implicit.ly
- Update MiMaSettings toward 2.3.1-SNAPSHOT development