### PR TITLE
Add a special ParameterBinder to allow bypassing ParameterBinderFactory

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
@@ -2,8 +2,10 @@ package scalikejdbc
 
 import java.sql.PreparedStatement
 
+import scalikejdbc.interpolation.SQLSyntax
+
 /**
- * EssentialParameterBinder which enables customizing StatementExecutor#binParams.
+ * Enables customizing StatementExecutor#bindParams behavior.
  *
  * {{{
  * val bytes = Array[Byte](1,2,3, ...)
@@ -23,18 +25,73 @@ trait ParameterBinder { self =>
   def apply(stmt: PreparedStatement, idx: Int): Unit
 
 }
+
+/**
+ * ParameterBinder which holds a value to bind.
+ * @tparam A value's type
+ */
 trait ParameterBinderWithValue[A] extends ParameterBinder { self =>
 
   def value: A
 
-  // [[scalikejdbc.ParameterBinder#map]] breaks the Functor-law
+  // keep this API private because [[scalikejdbc.ParameterBinder#map]] breaks the Functor-law
   private[scalikejdbc] def map[B](f: A => B): ParameterBinderWithValue[B] = new ParameterBinderWithValue[B] {
     lazy val value: B = f(self.value)
     def apply(stmt: PreparedStatement, idx: Int): Unit = self(stmt, idx)
   }
 
-  override def toString: String = s"ParameterBinder(value=$value)"
+  override def toString: String = s"ParameterBinderWithValue(value=$value)"
 
+}
+
+object ParameterBinderWithValue {
+
+  def extract(maybeBinder: Any): Any = maybeBinder match {
+    case null => null
+    case None => null
+    case Some(v) => extract(v)
+    case AsIsParameterBinder(value) => extract(value)
+    case binder: ParameterBinderWithValue[_] => extract(binder.value)
+    case value => value
+  }
+}
+
+/**
+ * ParameterBinder which holds SQLSyntax.
+ */
+case class SQLSyntaxParameterBinder(syntax: SQLSyntax)
+    extends ParameterBinderWithValue[SQLSyntax] {
+
+  val value = syntax
+
+  def apply(stmt: PreparedStatement, idx: Int): Unit = ()
+}
+
+/**
+ * Type unsafe ParameterBinder which holds any value and bind it as-is.
+ */
+class AsIsParameterBinder(private val underlying: Any)
+    extends ParameterBinderWithValue[Any] {
+
+  override val value: Any = ParameterBinderWithValue.extract(underlying)
+
+  def apply(stmt: PreparedStatement, idx: Int): Unit = ()
+
+  override def toString: String = s"AsIsParameterBinder(value=$value)"
+
+}
+
+object AsIsParameterBinder {
+
+  def apply(value: Any): ParameterBinder = {
+    new AsIsParameterBinder(ParameterBinderWithValue.extract(value))
+  }
+
+  def unapply(a: Any): Option[Any] = {
+    PartialFunction.condOpt(a) {
+      case x: AsIsParameterBinder => ParameterBinderWithValue.extract(x.value)
+    }
+  }
 }
 
 /**
@@ -55,7 +112,7 @@ object ParameterBinder {
 
   def unapply(a: Any): Option[Any] = {
     PartialFunction.condOpt(a) {
-      case x: ParameterBinderWithValue[_] => x.value
+      case x: ParameterBinderWithValue[_] => ParameterBinderWithValue.extract(x.value)
     }
   }
 
@@ -66,4 +123,3 @@ object ParameterBinder {
   }
 
 }
-

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
@@ -4,6 +4,8 @@ import java.sql.PreparedStatement
 
 import scalikejdbc.interpolation.SQLSyntax
 
+// ------------------------------------------------------------------------------
+
 /**
  * Enables customizing StatementExecutor#bindParams behavior.
  *
@@ -20,93 +22,15 @@ import scalikejdbc.interpolation.SQLSyntax
 trait ParameterBinder { self =>
 
   /**
-   * Returns true if this binder has value
+   * Returns true if this binder is the bypass one.
    */
-  def asIs: Boolean = false
+  def bypass: Boolean = false
 
   /**
    * Applies parameter to PreparedStatement.
    */
   def apply(stmt: PreparedStatement, idx: Int): Unit
 
-}
-
-/**
- * ParameterBinder which holds a value to bind.
- *
- * @tparam A value's type
- */
-trait ParameterBinderWithValue[A] extends ParameterBinder { self =>
-
-  override lazy val asIs: Boolean = value match {
-    case binder: ParameterBinder => binder.asIs
-    case _ => false
-  }
-
-  def value: A
-
-  // keep this API private because [[scalikejdbc.ParameterBinder#map]] breaks the Functor-law
-  private[scalikejdbc] def map[B](f: A => B): ParameterBinderWithValue[B] = new ParameterBinderWithValue[B] {
-    lazy val value: B = f(self.value)
-    def apply(stmt: PreparedStatement, idx: Int): Unit = self(stmt, idx)
-  }
-
-  override def toString: String = s"ParameterBinderWithValue(value=$value, asIs=$asIs)"
-
-}
-
-object ParameterBinderWithValue {
-
-  def extract(maybeBinder: Any): Any = maybeBinder match {
-    case null => null
-    case None => null
-    case Some(v) => extract(v)
-    case AsIsParameterBinder(value) => extract(value)
-    case binder: ParameterBinderWithValue[_] => extract(binder.value)
-    case value => value
-  }
-}
-
-/**
- * ParameterBinder which holds SQLSyntax.
- */
-case class SQLSyntaxParameterBinder(syntax: SQLSyntax)
-    extends ParameterBinderWithValue[SQLSyntax] {
-
-  val value = syntax
-
-  def apply(stmt: PreparedStatement, idx: Int): Unit = ()
-}
-
-/**
- * Type unsafe ParameterBinder which holds any value and bind it as-is.
- */
-class AsIsParameterBinder(private val underlying: Any)
-    extends ParameterBinderWithValue[Any] {
-
-  override lazy val asIs: Boolean = true
-
-  override val value: Any = ParameterBinderWithValue.extract(underlying)
-
-  def apply(stmt: PreparedStatement, idx: Int): Unit = {
-    throw new IllegalStateException("Ths method should not be called")
-  }
-
-  override def toString: String = s"AsIsParameterBinder(value=$value)"
-
-}
-
-object AsIsParameterBinder {
-
-  def apply(value: Any): ParameterBinder = {
-    new AsIsParameterBinder(ParameterBinderWithValue.extract(value))
-  }
-
-  def unapply(a: Any): Option[Any] = {
-    PartialFunction.condOpt(a) {
-      case x: AsIsParameterBinder => ParameterBinderWithValue.extract(x.value)
-    }
-  }
 }
 
 /**
@@ -127,7 +51,7 @@ object ParameterBinder {
 
   def unapply(a: Any): Option[Any] = {
     PartialFunction.condOpt(a) {
-      case x: ParameterBinderWithValue[_] => ParameterBinderWithValue.extract(x.value)
+      case x: ParameterBinderWithValue[_] => BypassParameterBinder.extractValue(x.value)
     }
   }
 
@@ -137,4 +61,84 @@ object ParameterBinder {
     override def toString: String = s"ParameterBinder(value=NULL)"
   }
 
+}
+
+// ------------------------------------------------------------------------------
+
+/**
+ * ParameterBinder which holds a value to bind.
+ *
+ * @tparam A value's type
+ */
+trait ParameterBinderWithValue[A] extends ParameterBinder { self =>
+
+  override lazy val bypass: Boolean = value match {
+    case binder: ParameterBinder => binder.bypass
+    case _ => false
+  }
+
+  def value: A
+
+  // keep this API private because [[scalikejdbc.ParameterBinder#map]] breaks the Functor-law
+  private[scalikejdbc] def map[B](f: A => B): ParameterBinderWithValue[B] = new ParameterBinderWithValue[B] {
+    lazy val value: B = f(self.value)
+    def apply(stmt: PreparedStatement, idx: Int): Unit = self(stmt, idx)
+  }
+
+  override def toString: String = s"ParameterBinderWithValue(value=$value, asIs=$bypass)"
+
+}
+
+// ------------------------------------------------------------------------------
+
+/**
+ * ParameterBinder which holds SQLSyntax.
+ */
+case class SQLSyntaxParameterBinder(syntax: SQLSyntax)
+    extends ParameterBinderWithValue[SQLSyntax] {
+
+  val value = syntax
+
+  def apply(stmt: PreparedStatement, idx: Int): Unit = ()
+}
+
+// ------------------------------------------------------------------------------
+
+/**
+ * Type unsafe ParameterBinder which holds any value and bind it as-is.
+ */
+class BypassParameterBinder(private val underlying: Any)
+    extends ParameterBinderWithValue[Any] {
+
+  override lazy val bypass: Boolean = true
+
+  override val value: Any = BypassParameterBinder.extractValue(underlying)
+
+  def apply(stmt: PreparedStatement, idx: Int): Unit = {
+    throw new IllegalStateException("Ths method should not be called")
+  }
+
+  override def toString: String = s"BypassParameterBinder(value=$value)"
+
+}
+
+object BypassParameterBinder {
+
+  def apply(value: Any): ParameterBinder = {
+    new BypassParameterBinder(extractValue(value))
+  }
+
+  def unapply(a: Any): Option[Any] = {
+    PartialFunction.condOpt(a) {
+      case x: BypassParameterBinder => extractValue(x.value)
+    }
+  }
+
+  def extractValue(maybeBinder: Any): Any = maybeBinder match {
+    case null | None => null
+    case Some(v) => extractValue(v)
+    case BypassParameterBinder(value) => extractValue(value)
+    case binder: ParameterBinderWithValue[_] => extractValue(binder.value)
+    case value => value
+  }
 }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/SQLInterpolationString.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/SQLInterpolationString.scala
@@ -38,11 +38,14 @@ class SQLInterpolationString(val s: StringContext) extends AnyVal {
 
   private def addPlaceholders(sb: StringBuilder, param: Any): StringBuilder = param match {
     case _: String => sb += '?'
-    case t: Traversable[_] => t.map {
-      case SQLSyntax(s, _) => s
-      case SQLSyntaxParameterBinder(SQLSyntax(s, _)) => s
-      case _ => "?"
-    }.addString(sb, ", ") // e.g. in clause
+    case t: Traversable[_] => {
+      // e.g. in clause
+      t.map {
+        case SQLSyntax(s, _) => s
+        case SQLSyntaxParameterBinder(SQLSyntax(s, _)) => s
+        case _ => "?"
+      }.addString(sb, ", ")
+    }
     case LastParameter => sb
     case SQLSyntax(s, _) => sb ++= s
     case SQLSyntaxParameterBinder(SQLSyntax(s, _)) => sb ++= s
@@ -50,15 +53,17 @@ class SQLInterpolationString(val s: StringContext) extends AnyVal {
   }
 
   private def buildParams(params: Seq[Any]): Seq[Any] = params.foldLeft(Seq.newBuilder[Any]) {
-    case (b, s: String) => b += s
-    case (b, t: Traversable[_]) => t.foldLeft(b) {
-      case (b, SQLSyntax(_, params)) => b ++= params
-      case (b, SQLSyntaxParameterBinder(SQLSyntax(_, params))) => b ++= params
-      case (b, e) => b += e
+    case (builder, str: String) => builder += str
+    case (builder, traversable: Traversable[_]) => traversable.foldLeft(builder) {
+      case (builder, SQLSyntax(_, params)) => builder ++= params
+      case (builder, SQLSyntaxParameterBinder(SQLSyntax(_, params))) => builder ++= params
+      case (builder, AsIsParameterBinder(value)) => builder += value
+      case (builder, value) => builder += value
     }
-    case (b, SQLSyntax(_, params)) => b ++= params
-    case (b, SQLSyntaxParameterBinder(SQLSyntax(_, params))) => b ++= params
-    case (b, n) => b += n
+    case (builder, SQLSyntax(_, params)) => builder ++= params
+    case (builder, SQLSyntaxParameterBinder(SQLSyntax(_, params))) => builder ++= params
+    case (builder, AsIsParameterBinder(value)) => builder += value
+    case (builder, value) => builder += value
   }.result()
 
 }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/SQLInterpolationString.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/SQLInterpolationString.scala
@@ -57,12 +57,12 @@ class SQLInterpolationString(val s: StringContext) extends AnyVal {
     case (builder, traversable: Traversable[_]) => traversable.foldLeft(builder) {
       case (builder, SQLSyntax(_, params)) => builder ++= params
       case (builder, SQLSyntaxParameterBinder(SQLSyntax(_, params))) => builder ++= params
-      case (builder, AsIsParameterBinder(value)) => builder += value
+      case (builder, BypassParameterBinder(value)) => builder += value
       case (builder, value) => builder += value
     }
     case (builder, SQLSyntax(_, params)) => builder ++= params
     case (builder, SQLSyntaxParameterBinder(SQLSyntax(_, params))) => builder ++= params
-    case (builder, AsIsParameterBinder(value)) => builder += value
+    case (builder, BypassParameterBinder(value)) => builder += value
     case (builder, value) => builder += value
   }.result()
 

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
@@ -54,16 +54,20 @@ case class StatementExecutor(
     }
   }
 
+  private[this] def extractOption(value: Any) = {
+    ParameterBinderWithValue.extract(value) match {
+      case option: Option[_] => option.orNull[Any]
+      case other => other
+    }
+  }
+
   /**
    * Binds parameters to the underlying java.sql.PreparedStatement object.
-   * @param params parameters
    */
   def bindParams(params: Seq[Any]): Unit = {
     val paramsWithIndices = params.map {
-      case AsIsParameterBinder(value) => ParameterBinderWithValue.extract(value) match {
-        case option: Option[_] => option.orNull[Any]
-        case other => other
-      }
+      case AsIsParameterBinder(value) => extractOption(value)
+      case binder: ParameterBinder if binder.asIs => extractOption(binder)
       case option: Option[_] => option.orNull[Any]
       case other => other
     }.zipWithIndex

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
@@ -54,8 +54,11 @@ case class StatementExecutor(
     }
   }
 
-  private[this] def extractOption(value: Any) = {
-    ParameterBinderWithValue.extract(value) match {
+  /**
+   * Extracts the raw value from maybe nested BypassParameterBinder.
+   */
+  private[this] def extractBypassParameterBinderRawValue(value: Any) = {
+    BypassParameterBinder.extractValue(value) match {
       case option: Option[_] => option.orNull[Any]
       case other => other
     }
@@ -66,8 +69,8 @@ case class StatementExecutor(
    */
   def bindParams(params: Seq[Any]): Unit = {
     val paramsWithIndices = params.map {
-      case AsIsParameterBinder(value) => extractOption(value)
-      case binder: ParameterBinder if binder.asIs => extractOption(binder)
+      case BypassParameterBinder(value) => extractBypassParameterBinderRawValue(value)
+      case binder: ParameterBinder if binder.bypass => extractBypassParameterBinderRawValue(binder)
       case option: Option[_] => option.orNull[Any]
       case other => other
     }.zipWithIndex

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
@@ -60,6 +60,10 @@ case class StatementExecutor(
    */
   def bindParams(params: Seq[Any]): Unit = {
     val paramsWithIndices = params.map {
+      case AsIsParameterBinder(value) => ParameterBinderWithValue.extract(value) match {
+        case option: Option[_] => option.orNull[Any]
+        case other => other
+      }
       case option: Option[_] => option.orNull[Any]
       case other => other
     }.zipWithIndex

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -674,18 +674,41 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
     }
   }
 
-  "insert.namedValues" should "accepts not only var args" in {
+  "insert.namedValues" should "accept not only var args" in {
     val ac = Account.column
     val s = insert.into(Account).namedValues(Map(ac.name -> "Bob Marley")).toSQL
     s.statement should equal("insert into qi_accounts (name) values (?)")
     s.parameters should equal(Seq("Bob Marley"))
   }
 
-  "update.set" should "accepts not only var args" in {
+  "update.set" should "accept not only var args" in {
     val ac = Account.column
     val s = update(Account).set(Map(ac.name -> "Bob Marley")).toSQL
     s.statement should equal("update qi_accounts set name = ?")
     s.parameters should equal(Seq("Bob Marley"))
+  }
+
+  "insert.namedValues" should "accept None" in {
+    DB autoCommit { implicit s =>
+      try sql"drop table ${Account.table}".execute.apply()
+      catch { case e: Exception => }
+      sql"create table ${Account.table} (id int not null, name varchar(256))".execute.apply()
+    }
+
+    try {
+      val ac = Account.column
+      val params: Seq[(SQLSyntax, Any)] = Seq(ac.id -> 123, ac.name -> None)
+      val query = insert.into(Account).namedValues(params.map { case (k, v) => (k, AsIsParameterBinder(v)) }: _*).toSQL
+      query.statement should equal("insert into qi_accounts (id, name) values (?, ?)")
+      query.parameters should equal(Seq(123, null))
+
+      DB autoCommit { implicit s => query.update.apply() }
+    } finally {
+      DB autoCommit { implicit s =>
+        try sql"drop table ${Account.table}".execute.apply()
+        catch { case e: Exception => }
+      }
+    }
   }
 
 }

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -699,8 +699,8 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
 
     try {
       val ac = Account.column
-      val params: Seq[(SQLSyntax, Any)] = Seq(ac.id -> 123, ac.name -> AsIsParameterBinder(None))
-      val query = insert.into(Account).namedValues(params.map { case (k, v) => k -> AsIsParameterBinder(v) }: _*).toSQL
+      val params: Seq[(SQLSyntax, Any)] = Seq(ac.id -> 123, ac.name -> BypassParameterBinder(None))
+      val query = insert.into(Account).namedValues(params.map { case (k, v) => k -> BypassParameterBinder(v) }: _*).toSQL
       query.statement should equal("insert into qi_accounts (id, name) values (?, ?)")
       query.parameters should equal(Seq(123, null))
 
@@ -722,11 +722,11 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
 
     try {
       val ac = Account.column
-      val params: Seq[(SQLSyntax, Any)] = Seq(ac.id -> 123, ac.name -> AsIsParameterBinder(None))
+      val params: Seq[(SQLSyntax, Any)] = Seq(ac.id -> 123, ac.name -> BypassParameterBinder(None))
       val query = insert.into(Account).namedValues(params.map {
         case (k, v) => (k, new ParameterBinderWithValue[Any] {
           // if this value is not configured correctly, ParameterBinder doesn't work
-          override lazy val asIs = true
+          override lazy val bypass = true
           override def value = v
           override def apply(stmt: PreparedStatement, idx: Int): Unit = {}
         })


### PR DESCRIPTION
 `AsIsParameterBinder`, a special `ParameterBinder`, is allowed to bind the value it holds as-is when embedding it into `SQLInterpolationString` template or working with `DBSession` and raw String template.

In some cases, we need to work with `Any` values inside libraries or frameworks that depend on ScalikeJDBC's QueryDSL APIs due to the library's design or type erasure.

Providing `AsIsParameterBinder` should be very helpful for the use cases. At least, this feature is strongly needed by [Skinny ORM](http://skinny-framework.org/documentation/orm.html). 2.4 release without this feature will be very hard for some existing applications.