### PR TITLE
fix batchInsert method indent

### DIFF
--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
@@ -640,10 +640,10 @@ class CodeGenerator(table: Table, specifiedClassName: Option[String] = None)(imp
      * {{{
      * def batchInsert(entities: Seq[Member])(implicit session: DBSession = autoSession): Seq[Int] = {
      *   val params: Seq[Seq[(Symbol, Any)]] = entities.map(entity =>
-     *   Seq(
-     *     'id -> entity.id,
-     *     'name -> entity.name,
-     *     'birthday -> entity.birthday))
+     *     Seq(
+     *       'id -> entity.id,
+     *       'name -> entity.name,
+     *       'birthday -> entity.birthday))
      *   SQL("""insert into member (
      *     id,
      *     name,
@@ -679,12 +679,12 @@ class CodeGenerator(table: Table, specifiedClassName: Option[String] = None)(imp
         3.indent + "Seq(" + eol +
         batchInsertColumns.map(c => 4.indent + "'" + c.nameInScala.replace("`", "") + " -> entity." + c.nameInScala).mkString(comma + eol) +
         "))" + eol +
-        4.indent + "SQL(\"\"\"insert into " + table.name + "(" + eol +
-        batchInsertColumns.map(c => 4.indent + c.name.replace("`", "")).mkString(comma + eol) + eol +
-        3.indent + ")" + " values (" + eol +
-        batchInsertColumns.map(c => 4.indent + "{" + c.nameInScala.replace("`", "") + "}").mkString(comma + eol) + eol +
-        3.indent + ")\"\"\").batchByName(params: _*).apply[" + returnType + "]()" + eol +
-        2.indent + "}" + eol
+        2.indent + "SQL(\"\"\"insert into " + table.name + "(" + eol +
+        batchInsertColumns.map(c => 3.indent + c.name.replace("`", "")).mkString(comma + eol) + eol +
+        2.indent + ")" + " values (" + eol +
+        batchInsertColumns.map(c => 3.indent + "{" + c.nameInScala.replace("`", "") + "}").mkString(comma + eol) + eol +
+        2.indent + ")\"\"\").batchByName(params: _*).apply[" + returnType + "]()" + eol +
+        1.indent + "}" + eol
     }
 
     val isQueryDsl = config.template == GeneratorTemplate.queryDsl


### PR DESCRIPTION
### before

```scala
def batchInsert(entities: Seq[Issue339table])(implicit session: DBSession = autoSession): List[Int] = {
  val params: Seq[Seq[(Symbol, Any)]] = entities.map(entity =>
    Seq(
      'column1 -> entity.column1,
      'column2 -> entity.column2))
      SQL("""insert into Issue339table(
      column1,
      column2
    ) values (
      {column1},
      {column2}
    )""").batchByName(params: _*).apply[List]()
  }


```

### after

```scala
def batchInsert(entities: Seq[Issue339table])(implicit session: DBSession = autoSession): List[Int] = {
  val params: Seq[Seq[(Symbol, Any)]] = entities.map(entity =>
    Seq(
      'column1 -> entity.column1,
      'column2 -> entity.column2))
  SQL("""insert into Issue339table(
    column1,
    column2
  ) values (
    {column1},
    {column2}
  )""").batchByName(params: _*).apply[List]()
}
```