### PR TITLE
copy SQLs

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/OneToManies2SQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/OneToManies2SQL.scala
@@ -44,6 +44,9 @@ class OneToManies2SQL[A, B1, B2, E <: WithExtractor, Z](
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-many extractor(one(RS => A).toMany(RS => Option[B])) is specified, use #map((A,B) =>Z) instead."))
     with AllOutputDecisionsUnsupported[Z, E] {
 
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one, to1: WrappedResultSet => Option[B1] = to1, to2: WrappedResultSet => Option[B2] = to2, extractor: (A, Seq[B1], Seq[B2]) => Z = extractor): OneToManies2SQL[A, B1, B2, E, Z] = {
+    new OneToManies2SQL(statement, rawParameters)(one)(to1, to2)(extractor)
+  }
   def map(extractor: (A, Seq[B1], Seq[B2]) => Z): OneToManies2SQL[A, B1, B2, HasExtractor, Z] = {
     new OneToManies2SQL(statement, rawParameters)(one)(to1, to2)(extractor)
   }
@@ -83,6 +86,9 @@ class OneToManies2SQLToList[A, B1, B2, E <: WithExtractor, Z](
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor): List[Z] = {
     executeQuery[List](session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor).toList)
   }
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one, to1: WrappedResultSet => Option[B1] = to1, to2: WrappedResultSet => Option[B2] = to2, extractor: (A, Seq[B1], Seq[B2]) => Z = extractor): OneToManies2SQLToList[A, B1, B2, E, Z] = {
+    new OneToManies2SQLToList(statement, rawParameters)(one)(to1, to2)(extractor)
+  }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo1: WrappedResultSet => Option[B1] = to1
@@ -102,6 +108,9 @@ final class OneToManies2SQLToCollection[A, B1, B2, E <: WithExtractor, Z] privat
 
   override def apply[C[_]]()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor, cbf: CanBuildFrom[Nothing, Z, C[Z]]): C[Z] = {
     executeQuery(session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor).to[C])
+  }
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one, to1: WrappedResultSet => Option[B1] = to1, to2: WrappedResultSet => Option[B2] = to2, extractor: (A, Seq[B1], Seq[B2]) => Z = extractor): OneToManies2SQLToCollection[A, B1, B2, E, Z] = {
+    new OneToManies2SQLToCollection(statement, rawParameters)(one)(to1, to2)(extractor)
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
@@ -124,6 +133,9 @@ class OneToManies2SQLToTraversable[A, B1, B2, E <: WithExtractor, Z](
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor): Traversable[Z] = {
     executeQuery[Traversable](session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor))
   }
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one, to1: WrappedResultSet => Option[B1] = to1, to2: WrappedResultSet => Option[B2] = to2, extractor: (A, Seq[B1], Seq[B2]) => Z = extractor): OneToManies2SQLToTraversable[A, B1, B2, E, Z] = {
+    new OneToManies2SQLToTraversable(statement, rawParameters)(one)(to1, to2)(extractor)
+  }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo1: WrappedResultSet => Option[B1] = to1
@@ -143,6 +155,9 @@ class OneToManies2SQLToOption[A, B1, B2, E <: WithExtractor, Z](
   import GeneralizedTypeConstraintsForWithExtractor._
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor): Option[Z] = {
     executeQuery[Option](session, (session: DBSession) => toSingle(toTraversable(session, statement, rawParameters, extractor)))
+  }
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one, to1: WrappedResultSet => Option[B1] = to1, to2: WrappedResultSet => Option[B2] = to2, extractor: (A, Seq[B1], Seq[B2]) => Z = extractor, isSingle: Boolean = isSingle): OneToManies2SQLToOption[A, B1, B2, E, Z] = {
+    new OneToManies2SQLToOption(statement, rawParameters)(one)(to1, to2)(extractor)(isSingle)
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/OneToManySQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/OneToManySQL.scala
@@ -35,6 +35,10 @@ class OneToManySQL[A, B, E <: WithExtractor, Z](
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-many extractor(one(RS => A).toMany(RS => Option[B])) is specified, use #map((A,B) =>Z) instead."))
     with AllOutputDecisionsUnsupported[Z, E] {
 
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one, toMany: WrappedResultSet => Option[B] = toMany, extractor: (A, Seq[B]) => Z = extractor): OneToManySQL[A, B, E, Z] = {
+    new OneToManySQL(statement, rawParameters)(one)(toMany)(extractor)
+  }
+
   def map(extractor: (A, Seq[B]) => Z): OneToManySQL[A, B, HasExtractor, Z] = {
     val q = new OneToManySQL[A, B, HasExtractor, Z](statement, rawParameters)(one)(toMany)(extractor)
     q.queryTimeout(queryTimeout)
@@ -104,6 +108,9 @@ class OneToManySQLToList[A, B, E <: WithExtractor, Z](
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor): List[Z] = {
     executeQuery[List](session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor).toList)
   }
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one, toMany: WrappedResultSet => Option[B] = toMany, extractor: (A, Seq[B]) => Z = extractor): OneToManySQLToList[A, B, E, Z] = {
+    new OneToManySQLToList(statement, rawParameters)(one)(toMany)(extractor)
+  }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo: WrappedResultSet => Option[B] = toMany
@@ -122,6 +129,9 @@ class OneToManySQLToTraversable[A, B, E <: WithExtractor, Z](
 
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor): Traversable[Z] = {
     executeQuery[Traversable](session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor))
+  }
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one, toMany: WrappedResultSet => Option[B] = toMany, extractor: (A, Seq[B]) => Z = extractor): OneToManySQLToTraversable[A, B, E, Z] = {
+    new OneToManySQLToTraversable(statement, rawParameters)(one)(toMany)(extractor)
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
@@ -142,6 +152,9 @@ class OneToManySQLToCollection[A, B, E <: WithExtractor, Z](
   override def apply[C[_]]()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor, cbf: CanBuildFrom[Nothing, Z, C[Z]]): C[Z] = {
     executeQuery(session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor).to[C])
   }
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one, toMany: WrappedResultSet => Option[B] = toMany, extractor: (A, Seq[B]) => Z = extractor): OneToManySQLToCollection[A, B, E, Z] = {
+    new OneToManySQLToCollection(statement, rawParameters)(one)(toMany)(extractor)
+  }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo: WrappedResultSet => Option[B] = toMany
@@ -159,6 +172,9 @@ class OneToManySQLToOption[A, B, E <: WithExtractor, Z](
   import GeneralizedTypeConstraintsForWithExtractor._
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor): Option[Z] = {
     executeQuery[Option](session, (session: DBSession) => toSingle(toTraversable(session, statement, rawParameters, extractor)))
+  }
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one, toMany: WrappedResultSet => Option[B] = toMany, extractor: (A, Seq[B]) => Z = extractor, isSingle: Boolean = isSingle): OneToManySQLToOption[A, B, E, Z] = {
+    new OneToManySQLToOption(statement, rawParameters)(one)(toMany)(extractor)(isSingle)
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/OneToOneSQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/OneToOneSQL.scala
@@ -36,6 +36,10 @@ class OneToOneSQL[A, B, E <: WithExtractor, Z](
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-one extractor(one(RS => A).toOne(RS => Option[B])) is specified, use #map((A,B) =>Z) instead."))
     with AllOutputDecisionsUnsupported[Z, E] {
 
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one, toOne: WrappedResultSet => Option[B] = toOne, extractor: (A, B) => Z = extractor): OneToOneSQL[A, B, E, Z] = {
+    new OneToOneSQL(statement, rawParameters)(one)(toOne)(extractor)
+  }
+
   def map(extractor: (A, B) => Z): OneToOneSQL[A, B, HasExtractor, Z] = {
     new OneToOneSQL(statement, rawParameters)(one)(toOne)(extractor)
   }
@@ -76,6 +80,9 @@ class OneToOneSQLToTraversable[A, B, E <: WithExtractor, Z](
     hasExtractor: ThisSQL =:= SQLWithExtractor): Traversable[Z] = {
     executeQuery[Traversable](session, (session: DBSession) => toTraversable(session, statement, rawParameters, transform))
   }
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one, toOne: WrappedResultSet => Option[B] = toOne, map: (A, B) => Z = map): OneToOneSQLToTraversable[A, B, E, Z] = {
+    new OneToOneSQLToTraversable(statement, rawParameters)(one)(toOne)(map)
+  }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo: WrappedResultSet => Option[B] = toOne
@@ -94,6 +101,9 @@ class OneToOneSQLToList[A, B, E <: WithExtractor, Z](
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext,
     hasExtractor: ThisSQL =:= SQLWithExtractor): List[Z] = {
     executeQuery[List](session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor).toList)
+  }
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one, toOne: WrappedResultSet => Option[B] = toOne, extractor: (A, B) => Z = extractor): OneToOneSQLToList[A, B, E, Z] = {
+    new OneToOneSQLToList(statement, rawParameters)(one)(toOne)(extractor)
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
@@ -114,6 +124,9 @@ class OneToOneSQLToCollection[A, B, E <: WithExtractor, Z](
     hasExtractor: ThisSQL =:= SQLWithExtractor, cbf: CanBuildFrom[Nothing, Z, C[Z]]): C[Z] = {
     executeQuery(session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor).to[C])
   }
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one, toOne: WrappedResultSet => Option[B] = toOne, extractor: (A, B) => Z = extractor): OneToOneSQLToCollection[A, B, E, Z] = {
+    new OneToOneSQLToCollection(statement, rawParameters)(one)(toOne)(extractor)
+  }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo: WrappedResultSet => Option[B] = toOne
@@ -131,6 +144,9 @@ class OneToOneSQLToOption[A, B, E <: WithExtractor, Z](
   import GeneralizedTypeConstraintsForWithExtractor._
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor): Option[Z] = {
     executeQuery[Option](session, (session: DBSession) => toSingle(toTraversable(session, statement, rawParameters, extractor)))
+  }
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one, toOne: WrappedResultSet => Option[B] = toOne, extractor: (A, B) => Z = extractor, isSingle: Boolean = isSingle): OneToOneSQLToOption[A, B, E, Z] = {
+    new OneToOneSQLToOption(statement, rawParameters)(one)(toOne)(extractor)(isSingle)
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/RelationalSQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/RelationalSQL.scala
@@ -53,6 +53,10 @@ class OneToXSQL[A, E <: WithExtractor, Z](
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-one/one-to-many operation needs toOne(RS => Option[B]).map((A,B) => A) or toMany(RS => Option[B]).map((A,Seq(B) => A)."))
     with AllOutputDecisionsUnsupported[Z, E] {
 
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, one: WrappedResultSet => A = one): OneToXSQL[A, E, Z] = {
+    new OneToXSQL(statement, rawParameters)(one)
+  }
+
   def toOne[B](to: WrappedResultSet => B): OneToOneSQL[A, B, E, Z] = {
     new OneToOneSQL(statement, rawParameters)(one)(to.andThen((b: B) => Option(b)))((a, b) => a.asInstanceOf[Z])
   }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/SQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/SQL.scala
@@ -558,6 +558,10 @@ class SQLBatch(val statement: String, val parameters: Seq[Seq[Any]], val tags: S
     // format: ON
   }
 
+  def copy(statement: String = statement, parameters: Seq[Seq[Any]] = parameters, tags: Seq[String] = tags): SQLBatch = {
+    new SQLBatch(statement, parameters, tags)
+  }
+
 }
 
 class SQLBatchWithGeneratedKey(val statement: String, val parameters: Seq[Seq[Any]], val tags: Seq[String] = Nil)(key: Option[String]) {
@@ -578,6 +582,10 @@ class SQLBatchWithGeneratedKey(val statement: String, val parameters: Seq[Seq[An
       case _                                 => f(session)
     }
     // format: ON
+  }
+
+  def copy(statement: String = statement, parameters: Seq[Seq[Any]] = parameters, tags: Seq[String] = tags, key: Option[String] = key): SQLBatchWithGeneratedKey = {
+    new SQLBatchWithGeneratedKey(statement, parameters, tags)(key)
   }
 
 }
@@ -609,6 +617,10 @@ class SQLExecution(val statement: String, val parameters: Seq[Any], val tags: Se
     // format: ON
   }
 
+  def copy(statement: String = statement, parameters: Seq[Any] = parameters, tags: Seq[String] = tags, before: (PreparedStatement) => Unit = before, after: (PreparedStatement) => Unit = after): SQLExecution = {
+    new SQLExecution(statement, parameters, tags)(before)(after)
+  }
+
 }
 
 /**
@@ -638,6 +650,10 @@ class SQLUpdate(val statement: String, val parameters: Seq[Any], val tags: Seq[S
       session.tags(tags: _*).updateWithFilters(before, after, statement, parameters: _*)
   }
 
+  def copy(statement: String = statement, parameters: Seq[Any] = parameters, tags: Seq[String] = tags, before: (PreparedStatement) => Unit = before, after: (PreparedStatement) => Unit = after): SQLUpdate = {
+    new SQLUpdate(statement, parameters, tags)(before)(after)
+  }
+
 }
 
 /**
@@ -659,6 +675,10 @@ class SQLUpdateWithGeneratedKey(val statement: String, val parameters: Seq[Any],
       case _                                 => f(session)
     }
     // format: ON
+  }
+
+  def copy(statement: String = statement, parameters: Seq[Any] = parameters, tags: Seq[String] = tags, key: Any = key): SQLUpdateWithGeneratedKey = {
+    new SQLUpdateWithGeneratedKey(statement, parameters, tags)(key)
   }
 
 }
@@ -717,6 +737,10 @@ class SQLToTraversableImpl[A, E <: WithExtractor](
     extends SQL[A, E](statement, rawParameters)(extractor)
     with SQLToTraversable[A, E] {
 
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, extractor: WrappedResultSet => A = extractor): SQLToResult[A, E, Traversable] = {
+    new SQLToTraversableImpl[A, E](statement, rawParameters)(extractor)
+  }
+
   override protected def withParameters(params: Seq[Any]): SQLToResult[A, E, Traversable] = {
     new SQLToTraversableImpl[A, E](statement, params)(extractor)
   }
@@ -763,6 +787,10 @@ class SQLToCollectionImpl[A, E <: WithExtractor](
     extends SQL[A, E](statement, rawParameters)(extractor)
     with SQLToCollection[A, E] {
 
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, extractor: WrappedResultSet => A = extractor): SQLToCollection[A, E] = {
+    new SQLToCollectionImpl[A, E](statement, rawParameters)(extractor)
+  }
+
   override protected def withParameters(params: Seq[Any]): SQLToCollection[A, E] = {
     new SQLToCollectionImpl[A, E](statement, params)(extractor)
   }
@@ -806,6 +834,10 @@ class SQLToListImpl[A, E <: WithExtractor](
 )
     extends SQL[A, E](statement, rawParameters)(extractor)
     with SQLToList[A, E] {
+
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, extractor: WrappedResultSet => A = extractor): SQLToResult[A, E, List] = {
+    new SQLToListImpl[A, E](statement, rawParameters)(extractor)
+  }
 
   override protected def withParameters(params: Seq[Any]): SQLToList[A, E] = {
     new SQLToListImpl[A, E](statement, params)(extractor)
@@ -856,6 +888,10 @@ class SQLToOptionImpl[A, E <: WithExtractor](
 )(protected val isSingle: Boolean = true)
     extends SQL[A, E](statement, rawParameters)(extractor)
     with SQLToOption[A, E] {
+
+  def copy(statement: String = statement, rawParameters: Seq[Any] = rawParameters, extractor: WrappedResultSet => A = extractor, isSingle: Boolean = isSingle): SQLToOption[A, E] = {
+    new SQLToOptionImpl[A, E](statement, rawParameters)(extractor)(isSingle)
+  }
 
   override protected def withParameters(params: Seq[Any]): SQLToOption[A, E] = {
     new SQLToOptionImpl[A, E](statement, params)(extractor)(isSingle)


### PR DESCRIPTION
Implement `copy` method on each SQL class.

Problem:
I tried to define `copy` on some traits (`SQLToList`, `SQLToOption`, ...) but I couldn't because many concrete SQL classes inherit these traits with different primary constructor arguments.
Thus, I implemented `copy` on each concrete class, but we have to write a little bit ugly code to use it like
```scala
val sql: SQLToList[Model, HasExtractor] = withSQL { select.from... }.map(Model(m)).list
sql.asInstanceOf[SQLToListImpl].copy(statement = modify(sql.statement))
```
Is it ok, or any better solutions?

-----

(Appendix: dummy code to show the problem)
```scala
// define signature in trait
trait SQLToList[A, E] {
  def copy(
      statement: String = statement,
      rawParameters: Seq[Any] = rawParameters,
      extractor: WrappedResultSet => A = extractor
  ): SQLToList[A, E]
}

// extend the trait in concrete classes
class OneToManySQLToList(statement, rawParameters)(one)(toMany)(extractor) extends SQLToList {
  // implement concrete method with necessary arguments for this class
  def copy(
      statement: String = statement,
      rawParameters: Seq[Any] = rawParameters,
      one: WrappedResultSet => A = one,
      toMany: WrappedResultSet => Option[B] = toMany,
      extractor: (A, Seq[B]) => Z = extractor
  ): OneToManySQLToList[A, B, E, Z] = {
    new OneToManySQLToList(statement, rawParameters)(one)(toMany)(extractor)
  }
}
class OneToManies2SQLToList(statement, rawParameters)(one)(to1, to2)(extractor) extends SQLToList {
  // implement concrete method with necessary arguments for this class
  def copy(
      statement: String = statement,
      rawParameters: Seq[Any] = rawParameters,
      one: WrappedResultSet => A = one,
      to1: WrappedResultSet => Option[B] = to1,
      to2: WrappedResultSet => Option[B] = to2,
      extractor: (A, Seq[B]) => Z = extractor
  ): OneToManySQLToList[A, B, E, Z] = {
    new OneToManySQLToList(statement, rawParameters)(one)(to1, to2)(extractor)
  }
}
```
When compiling this, it occurs error which says `multiple overloaded alternatives of method copy define default arguments`