### PR TITLE
Add a special ParameterBinder to allow bypassing ParameterBinderFactory

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
@@ -36,9 +36,10 @@ trait ParameterBinderWithValue[A] extends ParameterBinder { self =>
   override def toString: String = s"ParameterBinder(value=$value)"
 
 }
-class AsIsParameterBinder private (val value: Any) extends ParameterBinder {
+class AsIsParameterBinder private (val value: Any) extends ParameterBinderWithValue[Any] {
   override def apply(stmt: PreparedStatement, idx: Int): Unit = throw new UnsupportedOperationException // TODO: error message
-  override def toString: String = value.toString
+  override def toString: String = s"AsIsParameterBinder(value=$value)"
+  override private[scalikejdbc] def map[B](f: Any => B): ParameterBinderWithValue[B] = throw new UnsupportedOperationException // TODO: error message
 }
 object AsIsParameterBinder {
   def apply(value: Any): ParameterBinder = value match {
@@ -46,6 +47,7 @@ object AsIsParameterBinder {
     case _ => new AsIsParameterBinder(value)
   }
   def unapply(binder: AsIsParameterBinder): Option[Any] = Some(binder.value)
+
 }
 
 /**

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
@@ -36,6 +36,17 @@ trait ParameterBinderWithValue[A] extends ParameterBinder { self =>
   override def toString: String = s"ParameterBinder(value=$value)"
 
 }
+class AsIsParameterBinder private (val value: Any) extends ParameterBinder {
+  override def apply(stmt: PreparedStatement, idx: Int): Unit = throw new UnsupportedOperationException // TODO: error message
+  override def toString: String = value.toString
+}
+object AsIsParameterBinder {
+  def apply(value: Any): ParameterBinder = value match {
+    case x: ParameterBinder => x
+    case _ => new AsIsParameterBinder(value)
+  }
+  def unapply(binder: AsIsParameterBinder): Option[Any] = Some(binder.value)
+}
 
 /**
  * ParameterBinder factory.
@@ -55,6 +66,7 @@ object ParameterBinder {
 
   def unapply(a: Any): Option[Any] = {
     PartialFunction.condOpt(a) {
+      case AsIsParameterBinder(v) => v
       case x: ParameterBinderWithValue[_] => x.value
     }
   }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
@@ -2,8 +2,12 @@ package scalikejdbc
 
 import java.sql.PreparedStatement
 
+import scalikejdbc.interpolation.SQLSyntax
+
+// ------------------------------------------------------------------------------
+
 /**
- * EssentialParameterBinder which enables customizing StatementExecutor#binParams.
+ * Enables customizing StatementExecutor#bindParams behavior.
  *
  * {{{
  * val bytes = Array[Byte](1,2,3, ...)
@@ -22,24 +26,6 @@ trait ParameterBinder { self =>
    */
   def apply(stmt: PreparedStatement, idx: Int): Unit
 
-}
-trait ParameterBinderWithValue[A] extends ParameterBinder { self =>
-
-  def value: A
-
-  // [[scalikejdbc.ParameterBinder#map]] breaks the Functor-law
-  private[scalikejdbc] def map[B](f: A => B): ParameterBinderWithValue[B] = new ParameterBinderWithValue[B] {
-    lazy val value: B = f(self.value)
-    def apply(stmt: PreparedStatement, idx: Int): Unit = self(stmt, idx)
-  }
-
-  override def toString: String = s"ParameterBinder(value=$value)"
-
-}
-case class AsIsParameterBinder(value: Any) extends ParameterBinderWithValue[Any] {
-  override def apply(stmt: PreparedStatement, idx: Int): Unit = throw new UnsupportedOperationException // TODO: error message
-  override def toString: String = s"AsIsParameterBinder(value=$value)"
-  override private[scalikejdbc] def map[B](f: Any => B): ParameterBinderWithValue[B] = throw new UnsupportedOperationException // TODO: error message
 }
 
 /**
@@ -78,3 +64,54 @@ object ParameterBinder {
 
 }
 
+// ------------------------------------------------------------------------------
+
+/**
+ * ParameterBinder which holds a value to bind.
+ *
+ * @tparam A value's type
+ */
+trait ParameterBinderWithValue[A] extends ParameterBinder { self =>
+
+  def value: A
+
+  // keep this API private because [[scalikejdbc.ParameterBinder#map]] breaks the Functor-law
+  private[scalikejdbc] def map[B](f: A => B): ParameterBinderWithValue[B] = new ParameterBinderWithValue[B] {
+    lazy val value: B = f(self.value)
+    def apply(stmt: PreparedStatement, idx: Int): Unit = self(stmt, idx)
+  }
+
+  override def toString: String = s"ParameterBinder(value=$value)"
+
+}
+
+// ------------------------------------------------------------------------------
+
+/**
+ * ParameterBinder which holds SQLSyntax.
+ */
+private[scalikejdbc] case class SQLSyntaxParameterBinder(syntax: SQLSyntax)
+    extends ParameterBinderWithValue[SQLSyntax] {
+
+  val value = syntax
+
+  def apply(stmt: PreparedStatement, idx: Int): Unit = ()
+}
+
+// ------------------------------------------------------------------------------
+
+/**
+ * Type unsafe ParameterBinder which holds any value and binds it as-is to PreparedStatement.
+ */
+case class AsIsParameterBinder(value: Any) extends ParameterBinderWithValue[Any] {
+
+  private[this] def unsupportedError(): Nothing = {
+    throw new UnsupportedOperationException("Apply method doesn't work because this is an AsIsParameterBinder")
+  }
+
+  override def apply(stmt: PreparedStatement, idx: Int): Unit = unsupportedError
+  override private[scalikejdbc] def map[B](f: Any => B): ParameterBinderWithValue[B] = unsupportedError
+
+  override def toString: String = s"AsIsParameterBinder(value=$value)"
+
+}

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinderFactory.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinderFactory.scala
@@ -67,10 +67,14 @@ trait LowPriorityImplicitsParameterBinderFactory1 extends LowPriorityImplicitsPa
   implicit def optionalParameterBinderFactory[A](implicit ev: ParameterBinderFactory[A]): ParameterBinderFactory[Option[A]] = new ParameterBinderFactory[Option[A]] {
     def apply(value: Option[A]): ParameterBinderWithValue[Option[A]] = {
       if (value == null) ParameterBinder.NullParameterBinder
+      else if (ev == asisParameterBinderFactory) AsIsParameterBinder(value).asInstanceOf[ParameterBinderWithValue[Option[A]]]
       else value.fold[ParameterBinderWithValue[Option[A]]](ParameterBinder.NullParameterBinder)(v => ev(v).map(Option.apply))
     }
   }
 
+  val asisParameterBinderFactory: ParameterBinderFactory[Any] = new ParameterBinderFactory[Any] {
+    def apply(value: Any): ParameterBinderWithValue[Any] = AsIsParameterBinder(value)
+  }
 }
 
 trait LowPriorityImplicitsParameterBinderFactory0 {

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
@@ -72,6 +72,7 @@ case class StatementExecutor(
     }
   }
 
+  @annotation.tailrec
   private[this] def bind(param: Any, i: Int): Unit = {
     param match {
       case null => underlying.setObject(i, null)

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
@@ -196,6 +196,7 @@ class SQLSyntax private[scalikejdbc] (val value: String, private[scalikejdbc] va
   def stripMargin(marginChar: Char): SQLSyntax = new SQLSyntax(value.stripMargin(marginChar), rawParameters)
 
   def -> [A](value: A)(implicit ev: ParameterBinderFactory[A]): (SQLSyntax, ParameterBinder) = (this, ev(value))
+  def -> (value: ParameterBinder): (SQLSyntax, ParameterBinder) = (this, value)
 }
 
 /**


### PR DESCRIPTION
Thanks to @gakuzzzz, this pull request brings a better solution for https://github.com/scalikejdbc/scalikejdbc/pull/514

This version is already sonatype snapshots repository. I'll merge this after checking it works fine with skinny orm implementation.