### PR TITLE
Fix #494 Allow driver absence when using scalikejdbc-config

### DIFF
--- a/scalikejdbc-config/src/main/scala/scalikejdbc/config/DBs.scala
+++ b/scalikejdbc-config/src/main/scala/scalikejdbc/config/DBs.scala
@@ -10,7 +10,9 @@ trait DBs { self: TypesafeConfigReader with TypesafeConfig with EnvPrefix =>
   def setup(dbName: Symbol = ConnectionPool.DEFAULT_NAME): Unit = {
     val JDBCSettings(url, user, password, driver) = readJDBCSettings(dbName)
     val cpSettings = readConnectionPoolSettings(dbName)
-    Class.forName(driver)
+    if (driver != null && driver.trim.nonEmpty) {
+      Class.forName(driver)
+    }
     ConnectionPool.add(dbName, url, user, password, cpSettings)
   }
 

--- a/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfigReader.scala
+++ b/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfigReader.scala
@@ -59,8 +59,10 @@ trait TypesafeConfigReader extends NoEnvPrefix with LogSupport { self: TypesafeC
 
   def readJDBCSettings(dbName: Symbol = ConnectionPool.DEFAULT_NAME): JDBCSettings = {
     val configMap = self.readAsMap(dbName)
+    // https://github.com/scalikejdbc/scalikejdbc/issues/494#issuecomment-184015480
+    // never forcing scalikejdbc-config users to load JDBC drivers in global
+    val driver = configMap.getOrElse("driver", "")
     (for {
-      driver <- configMap.get("driver")
       url <- configMap.get("url")
     } yield {
       val user = configMap.get("user").orElse(configMap.get("username")).orNull[String]

--- a/scalikejdbc-config/src/test/resources/application-no-driver.conf
+++ b/scalikejdbc-config/src/test/resources/application-no-driver.conf
@@ -1,0 +1,8 @@
+db.default.url="jdbc:h2:mem:test123"
+db.default.user="sa"
+db.default.password="secret"
+
+db.foo.driver=""
+db.foo.url="jdbc:h2:mem:test234"
+db.foo.user="user"
+db.foo.password="pass"

--- a/scalikejdbc-config/src/test/resources/application.conf
+++ b/scalikejdbc-config/src/test/resources/application.conf
@@ -41,6 +41,20 @@ db.bar.poolWarmUpTimeMillis=10
 db.baz.url="jdbc:h2:mem:test4"
 db.baz.driver="org.h2.Driver"
 
+db {
+  nodriver1 {
+    url="jdbc:h2:mem:hocon"
+    user="user"
+    password="pass"
+  }
+  nodriver2 {
+    driver=""
+    url="jdbc:h2:mem:hocon"
+    user="user"
+    password="pass"
+  }
+}
+
 scalikejdbc.global.loggingSQLAndTime.enabled=true
 scalikejdbc.global.loggingSQLAndTime.singleLineMode=false
 scalikejdbc.global.loggingSQLAndTime.printUnprocessedStackTrace=false

--- a/scalikejdbc-config/src/test/scala/scalikejdbc/config/TypesafeConfigReaderSpec.scala
+++ b/scalikejdbc-config/src/test/scala/scalikejdbc/config/TypesafeConfigReaderSpec.scala
@@ -22,6 +22,10 @@ class TypesafeConfigReaderSpec extends FunSpec with Matchers {
     override lazy val config: Config = ConfigFactory.load("application-bad-logenabled.conf")
   }
 
+  val noDriverConfigReader = new TypesafeConfigReader with TypesafeConfig {
+    override lazy val config: Config = ConfigFactory.load("application-no-driver.conf")
+  }
+
   describe("TypesafeConfigReader") {
 
     describe("#readJDBCSettings") {
@@ -55,6 +59,18 @@ class TypesafeConfigReaderSpec extends FunSpec with Matchers {
           intercept[ConfigurationException] {
             emptyConfigReader.readJDBCSettings('foo) should be(None)
           }
+        }
+      }
+
+      describe("When configuration file doesn't have driver configuration") {
+        it("should return default JDBCSettings") {
+          val expected = JDBCSettings("jdbc:h2:mem:test123", "sa", "secret", "")
+          noDriverConfigReader.readJDBCSettings() should be(expected)
+        }
+
+        it("should return foo JDBCSettings") {
+          val expected = JDBCSettings("jdbc:h2:mem:test234", "user", "pass", "")
+          noDriverConfigReader.readJDBCSettings('foo) should be(expected)
         }
       }
 
@@ -156,7 +172,7 @@ class TypesafeConfigReaderSpec extends FunSpec with Matchers {
     }
 
     it("should get db names") {
-      val expected = List("default", "foo", "bar", "baz", "topLevelDefaults").sorted
+      val expected = List("bar", "baz", "default", "foo", "nodriver1", "nodriver2", "topLevelDefaults").sorted
       TypesafeConfigReader.dbNames.sorted should be(expected)
     }
 


### PR DESCRIPTION
refs #494