### PR TITLE
Bump ScalaTest version to 3.0, Scala 2.12.0-M5 CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
 
 matrix:
   include:
-    - scala: 2.12.0-M4
+    - scala: 2.12.0-M5
       jdk: oraclejdk8
       env: SCALIKEJDBC_DATABASE="mysql"
     - scala: scripted-test

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,7 @@ import sbtbuildinfo.Plugin._
 
 object ScalikeJDBCProjects extends Build {
 
-  lazy val _version = "2.4.3-SNAPSHOT"
+  lazy val _version = "2.5.0-SNAPSHOT"
 
   lazy val _organization = "org.scalikejdbc"
 
@@ -20,7 +20,8 @@ object ScalikeJDBCProjects extends Build {
   // 6.0.x is still under development? https://dev.mysql.com/downloads/connector/j/
   lazy val _mysqlVersion = "5.1.39"
   lazy val _postgresqlVersion = "9.4.1208.jre7"
-  lazy val _hibernateVersion = "5.1.0.Final"
+  // Hibernate 5.2 dropped JDK 7 support
+  lazy val _hibernateVersion = "5.1.1.Final"
   lazy val scalatestVersion = SettingKey[String]("scalatestVersion")
   lazy val specs2Version = SettingKey[String]("specs2Version")
 
@@ -42,11 +43,11 @@ object ScalikeJDBCProjects extends Build {
     fullResolvers ~= { _.filterNot(_.name == "jcenter") },
     transitiveClassifiers in Global := Seq(Artifact.SourceClassifier),
     incOptions := incOptions.value.withNameHashing(true),
-    scalatestVersion := "2.2.6",
+    scalatestVersion := "3.0.0",
     specs2Version := {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, v)) if v <= 11 => "2.5"
-        case _ => "3.7.3"
+        case _ => "3.8.4"
       }
     },
     //scalaVersion := "2.11.8",
@@ -126,7 +127,7 @@ object ScalikeJDBCProjects extends Build {
           "commons-dbcp"            %  "commons-dbcp"    % "1.4"             % "provided",
           "com.jolbox"              %  "bonecp"          % "0.8.0.RELEASE"   % "provided",
           // scope: test
-          "com.zaxxer"              %  "HikariCP"        % "2.4.6"           % "test",
+          "com.zaxxer"              %  "HikariCP"        % "2.4.7"           % "test",
           "ch.qos.logback"          %  "logback-classic" % _logbackVersion   % "test",
           "org.hibernate"           %  "hibernate-core"  % _hibernateVersion % "test",
           "org.mockito"             %  "mockito-all"     % "1.10.+"          % "test"

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -11,16 +11,17 @@ import com.typesafe.tools.mima.plugin.MimaKeys.{previousArtifacts, reportBinaryI
  */
 object MimaSettings {
 
-  // The `previousVersions` must be *ALL* the previous versions to be binary compatible (e.g. Set("2.4.0", "2.4.1") for "2.4.2-SNAPSHOT").
+  // The `previousVersions` must be *ALL* the previous versions to be binary compatible (e.g. Set("2.5.0", "2.5.1") for "2.5.2-SNAPSHOT").
   //
   // The following bad scenario is the reason we must obey the rule:
   //
-  //  - your build is toward 2.4.2 release and the `previousVersions` is "2.4.0" only
-  //  - you've added new methods since 2.4.1
-  //  - you're going to remove some of the methods in 2.4.2
+  //  - your build is toward 2.5.2 release and the `previousVersions` is "2.5.0" only
+  //  - you've added new methods since 2.5.1
+  //  - you're going to remove some of the methods in 2.5.2
   //  - in this case, the incompatibility won't be detected
   //
-  val previousVersions = (0 to 2).map(patch => s"2.4.$patch").toSet
+  //val previousVersions = (0 to 2).map(patch => s"2.5.$patch").toSet
+  val previousVersions: Set[String] = Set.empty
 
   val mimaSettings = MimaPlugin.mimaDefaultSettings ++ Seq(
     previousArtifacts := {

--- a/scalikejdbc-test/src/main/scala/scalikejdbc/scalatest/AutoRollback.scala
+++ b/scalikejdbc-test/src/main/scala/scalikejdbc/scalatest/AutoRollback.scala
@@ -1,6 +1,6 @@
 package scalikejdbc.scalatest
 
-import org.scalatest.fixture.Suite
+import org.scalatest.fixture.TestSuite
 import scalikejdbc._
 
 /**
@@ -28,7 +28,7 @@ import scalikejdbc._
  * }
  * }}}
  */
-trait AutoRollback extends LoanPattern { self: Suite =>
+trait AutoRollback extends LoanPattern { self: TestSuite =>
 
   type FixtureParam = DBSession
 

--- a/scripts/release_2.12.sh
+++ b/scripts/release_2.12.sh
@@ -3,14 +3,14 @@
 cd `dirname $0`/..
 rm -rf */target
 
-sbt 'set scalaVersion := "2.12.0-M4"' \
+sbt 'set scalaVersion := "2.12.0-M5"' \
   clean \
-  "project core" 'set scalaVersion := "2.12.0-M4"' publishSigned \
-  "project config" 'set scalaVersion := "2.12.0-M4"' publishSigned \
-  "project interpolation-macro" 'set scalaVersion := "2.12.0-M4"' publishSigned \
-  "project interpolation" 'set scalaVersion := "2.12.0-M4"' publishSigned \
-  "project library" 'set scalaVersion := "2.12.0-M4"' publishSigned \
-  "project jsr310" 'set scalaVersion := "2.12.0-M4"' publishSigned \
-  "project syntax-support-macro" 'set scalaVersion := "2.12.0-M4"' publishSigned \
-  "project test" 'set scalaVersion := "2.12.0-M4"' publishSigned \
-  "project mapper-generator-core" 'set scalaVersion := "2.12.0-M4"' publishSigned
+  "project core" 'set scalaVersion := "2.12.0-M5"' publishSigned \
+  "project config" 'set scalaVersion := "2.12.0-M5"' publishSigned \
+  "project interpolation-macro" 'set scalaVersion := "2.12.0-M5"' publishSigned \
+  "project interpolation" 'set scalaVersion := "2.12.0-M5"' publishSigned \
+  "project library" 'set scalaVersion := "2.12.0-M5"' publishSigned \
+  "project jsr310" 'set scalaVersion := "2.12.0-M5"' publishSigned \
+  "project syntax-support-macro" 'set scalaVersion := "2.12.0-M5"' publishSigned \
+  "project test" 'set scalaVersion := "2.12.0-M5"' publishSigned \
+  "project mapper-generator-core" 'set scalaVersion := "2.12.0-M5"' publishSigned


### PR DESCRIPTION
This pull request starts 2.5.x series development and fixes the issue #550 first.

- Disable the MiMa's bin-compatibility validation until 2.5.0 release
- Bump ScalaTest version to 3.0.0, Fix a compilation error due to a ScalaTest's API breaking change
- Bump Scala 2.12.0-M4 to 2.12.0-M5 (ScalaTest lib absence was a blocker to bump it)
