### PR TITLE
add settings for avoid connection handling logging

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
@@ -123,8 +123,9 @@ object ConnectionPool extends LogSupport {
       // asynchronously close the old pool if exists
       oldPoolOpt.foreach(pool => abandonOldPool(name, pool))
     }
-
-    log.debug(s"Registered connection pool : ${get(name)} using factory : $factoryName")
+    if (GlobalSettings.loggingConnections) {
+      log.debug(s"Registered connection pool : ${get(name)} using factory : $factoryName")
+    }
   }
 
   /**
@@ -172,14 +173,18 @@ object ConnectionPool extends LogSupport {
     ec: ExecutionContext = DEFAULT_EXECUTION_CONTEXT
   ) = {
     scala.concurrent.Future {
-      log.debug("The old pool destruction started. connection pool : " + get(name).toString())
+      if (GlobalSettings.loggingConnections) {
+        log.debug("The old pool destruction started. connection pool : " + get(name).toString())
+      }
       var millis = 0L
       while (millis < 60000L && oldPool.numActive > 0) {
         Thread.sleep(100L)
         millis += 100L
       }
       oldPool.close()
-      log.debug("The old pool is successfully closed. connection pool : " + get(name).toString())
+      if (GlobalSettings.loggingConnections) {
+        log.debug("The old pool is successfully closed. connection pool : " + get(name).toString())
+      }
     }
   }
 

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
@@ -135,7 +135,9 @@ trait DBConnection extends LogSupport with LoanPattern {
     ignoring(classOf[Throwable]) {
       conn.close()
     }
-    log.debug("A Connection is closed.")
+    if (GlobalSettings.loggingConnections) {
+      log.debug("A Connection is closed.")
+    }
   }
 
   /**

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DBSession.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DBSession.scala
@@ -668,7 +668,9 @@ trait DBSession extends LogSupport with LoanPattern {
     ignoring(classOf[Throwable]) {
       conn.close()
     }
-    log.debug("A Connection is closed.")
+    if (GlobalSettings.loggingConnections) {
+      log.debug("A Connection is closed.")
+    }
   }
 
 }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/GlobalSettings.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/GlobalSettings.scala
@@ -21,6 +21,11 @@ object GlobalSettings {
   var loggingSQLErrors: Boolean = true
 
   /**
+   * Enables logging for connection handling.
+   */
+  var loggingConnections: Boolean = true
+
+  /**
    * Settings for query timing logs.
    */
   var loggingSQLAndTime: LoggingSQLAndTimeSettings = LoggingSQLAndTimeSettings()


### PR DESCRIPTION
I'd like to disable something like `DEBUG scalikejdbc.DB - A Connection is closed.` logs on unit tests but there is not any configuration now.

Also, I tried to write specs for this pull request, but it seems to be difficult to write tests for logging because a logger cannot be able to check.
So this pull request doesn't add any specs ... but if you have any ideas, I will try it.