### PR TITLE
avoid NullPointerException

### DIFF
--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
@@ -157,7 +157,8 @@ class CodeGenerator(table: Table, specifiedClassName: Option[String] = None)(imp
    * Create directory to put the source code file if it does not exist yet.
    */
   def mkdirRecursively(file: File): Unit = {
-    if (!file.getParentFile.exists) mkdirRecursively(file.getParentFile)
+    val parent = file.getAbsoluteFile.getParentFile
+    if (!parent.exists) mkdirRecursively(parent)
     if (!file.exists) file.mkdir()
   }
 


### PR DESCRIPTION
```
Welcome to Scala 2.12.0 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_112).
Type in expressions for evaluation. Or try :help.

scala> new java.io.File(".")
res0: java.io.File = .

scala> res0.getParentFile
res1: java.io.File = null

scala> res0.getAbsoluteFile.getParentFile
res2: java.io.File = /Users/kenji_yoshida
```