### PR TITLE
[Proposal] Introduce ParameterBinderFactory contramap for contravariant types

### DIFF
--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DBSessionSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DBSessionSpec.scala
@@ -1041,7 +1041,7 @@ class DBSessionSpec extends FlatSpec with Matchers with BeforeAndAfter with Sett
           }
           val bytes = scala.Array[Byte](1, 2, 3, 4, 5, 6, 7)
           val in = new ByteArrayInputStream(bytes)
-          val v = ParameterBinder[InputStream](
+          val v = ParameterBinder(
             value = in,
             binder = (stmt: PreparedStatement, idx: Int) => stmt.setBinaryStream(idx, in, bytes.length)
           )

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/ParameterBinderFactorySpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/ParameterBinderFactorySpec.scala
@@ -371,4 +371,25 @@ class ParameterBinderFactorySpec extends FlatSpec with MockitoSugar {
     verify(stmt).setObject(3, null)
   }
 
+  it should "have instance for EnumLike" in {
+    val stmt = mock[PreparedStatement]
+    implicitly[ParameterBinderFactory[EnumLike]].apply(EnumLike.Foo)(stmt, 1)
+    implicitly[ParameterBinderFactory[EnumLike]].apply(EnumLike.Bar)(stmt, 2)
+    verify(stmt).setString(1, "Foo")
+    verify(stmt).setString(2, "Bar")
+
+    assert(SQLSyntax.eq(SQLSyntax.empty, EnumLike.Foo).parameters === Seq(EnumLike.Foo))
+  }
+}
+
+sealed trait EnumLike
+object EnumLike {
+
+  case object Foo extends EnumLike
+  case object Bar extends EnumLike
+
+  implicit def FooEnumParameterBinderFactory[A <: EnumLike]: ParameterBinderFactory[A] = {
+    ParameterBinderFactory.stringParameterBinderFactory.contramap(_.toString)
+  }
+
 }

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -14,7 +14,7 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
   case class Price(value: Int)
   object Price {
     implicit val bider: TypeBinder[Price] = TypeBinder.int.map(Price.apply)
-    implicit val unbinder: ParameterBinderFactory[Price] = ParameterBinderFactory.intParameterBinderFactory.xmap(Price.apply, _.value)
+    implicit val unbinder: ParameterBinderFactory[Price] = ParameterBinderFactory.intParameterBinderFactory.contramap(_.value)
   }
   case class Order(id: Int, productId: Int, accountId: Option[Int], createdAt: DateTime, product: Option[Product] = None, account: Option[Account] = None)
   case class LegacyProduct(id: Option[Int], name: Option[String], price: Int)


### PR DESCRIPTION
refs #530

In 2.4.2, we can not define contravariant ParameterBinderFactory with defined ParameterBinderFactory 

```scala
sealed trait XXX
case object YYY extends XXX

object XXX {
  implicit def xxxPBF[A <: XXX]: ParameterBinderFactory[A] = {
    ParameterBinderFactory.stringParameterBinderFactory.xmap(???, _.toString) // can not define
  }
}
```

This PR makes enable it as follows

```scala
sealed trait XXX
case object YYY extends XXX

object XXX {
  implicit def xxxPBF[A <: XXX]: ParameterBinderFactory[A] = {
    ParameterBinderFactory.stringParameterBinderFactory.contramap(_.toString)
  }
}
```

## problem

This PR breaks binary compatibility.