### PR TITLE
AutoRollback calls withFixutre(NoArgTest) in withFixture(OneArgTest)

### DIFF
--- a/scalikejdbc-test/src/main/scala/scalikejdbc/scalatest/AutoRollback.scala
+++ b/scalikejdbc-test/src/main/scala/scalikejdbc/scalatest/AutoRollback.scala
@@ -1,5 +1,6 @@
 package scalikejdbc.scalatest
 
+import org.scalatest.Outcome
 import org.scalatest.fixture.TestSuite
 import scalikejdbc._
 
@@ -48,14 +49,14 @@ trait AutoRollback extends LoanPattern { self: TestSuite =>
    * Provides transactional block
    * @param test one arg test
    */
-  override def withFixture(test: OneArgTest) = {
+  override def withFixture(test: OneArgTest): Outcome = {
     using(db()) { db =>
       try {
         db.begin()
         db.withinTx { implicit session =>
           fixture(session)
         }
-        test(db.withinTxSession())
+        withFixture(test.toNoArgTest(db.withinTxSession()))
       } finally {
         db.rollbackIfActive()
       }

--- a/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/AutoRollbackSpec.scala
+++ b/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/AutoRollbackSpec.scala
@@ -52,3 +52,15 @@ class NamedAutoRollbackSpec extends FlatSpecWithCommonTraits with AutoRollback {
   }
 
 }
+
+class AutoRollbackWithNoArgTestFixtureSpec extends FlatSpecWithCommonTraits with AutoRollback with BufferMixin {
+
+  override def db = NamedDB('db2).toDB
+
+  behavior of "AutoRollback with NoArgTestFixture"
+
+  it should "call withFixture(NoArgTest)" in { implicit session =>
+    // "test" is appended in BufferMixin
+    assert(buffer.contains("test"))
+  }
+}

--- a/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/BufferMixin.scala
+++ b/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/BufferMixin.scala
@@ -1,0 +1,17 @@
+package scalikejdbc.scalatest
+
+import org.scalatest.Outcome
+import org.scalatest.TestSuite
+import org.scalatest.TestSuiteMixin
+import scala.collection.mutable.ListBuffer
+
+trait BufferMixin extends TestSuiteMixin { this: TestSuite =>
+
+  val buffer = new ListBuffer[String]
+
+  abstract override def withFixture(test: NoArgTest): Outcome = {
+    buffer.append("test")
+    try super.withFixture(test)
+    finally buffer.clear()
+  }
+}


### PR DESCRIPTION
Hi, all. I improved AutoRollback trait to call withFixture(NoArgTest). I would be happy if you could like this change.

# Problem
The current implementation of AutoRollback.withFixture(OneArgTest) doesn't call withFixture(NoArgTest), so it can't be used with fixtures for NoArgTest.

# Solution
Call test after converting OneArgTest to NoArgTest.

This method is documented in http://www.scalatest.org/user_guide/sharing_fixtures#withFixtureOneArgTest (Note that the document is for 2.x and not for 3.0.0). 
The document says:

```
To enable the stacking of traits that define withFixture(NoArgTest), it is a good idea to let withFixture(NoArgTest) invoke the test function instead of invoking the test function directly. To do so, you'll need to convert the OneArgTest to a NoArgTest. You can do that by passing the fixture object to the toNoArgTest method of OneArgTest. 
```