### PR TITLE
Fix #465 Sql.batchByName throws an exception on empty parameters list

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/SQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/SQL.scala
@@ -251,7 +251,7 @@ abstract class SQL[A, E <: WithExtractor](
    * @return SQL for batch
    */
   def batchByName(parameters: Seq[(Symbol, Any)]*): SQLBatch = {
-    val _sql = validateAndConvertToNormalStatement(statement, parameters.head)._1
+    val _sql = validateAndConvertToNormalStatement(statement, parameters.headOption.getOrElse(Seq.empty))._1
     val _parameters: Seq[Seq[Any]] = parameters.map { p =>
       validateAndConvertToNormalStatement(statement, p)._2
     }

--- a/scalikejdbc-core/src/test/scala/BasicUsageSpec.scala
+++ b/scalikejdbc-core/src/test/scala/BasicUsageSpec.scala
@@ -1,6 +1,5 @@
 import org.joda.time.DateTime
 import org.scalatest._
-import java.sql.SQLException
 import util.control.Exception._
 import java.sql.Connection
 import scalikejdbc._
@@ -356,6 +355,16 @@ class BasicUsageSpec extends FlatSpec with Matchers with LoanPattern {
         count should be > 3000L
       }
 
+    } finally { TestUtils.deleteTable(tableName) }
+  }
+
+  it should "execute batch with empty params" in {
+    val tableName = tableNamePrefix + "_batch_with_empty_params"
+    try {
+      TestUtils.initialize(tableName)
+      DB localTx { implicit session =>
+        SQL("insert into " + tableName + " (id, name) values (999, 'Alice')").batchByName(Seq.empty: _*).apply()
+      }
     } finally { TestUtils.deleteTable(tableName) }
   }
 


### PR DESCRIPTION
This pull request fixes #465 issue.