### PR TITLE
Add insert and update returning for arbitrary columns in PostgreSQL

### DIFF
--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
@@ -538,6 +538,11 @@ trait QueryDSLFeature { self: SQLInterpolationFeature with SQLSyntaxSupportFeatu
      */
     def set(tuples: Map[SQLSyntax, ParameterBinder]): UpdateSQLBuilder = set(sqls.csv(tuples.toSeq.map(each => sqls"${each._1} = ${each._2}"): _*))
 
+    /**
+     *  `returning` for PostgreSQL
+     */
+    def returning(columns: SQLSyntax*): UpdateSQLBuilder = append(sqls"returning ${sqls.csv(columns: _*)}")
+
     override def append(part: SQLSyntax): UpdateSQLBuilder = this.copy(sql = sqls"${sql} ${part}")
   }
 

--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
@@ -513,6 +513,11 @@ trait QueryDSLFeature { self: SQLInterpolationFeature with SQLSyntaxSupportFeatu
      */
     def returningId: InsertSQLBuilder = append(sqls"returning id")
 
+    /**
+     *  `returning` for PostgreSQL
+     */
+    def returning(columns: SQLSyntax*): InsertSQLBuilder = append(sqls"returning ${sqls.csv(columns: _*)}")
+
     override def append(part: SQLSyntax): InsertSQLBuilder = this.copy(sql = sqls"${sql} ${part}")
   }
 

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -652,14 +652,17 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
         QueryDSL.update(Account).set(ac.name -> "Bob Marley").where.eq(ac.c("id"), 2)
         QueryDSL.delete.from(Order).where.isNull(Order.column.field("accountId"))
 
-        // returing id for PostgreSQL
+        // insert returing id for PostgreSQL
         val returningIdQuery = insert.into(Account).namedValues(ac.name -> "Alice").returningId
         returningIdQuery.toSQL.statement should equal("insert into qi_accounts (name) values (?) returning id")
 
-        // returning columns* for PostgreSQL
+        // insert returning columns* for PostgreSQL
         val returningColumnsQuery = insert.into(Account).namedValues(ac.name -> "Alice").returning(ac.name, ac.id)
         returningColumnsQuery.toSQL.statement should equal("insert into qi_accounts (name) values (?) returning name, id")
 
+        // update returning columns* for PostgreSQL
+        val updateReturningColumnsQuery = QueryDSL.update(Account).set(ac.name -> "Alice").returning(ac.name, ac.id, ac.name)
+        updateReturningColumnsQuery.toSQL.statement should equal("update qi_accounts set name = ? returning name, id, name")
       }
 
       // for update query

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -656,6 +656,10 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
         val returningIdQuery = insert.into(Account).namedValues(ac.name -> "Alice").returningId
         returningIdQuery.toSQL.statement should equal("insert into qi_accounts (name) values (?) returning id")
 
+        // returning columns* for PostgreSQL
+        val returningColumnsQuery = insert.into(Account).namedValues(ac.name -> "Alice").returning(ac.name, ac.id)
+        returningColumnsQuery.toSQL.statement should equal("insert into qi_accounts (name) values (?) returning name, id")
+
       }
 
       // for update query


### PR DESCRIPTION
For issue #559 add insert and update returning for arbitrary columns in PostgreSQL.  FYI somewhat more needs to be done if the UPDATE ... FROM ... RETURNING syntax is ever supported (https://www.postgresql.org/docs/current/static/sql-update.html) 