### PR TITLE
Specify timeZone to avoid environment-dependent failure which fixes #565

### DIFF
--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DBSessionSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DBSessionSpec.scala
@@ -1060,7 +1060,7 @@ class DBSessionSpec extends FlatSpec with Matchers with BeforeAndAfter with Sett
     import java.util.TimeZone
     import org.joda.time.DateTimeZone
 
-    val time = new DateTime(2016, 1, 9, 2, 43, 42)
+    val time = new DateTime(2016, 1, 9, 2, 43, 42, DateTimeZone.forID("Asia/Tokyo"))
 
     val castToString: String = if (driverClassName.contains("mysql")) {
       "date_format(t, '%Y-%m-%d %H:%i:%S')"
@@ -1087,7 +1087,7 @@ class DBSessionSpec extends FlatSpec with Matchers with BeforeAndAfter with Sett
 
         SQL("insert into zone_test values (?, ?)").bind(1, time).execute.apply()(jstSession)
         val jstString = SQL(s"select $castToString as s from zone_test where id = 1").map(_.string("s")).single.apply().get
-        jstString should equal(time.withZone(DateTimeZone.forID("Asia/Tokyo")).toString("yyyy-MM-dd hh:mm:ss"))
+        jstString should equal(time.toString("yyyy-MM-dd HH:mm:ss"))
 
         val expectedTime1 = SQL("select t from zone_test where id = 1").map(_.jodaDateTime("t")).single.apply().get
         expectedTime1.isEqual(time) should equal(true)

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -729,7 +729,7 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
 
     val t = TimeHolder.syntax("t")
 
-    val time = new DateTime(2016, 1, 9, 2, 43, 42)
+    val time = new DateTime(2016, 1, 9, 2, 43, 42, DateTimeZone.forID("Asia/Tokyo"))
 
     val castToString: String = if (isMySQL) {
       "date_format(time, '%Y-%m-%d %H:%i:%S')"
@@ -753,7 +753,7 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
 
         applyUpdate(insertInto(TimeHolder).namedValues(TimeHolder.column.id -> 1, TimeHolder.column.time -> time))
         val jstString = SQL(s"select $castToString as s from ${TimeHolder.tableName} where id = 1").map(_.string("s")).single.apply().get
-        jstString should equal(time.withZone(DateTimeZone.forID("Asia/Tokyo")).toString("yyyy-MM-dd hh:mm:ss"))
+        jstString should equal(time.toString("yyyy-MM-dd HH:mm:ss"))
 
         val expectedTime1 = withSQL(selectFrom(TimeHolder as t).where.eq(t.id, 1)).map(TimeHolder(t)(_)).single.apply().get.time
         expectedTime1.isEqual(time) should equal(true)


### PR DESCRIPTION
I guess that scala/communitybuilds envinronment is under UTC-8 timezone.