### PR TITLE
Use xxx.nonEmpty instead of checking `xxx.isEmpty == false`

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/Binders.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/Binders.scala
@@ -93,7 +93,7 @@ object Binders {
     case b: Boolean => b.asInstanceOf[java.lang.Boolean]
     case s: String => {
       try s.toInt != 0
-      catch { case e: NumberFormatException => !s.isEmpty }
+      catch { case e: NumberFormatException => s.nonEmpty }
     }.asInstanceOf[java.lang.Boolean]
     case n: Number => (n.intValue() != 0).asInstanceOf[java.lang.Boolean]
     case v => (v != 0).asInstanceOf[java.lang.Boolean]

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/Commons2ConnectionPool.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/Commons2ConnectionPool.scala
@@ -37,7 +37,7 @@ class Commons2ConnectionPool(
 
   // To fix MS SQLServer jtds driver issue
   // https://github.com/scalikejdbc/scalikejdbc/issues/461
-  if (Option(settings.validationQuery).exists(_.trim.isEmpty == false)) {
+  if (Option(settings.validationQuery).exists(_.trim.nonEmpty)) {
     _pool.setTestOnBorrow(true)
   }
 

--- a/scalikejdbc-interpolation-macro/src/main/scala/scalikejdbc/SQLInterpolationMacro.scala
+++ b/scalikejdbc-interpolation-macro/src/main/scala/scalikejdbc/SQLInterpolationMacro.scala
@@ -26,7 +26,7 @@ object SQLInterpolationMacro {
     }.getOrElse(Nil)
 
     nameOpt.map { _name =>
-      if (!expectedNames.isEmpty && !expectedNames.contains(_name)) {
+      if (expectedNames.nonEmpty && !expectedNames.contains(_name)) {
         c.error(c.enclosingPosition, s"${c.weakTypeOf[E]}#${_name} not found. Expected fields are ${expectedNames.mkString("#", ", #", "")}.")
       }
     }


### PR DESCRIPTION
We can use `nonEmpty` to check if the expression is equivalent to false in these cases.