### PR TITLE
Use named daemon thread in connection pool object

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
@@ -1,5 +1,6 @@
 package scalikejdbc
 
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.Executors
 import javax.sql.DataSource
 import java.sql.Connection
@@ -18,7 +19,14 @@ object ConnectionPool extends LogSupport {
    * The default execution context used by async workers for connection pools management.
    */
   private lazy val DEFAULT_EXECUTION_CONTEXT: ExecutionContextExecutor = {
-    ExecutionContext.fromExecutor(Executors.newFixedThreadPool(3))
+    ExecutionContext.fromExecutor(Executors.newFixedThreadPool(3, new ThreadFactory {
+      private val i = new AtomicInteger(0)
+      override def newThread(r: Runnable): Thread = {
+        val thread = new Thread(s"scalikejdbc-connection-pool-default-ec-${i.incrementAndGet()}")
+        thread.setDaemon(true)
+        thread
+      }
+    }))
   }
 
   type MutableMap[A, B] = scala.collection.mutable.HashMap[A, B]

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
@@ -2,6 +2,7 @@ package scalikejdbc
 
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
 import javax.sql.DataSource
 import java.sql.Connection
 import scala.concurrent.{ ExecutionContextExecutor, ExecutionContext }


### PR DESCRIPTION
It's for ease of debugging of suspended threads

This closes #527