### PR TITLE
Fix SQLSyntax.join() ignore empty part

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
@@ -230,7 +230,7 @@ object SQLSyntax {
     } else {
       s"${delimiter.value} "
     }
-    val value = parts.map(_.value).mkString(sep)
+    val value = parts.collect { case p if p.value.nonEmpty => p.value }.mkString(sep)
     val parameters = if (delimiter.parameters.isEmpty) {
       parts.flatMap(_.parameters)
     } else {

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
@@ -25,6 +25,12 @@ class SQLSyntaxSpec extends FlatSpec with Matchers {
     s.parameters should equal(Nil)
   }
 
+  it should "have #join contains empty part" in {
+    val s = SQLSyntax.join(Seq(sqls"id", sqls"", sqls"name", sqls""), sqls"and")
+    s.value should equal("id and name")
+    s.parameters should equal(Nil)
+  }
+
   it should "have #join for delimiter with parameters" in {
     val (id1, id2, id3) = (1, 2, 3)
     val (name1, name2) = ("Alice", "Bob")


### PR DESCRIPTION
degrade by #443...

```scala
joinWithAnd(sqls"aaa", sqls"bbb", sqls"")
```

* before #443 
```
SQLSyntax(value: aaa and bbb, parameters: List())
```

* after #443 
```
SQLSyntax(value: aaa and bbb and, parameters: ArrayBuffer())
```

* this PR
```
SQLSyntax(value: aaa and bbb, parameters: ArrayBuffer())
```