### PR TITLE
add time zone configuration

### DIFF
--- a/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfigReader.scala
+++ b/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfigReader.scala
@@ -95,25 +95,29 @@ trait TypesafeConfigReader extends NoEnvPrefix with LogSupport { self: TypesafeC
   }
 
   def loadGlobalSettings(): Unit = {
-    for {
-      globalConfig <- readConfig(config, envPrefix + "scalikejdbc.global")
-      logConfig <- readConfig(globalConfig, "loggingSQLAndTime")
-    } {
-      val enabled = readBoolean(logConfig, "enabled").getOrElse(false)
-      if (enabled) {
-        val default = LoggingSQLAndTimeSettings()
-        GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
-          enabled = enabled,
-          singleLineMode = readBoolean(logConfig, "singleLineMode").getOrElse(default.singleLineMode),
-          printUnprocessedStackTrace = readBoolean(logConfig, "printUnprocessedStackTrace").getOrElse(default.printUnprocessedStackTrace),
-          stackTraceDepth = readInt(logConfig, "stackTraceDepth").getOrElse(default.stackTraceDepth),
-          logLevel = readString(logConfig, "logLevel").map(v => Symbol(v)).getOrElse(default.logLevel),
-          warningEnabled = readBoolean(logConfig, "warningEnabled").getOrElse(default.warningEnabled),
-          warningThresholdMillis = readLong(logConfig, "warningThresholdMillis").getOrElse(default.warningThresholdMillis),
-          warningLogLevel = readString(logConfig, "warningLogLevel").map(v => Symbol(v)).getOrElse(default.warningLogLevel)
-        )
-      } else {
-        GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(enabled = false)
+    readConfig(config, envPrefix + "scalikejdbc.global").foreach { globalConfig =>
+      readConfig(globalConfig, "loggingSQLAndTime").foreach { logConfig =>
+        val enabled = readBoolean(logConfig, "enabled").getOrElse(false)
+        if (enabled) {
+          val default = LoggingSQLAndTimeSettings()
+          GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
+            enabled = enabled,
+            singleLineMode = readBoolean(logConfig, "singleLineMode").getOrElse(default.singleLineMode),
+            printUnprocessedStackTrace = readBoolean(logConfig, "printUnprocessedStackTrace").getOrElse(default.printUnprocessedStackTrace),
+            stackTraceDepth = readInt(logConfig, "stackTraceDepth").getOrElse(default.stackTraceDepth),
+            logLevel = readString(logConfig, "logLevel").map(v => Symbol(v)).getOrElse(default.logLevel),
+            warningEnabled = readBoolean(logConfig, "warningEnabled").getOrElse(default.warningEnabled),
+            warningThresholdMillis = readLong(logConfig, "warningThresholdMillis").getOrElse(default.warningThresholdMillis),
+            warningLogLevel = readString(logConfig, "warningLogLevel").map(v => Symbol(v)).getOrElse(default.warningLogLevel)
+          )
+        } else {
+          GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(enabled = false)
+        }
+      }
+
+      readString(globalConfig, "serverTimeZone") match {
+        case Some(timeZoneID) => GlobalSettings.serverTimeZone = Some(java.util.TimeZone.getTimeZone(timeZoneID))
+        case _ => GlobalSettings.serverTimeZone = None
       }
     }
   }

--- a/scalikejdbc-config/src/test/resources/application-server-time-zone-specified.conf
+++ b/scalikejdbc-config/src/test/resources/application-server-time-zone-specified.conf
@@ -1,0 +1,1 @@
+scalikejdbc.global.serverTimeZone=AST

--- a/scalikejdbc-config/src/test/scala/scalikejdbc/config/TypesafeConfigReaderSpec.scala
+++ b/scalikejdbc-config/src/test/scala/scalikejdbc/config/TypesafeConfigReaderSpec.scala
@@ -22,6 +22,10 @@ class TypesafeConfigReaderSpec extends FunSpec with Matchers {
     override lazy val config: Config = ConfigFactory.load("application-bad-logenabled.conf")
   }
 
+  val configReaderServerTimeZoneSpecified = new TypesafeConfigReader with TypesafeConfig {
+    override lazy val config: Config = ConfigFactory.load("application-server-time-zone-specified.conf")
+  }
+
   describe("TypesafeConfigReader") {
 
     describe("#readJDBCSettings") {
@@ -189,6 +193,11 @@ class TypesafeConfigReaderSpec extends FunSpec with Matchers {
 
       it("should load global settings") {
         TypesafeConfigReader.loadGlobalSettings()
+      }
+
+      it("should load serverTimeZone") {
+        configReaderServerTimeZoneSpecified.loadGlobalSettings()
+        GlobalSettings.serverTimeZone.get.getID should equal("AST")
       }
 
       describe("When the format of config file is bad") {

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/GlobalSettings.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/GlobalSettings.scala
@@ -59,4 +59,9 @@ object GlobalSettings {
     (statement: String, params: Seq[Any], e: Throwable, tags: Seq[String]) => ()
   }
 
+  /**
+   * Specifies server timeZone used in binding/extracting time related values.
+   */
+  var serverTimeZone: Option[java.util.TimeZone] = None
+
 }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
@@ -36,9 +36,13 @@ case class StatementExecutor(
   isBatch: Boolean = false)
     extends LogSupport with UnixTimeInMillisConverterImplicits {
 
+  import java.util.TimeZone
   import StatementExecutor._
+  import GlobalSettings.serverTimeZone
 
   private[this] lazy val batchParamsList = new MutableList[Seq[Any]]
+  private[this] lazy val timeZoneConverter =
+    TimeZoneConverter.from(TimeZone.getDefault).to(serverTimeZone.getOrElse(TimeZone.getDefault))
 
   initialize()
 
@@ -62,6 +66,8 @@ case class StatementExecutor(
       case other => other
     }.zipWithIndex
 
+    val timeZoneEnabled = serverTimeZone.isDefined
+
     for ((param, idx) <- paramsWithIndices; i = idx + 1) {
       param match {
         case null => underlying.setObject(i, null)
@@ -70,7 +76,7 @@ case class StatementExecutor(
         case p: BigDecimal => underlying.setBigDecimal(i, p.bigDecimal)
         case p: Boolean => underlying.setBoolean(i, p)
         case p: Byte => underlying.setByte(i, p)
-        case p: java.sql.Date => underlying.setDate(i, p)
+        case p: java.sql.Date => underlying.setDate(i, if (timeZoneEnabled) timeZoneConverter.convert(p) else p)
         case p: Double => underlying.setDouble(i, p)
         case p: Float => underlying.setFloat(i, p)
         case p: Int => underlying.setInt(i, p)
@@ -78,14 +84,20 @@ case class StatementExecutor(
         case p: Short => underlying.setShort(i, p)
         case p: java.sql.SQLXML => underlying.setSQLXML(i, p)
         case p: String => underlying.setString(i, p)
-        case p: java.sql.Time => underlying.setTime(i, p)
-        case p: java.sql.Timestamp => underlying.setTimestamp(i, p)
+        case p: java.sql.Time => underlying.setTime(i, if (timeZoneEnabled) timeZoneConverter.convert(p) else p)
+        case p: java.sql.Timestamp => underlying.setTimestamp(i, if (timeZoneEnabled) timeZoneConverter.convert(p) else p)
         case p: java.net.URL => underlying.setURL(i, p)
-        case p: java.util.Date => underlying.setTimestamp(i, p.toSqlTimestamp)
-        case p: org.joda.time.DateTime => underlying.setTimestamp(i, p.toDate.toSqlTimestamp)
-        case p: org.joda.time.LocalDateTime => underlying.setTimestamp(i, p.toDate.toSqlTimestamp)
-        case p: org.joda.time.LocalDate => underlying.setDate(i, p.toDate.toSqlDate)
-        case p: org.joda.time.LocalTime => underlying.setTime(i, p.toSqlTime)
+        case p: java.util.Date => underlying.setTimestamp(i, if (timeZoneEnabled) timeZoneConverter.convert(p.toSqlTimestamp) else p.toSqlTimestamp)
+        case p: org.joda.time.DateTime =>
+          val timestamp = p.toDate.toSqlTimestamp
+          underlying.setTimestamp(i, if (timeZoneEnabled) timeZoneConverter.convert(timestamp) else timestamp)
+        case p: org.joda.time.LocalDateTime =>
+          val timestamp = p.toDate.toSqlTimestamp
+          underlying.setTimestamp(i, if (timeZoneEnabled) timeZoneConverter.convert(timestamp) else timestamp)
+        case p: org.joda.time.LocalDate =>
+          val date = p.toDate.toSqlDate
+          underlying.setDate(i, if (timeZoneEnabled) timeZoneConverter.convert(date) else date)
+        case p: org.joda.time.LocalTime => underlying.setTime(i, if (timeZoneEnabled) timeZoneConverter.convert(p.toSqlTime) else p.toSqlTime)
         case p if param.getClass.getCanonicalName.startsWith("java.time.") => {
           // Accessing JSR-310 APIs via Java reflection
           // because scalikejdbc-core should work on not only Java 8 but 6 & 7.
@@ -98,16 +110,21 @@ case class StatementExecutor(
               val dateClazz: Class[_] = Class.forName("java.util.Date") // java.util.Date
               val fromMethod: Method = dateClazz.getMethod("from", Class.forName("java.time.Instant"))
               val dateValue = fromMethod.invoke(null, instant).asInstanceOf[java.util.Date]
-              underlying.setTimestamp(i, dateValue.toSqlTimestamp)
+              val timestamp = dateValue.toSqlTimestamp
+              underlying.setTimestamp(i, if (timeZoneEnabled) timeZoneConverter.convert(timestamp) else timestamp)
             case "java.time.Instant" =>
               val millis = clazz.getMethod("toEpochMilli").invoke(p).asInstanceOf[java.lang.Long]
-              underlying.setTimestamp(i, new java.util.Date(millis).toSqlTimestamp)
+              val timestamp = new java.util.Date(millis).toSqlTimestamp
+              underlying.setTimestamp(i, if (timeZoneEnabled) timeZoneConverter.convert(timestamp) else timestamp)
             case "java.time.LocalDateTime" =>
-              underlying.setTimestamp(i, org.joda.time.LocalDateTime.parse(p.toString).toDate.toSqlTimestamp)
+              val timestamp = org.joda.time.LocalDateTime.parse(p.toString).toDate.toSqlTimestamp
+              underlying.setTimestamp(i, if (timeZoneEnabled) timeZoneConverter.convert(timestamp) else timestamp)
             case "java.time.LocalDate" =>
-              underlying.setDate(i, org.joda.time.LocalDate.parse(p.toString).toDate.toSqlDate)
+              val date = org.joda.time.LocalDate.parse(p.toString).toDate.toSqlDate
+              underlying.setDate(i, if (timeZoneEnabled) timeZoneConverter.convert(date) else date)
             case "java.time.LocalTime" =>
-              underlying.setTime(i, org.joda.time.LocalTime.parse(p.toString).toSqlTime)
+              val time = org.joda.time.LocalTime.parse(p.toString).toSqlTime
+              underlying.setTime(i, if (timeZoneEnabled) timeZoneConverter.convert(time) else time)
           }
         }
         case p: java.io.InputStream => underlying.setBinaryStream(i, p)

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/TimeZoneConverter.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/TimeZoneConverter.scala
@@ -1,0 +1,56 @@
+package scalikejdbc
+
+import java.sql.{ Time, Date, Timestamp }
+import java.util.{ Calendar, TimeZone }
+
+import scala.collection.concurrent.TrieMap
+
+/**
+ * TimeZone converter for time related types.
+ */
+class TimeZoneConverter(fromTimeZone: TimeZone, toTimeZone: TimeZone) {
+  def convert(date: Date): Date =
+    if (date != null) new Date(convertMillis(date)) else null
+
+  def convert(time: Time): Time =
+    if (time != null) new Time(convertMillis(time)) else null
+
+  def convert(timestamp: Timestamp): Timestamp =
+    if (timestamp != null) new Timestamp(convertMillis(timestamp)) else null
+
+  private[this] def convertMillis(utilDate: java.util.Date): Long = {
+    val fromCal = Calendar.getInstance(fromTimeZone)
+    fromCal.setTime(utilDate)
+    val fromOffset = fromCal.get(Calendar.ZONE_OFFSET) + fromCal.get(Calendar.DST_OFFSET)
+
+    val toCal = Calendar.getInstance(toTimeZone)
+    toCal.setTime(utilDate)
+    val toOffset = toCal.get(Calendar.ZONE_OFFSET) + toCal.get(Calendar.DST_OFFSET)
+
+    val delta = toOffset - fromOffset
+
+    utilDate.getTime + delta
+  }
+}
+
+object TimeZoneConverter {
+  class TimeZoneConverterBuilder(fromTimeZone: TimeZone) {
+    private[this] val converterCache: TrieMap[TimeZone, TimeZoneConverter] = TrieMap.empty
+
+    def to(toTimeZone: TimeZone): TimeZoneConverter =
+      converterCache.getOrElse(toTimeZone, {
+        val converter = new TimeZoneConverter(fromTimeZone, toTimeZone)
+        converterCache(toTimeZone) = converter
+        converter
+      })
+  }
+
+  private[this] val builderCache: TrieMap[TimeZone, TimeZoneConverterBuilder] = TrieMap.empty
+
+  def from(timeZone: TimeZone): TimeZoneConverterBuilder =
+    builderCache.getOrElse(timeZone, {
+      val builder = new TimeZoneConverterBuilder(timeZone)
+      builderCache(timeZone) = builder
+      builder
+    })
+}

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/GlobalSettingsSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/GlobalSettingsSpec.scala
@@ -220,4 +220,53 @@ class GlobalSettingsSpec extends FlatSpec with Matchers with Settings with LogSu
     }
   }
 
+  it should "configure timeZone" in {
+    import java.util.TimeZone
+    import org.joda.time.DateTimeZone
+
+    DB autoCommit { implicit session =>
+      try {
+        try SQL("drop table zone_test").execute.apply()
+        catch { case e: Exception => }
+
+        SQL("create table zone_test (id int primary key, t timestamp)").execute.apply()
+        val time = new DateTime(2016, 1, 9, 2, 43, 42)
+
+        val castToString: String = if (driverClassName.contains("mysql")) {
+          "date_format(t, '%Y-%m-%d %H:%i:%S')"
+        } else {
+          "to_char(t, 'YYYY-MM-DD HH24:MI:SS')"
+        }
+
+        /**
+         * configure server timeZone to Asia/Tokyo
+         */
+        GlobalSettings.serverTimeZone = Some(TimeZone.getTimeZone("Asia/Tokyo"))
+
+        SQL("insert into zone_test values (?, ?)").bind(1, time).execute.apply()
+        val jstString = SQL(s"select $castToString as s from zone_test where id = 1").map(_.string("s")).single.apply().get
+        jstString should equal(time.withZone(DateTimeZone.forID("Asia/Tokyo")).toString("yyyy-MM-dd hh:mm:ss"))
+
+        val expectedTime1 = SQL("select t from zone_test where id = 1").map(_.jodaDateTime("t")).single.apply().get
+        expectedTime1.isEqual(time) should equal(true)
+
+        /**
+         * configure server timeZone to UTC
+         */
+        GlobalSettings.serverTimeZone = Some(TimeZone.getTimeZone("UTC"))
+
+        SQL("insert into zone_test values (?, ?)").bind(2, time).execute.apply()
+        val utcString = SQL(s"select $castToString as s from zone_test where id = 2").map(_.string("s")).single.apply().get
+        utcString should equal(time.withZone(DateTimeZone.forID("UTC")).toString("yyyy-MM-dd HH:mm:ss"))
+
+        val expectedTime2 = SQL("select t from zone_test where id = 2").map(_.jodaDateTime("t")).single.apply().get
+        expectedTime2.isEqual(time) should equal(true)
+
+      } finally {
+        GlobalSettings.serverTimeZone = None
+        try SQL("drop table zone_test").execute.apply()
+        catch { case e: Exception => }
+      }
+    }
+  }
 }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/TimeZoneConverterSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/TimeZoneConverterSpec.scala
@@ -1,0 +1,71 @@
+package scalikejdbc
+
+import java.util.TimeZone
+
+import org.joda.time.DateTime
+import org.scalatest.{ FlatSpec, Matchers }
+
+class TimeZoneConverterSpec extends FlatSpec with Matchers {
+
+  behavior of "TimeZoneConverter"
+
+  val jst = TimeZone.getTimeZone("Asia/Tokyo") // UTC+9
+  val ast = TimeZone.getTimeZone("AST") // UTC-9 with DST
+  val converter = TimeZoneConverter.from(jst).to(ast)
+
+  val date = new DateTime(2016, 1, 3, 12, 0).toDate.getTime
+  val dstDate = new DateTime(2016, 7, 3, 12, 0).toDate.getTime
+
+  val jstOffset = jst.getOffset(date)
+  val astOffset = ast.getOffset(date)
+  val astOffsetWithDst = ast.getOffset(dstDate)
+
+  it should "convert timeZone of java.sql.Timestamp" in {
+    val sqlTimestamp = new java.sql.Timestamp(date)
+    val convertedTimestamp = converter.convert(sqlTimestamp)
+
+    (sqlTimestamp.getTime - convertedTimestamp.getTime) should equal(jstOffset - astOffset)
+  }
+
+  it should "convert timeZone of java.sql.Timestamp with DST" in {
+    val sqlTimestamp = new java.sql.Timestamp(dstDate)
+    val convertedTimestamp = converter.convert(sqlTimestamp)
+
+    (sqlTimestamp.getTime - convertedTimestamp.getTime) should equal(jstOffset - astOffsetWithDst)
+  }
+
+  it should "convert timeZone of java.sql.Time" in {
+    val sqlTime = new java.sql.Time(date)
+    val convertedTime = converter.convert(sqlTime)
+
+    (sqlTime.getTime - convertedTime.getTime) should equal(jstOffset - astOffset)
+  }
+
+  it should "convert timeZone of java.sql.Time with DST" in {
+    val sqlTime = new java.sql.Time(dstDate)
+    val convertedTime = converter.convert(sqlTime)
+
+    (sqlTime.getTime - convertedTime.getTime) should equal(jstOffset - astOffsetWithDst)
+  }
+
+  it should "convert timeZone of java.sql.Date" in {
+    val sqlDate = new java.sql.Date(date)
+    val convertedDate = converter.convert(sqlDate)
+
+    (sqlDate.getTime - convertedDate.getTime) should equal(jstOffset - astOffset)
+  }
+
+  it should "convert timeZone of java.sql.Date with DST" in {
+    val sqlDate = new java.sql.Date(dstDate)
+    val convertedDate = converter.convert(sqlDate)
+
+    (sqlDate.getTime - convertedDate.getTime) should equal(jstOffset - astOffsetWithDst)
+  }
+
+  it should "cache converter for same [from/to]" in {
+    val converter1 = TimeZoneConverter.from(jst).to(ast)
+    val converter2 = TimeZoneConverter.from(jst).to(ast)
+
+    converter1 should be theSameInstanceAs converter2
+  }
+}


### PR DESCRIPTION
Add time zone conversion settings.
This feature can be used as follows.

```
scalikejdbc.global.serverTimeZone=UTC
```

Then time zone will be converted when binding/extracting time related columns. (e.g. java.sql.Date, java.sql.Time, java.sql.Timestamp)

This PR solves #424 .