### PR TITLE
use length instead of size

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
@@ -363,10 +363,10 @@ trait DBConnection extends LogSupport with LoanPattern {
    */
   private[this] def toSchemaAndTable(name: String): (String, String) = {
     val schema = {
-      if (name.split("\\.").size > 1) name.split("\\.").head
+      if (name.split("\\.").length > 1) name.split("\\.").head
       else null
     }
-    val table = if (name.split("\\.").size > 1) name.split("\\.")(1) else name
+    val table = if (name.split("\\.").length > 1) name.split("\\.")(1) else name
     (schema, table)
   }
 

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
@@ -160,8 +160,8 @@ case class StatementExecutor(
           case null => "null"
           case result: String =>
             loggingSQLAndTime.maxColumnSize.collect {
-              case maxSize if result.size > maxSize =>
-                "'" + result.take(maxSize) + "... (" + result.size + ")" + "'"
+              case maxSize if result.length > maxSize =>
+                "'" + result.take(maxSize) + "... (" + result.length + ")" + "'"
             }.getOrElse {
               "'" + result + "'"
             }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/metadata/Table.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/metadata/Table.scala
@@ -42,7 +42,7 @@ case class Table(
     }
     def length(str: String): Int = {
       if (str == null) 0
-      else withoutCRLF(str).map(c => if (c.toString.getBytes.size > 1) 2 else 1).sum
+      else withoutCRLF(str).map(c => if (c.toString.getBytes.length > 1) 2 else 1).sum
     }
     def take(str: String, maxLength: Int): String = {
       if (str == null) null

--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
@@ -410,7 +410,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
      */
     private[this] def toAlphabetOnly(name: String): String = {
       val _name = name.filter(c => c.isLetter && c <= 'z' || c == '_')
-      if (_name.size == 0) "x" else _name
+      if (_name.isEmpty) "x" else _name
     }
 
   }

--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/GeneratorConfig.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/GeneratorConfig.scala
@@ -21,7 +21,7 @@ case class GeneratorConfig(
 object GeneratorConfig {
   private def toProperCase(s: String): String = {
     import java.util.Locale.ENGLISH
-    if (s == null || s.trim.size == 0) ""
+    if (s == null || s.trim.isEmpty) ""
     else s.substring(0, 1).toUpperCase(ENGLISH) + s.substring(1).toLowerCase(ENGLISH)
   }
 

--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/Model.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/Model.scala
@@ -29,7 +29,7 @@ case class Model(url: String, username: String, password: String) {
       val (catalog, _schema) = {
         (schema, meta.getDatabaseProductName) match {
           case (null, _) => (null, null)
-          case (s, _) if s.size == 0 => (null, null)
+          case (s, _) if s.isEmpty => (null, null)
           case (s, "MySQL") => (s, null)
           case (s, _) => (null, s)
         }
@@ -48,7 +48,7 @@ case class Model(url: String, username: String, password: String) {
 
   def table(schema: String = null, tableName: String): Option[Table] = {
     val catalog = null
-    val _schema = if (schema == null || schema.size == 0) null else schema
+    val _schema = if (schema == null || schema.isEmpty) null else schema
     DB readOnlyWithConnection { conn =>
       val meta = conn.getMetaData
       new RSTraversable(meta.getColumns(catalog, _schema, tableName, "%"))


### PR DESCRIPTION
IntelliJ IDEA says


> Replace .size with .length on arrays and strings
>
> This inspection reports array.size and string.size calls. While such calls are legitimate, they require an additional implicit conversion to SeqLike to be made. A common use case would be calling length on arrays and strings may provide significant advantages.
>
> Before:
Array(1, 2, 3, 4).size
"this is a string".size
>
> After:
Array(1, 2, 3, 4).length
"this is a string".length



![IDEA](https://cloud.githubusercontent.com/assets/389787/20394602/709bde20-ad23-11e6-8d28-c1a0588343b2.png)
