### PR TITLE
Fix #461 java.sql.SQLException: Cannot get a connection, pool error Unable to validate object

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/Commons2ConnectionPool.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/Commons2ConnectionPool.scala
@@ -32,7 +32,12 @@ class Commons2ConnectionPool(
   _pool.setBlockWhenExhausted(true)
   _pool.setMaxTotal(settings.maxSize)
   _pool.setMaxWaitMillis(settings.connectionTimeoutMillis)
-  _pool.setTestOnBorrow(true)
+
+  // To fix MS SQLServer jtds driver issue
+  // https://github.com/scalikejdbc/scalikejdbc/issues/461
+  if (Option(settings.validationQuery).exists(_.trim.isEmpty == false)) {
+    _pool.setTestOnBorrow(true)
+  }
 
   private[this] val _dataSource: DataSource = new PoolingDataSource(_pool)
 


### PR DESCRIPTION
commons-dbcp2 and jtds JDBC driver have bad chemistry. Although MS SQLServer is not officially supported, the blocking issue #461 should be fixed.