### PR TITLE
Accept java.util.Collection in SQL interpolation

### DIFF
--- a/scalikejdbc-core/src/test/scala/scalikejdbc/SQLInterpolationStringSuite.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/SQLInterpolationStringSuite.scala
@@ -1,5 +1,7 @@
 package scalikejdbc
 
+import java.{ util => ju }
+
 import org.scalatest._
 
 class SQLInterpolationStringSuite extends FlatSpec with Matchers {
@@ -13,6 +15,28 @@ class SQLInterpolationStringSuite extends FlatSpec with Matchers {
     val s1 = sqls"s in (${Set(1, 2, 3)})"
     val s2 = sqls"s in (${mutable.Set(1, 2, 3)}"
     s1.parameters should equal(s2.parameters)
+  }
+
+  it should "interpolate java.util.Set" in {
+    val set: ju.Set[Int] = new ju.HashSet()
+    set.add(1)
+    set.add(2)
+    set.add(3)
+
+    val s = sqls"s in ($set)"
+    s.value should equal("s in (?, ?, ?)")
+    s.parameters.toSet should equal(Set(1, 2, 3))
+  }
+
+  it should "interpolate java.util.List" in {
+    val list: ju.List[Int] = new ju.ArrayList()
+    list.add(1)
+    list.add(2)
+    list.add(3)
+
+    val s = sqls"s in ($list)"
+    s.value should equal("s in (?, ?, ?)")
+    s.parameters should equal(List(1, 2, 3))
   }
 
   it should "strip margin by stripMargin" in {


### PR DESCRIPTION
Fixes #469 

This PR changed to converts all Traversable and java.util.Collection to immutable List before building query and params.