### PR TITLE
Fix the stability of core library tests

### DIFF
--- a/scalikejdbc-core/src/test/scala/scalikejdbc/NamedDBSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/NamedDBSpec.scala
@@ -15,10 +15,6 @@ class NamedDBSpec extends FlatSpec with Matchers with BeforeAndAfter with Settin
 
   behavior of "NamedDB"
 
-  before {
-    initializeConnectionPools()
-  }
-
   it should "be available" in {
     using(ConnectionPool.borrow('named)) { conn =>
       using(new DB(conn)) { db =>

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/Settings.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/Settings.scala
@@ -1,8 +1,9 @@
 package scalikejdbc
 
 import java.util.Properties
+import org.scalatest._
 
-trait Settings {
+trait Settings extends BeforeAndAfter { self: Suite =>
 
   val props = new Properties
   props.load(classOf[Settings].getClassLoader.getResourceAsStream("jdbc.properties"))
@@ -22,6 +23,8 @@ trait Settings {
     }
   }
 
-  initializeConnectionPools()
+  before {
+    initializeConnectionPools()
+  }
 
 }


### PR DESCRIPTION
Related to https://github.com/scalikejdbc/scalikejdbc/issues/574

This pull request removes potentially unstable initialization on core-library's tests.