### PR TITLE
sql.unapply

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/OneToManies2SQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/OneToManies2SQL.scala
@@ -29,9 +29,9 @@ private[scalikejdbc] trait OneToManies2Extractor[A, B1, B2, E <: WithExtractor, 
     }
   }
 
-  private[scalikejdbc] def toTraversable(session: DBSession, sql: String, params: Seq[_], extractor: (A, Seq[B1], Seq[B2]) => Z): Traversable[Z] = {
+  private[scalikejdbc] def toTraversable(session: DBSession, sql: String, params: Seq[_], zExtractor: (A, Seq[B1], Seq[B2]) => Z): Traversable[Z] = {
     session.foldLeft(statement, rawParameters: _*)(LinkedHashMap[A, (Seq[B1], Seq[B2])]())(processResultSet).map {
-      case (one, (t1, t2)) => extractor(one, t1, t2)
+      case (one, (t1, t2)) => zExtractor(one, t1, t2)
     }
   }
 
@@ -39,28 +39,28 @@ private[scalikejdbc] trait OneToManies2Extractor[A, B1, B2, E <: WithExtractor, 
 
 class OneToManies2SQL[A, B1, B2, E <: WithExtractor, Z](
   override val statement: String,
-  override private[scalikejdbc] val rawParameters: Seq[Any]
-)(one: WrappedResultSet => A)(to1: WrappedResultSet => Option[B1], to2: WrappedResultSet => Option[B2])(extractor: (A, Seq[B1], Seq[B2]) => Z)
+  override val rawParameters: Seq[Any]
+)(val one: WrappedResultSet => A)(val to1: WrappedResultSet => Option[B1], val to2: WrappedResultSet => Option[B2])(val zExtractor: (A, Seq[B1], Seq[B2]) => Z)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-many extractor(one(RS => A).toMany(RS => Option[B])) is specified, use #map((A,B) =>Z) instead."))
     with AllOutputDecisionsUnsupported[Z, E] {
 
-  def map(extractor: (A, Seq[B1], Seq[B2]) => Z): OneToManies2SQL[A, B1, B2, HasExtractor, Z] = {
-    new OneToManies2SQL(statement, rawParameters)(one)(to1, to2)(extractor)
+  def map(zExtractor: (A, Seq[B1], Seq[B2]) => Z): OneToManies2SQL[A, B1, B2, HasExtractor, Z] = {
+    new OneToManies2SQL(statement, rawParameters)(one)(to1, to2)(zExtractor)
   }
   override def toTraversable(): OneToManies2SQLToTraversable[A, B1, B2, E, Z] = {
-    new OneToManies2SQLToTraversable[A, B1, B2, E, Z](statement, rawParameters)(one)(to1, to2)(extractor)
+    new OneToManies2SQLToTraversable[A, B1, B2, E, Z](statement, rawParameters)(one)(to1, to2)(zExtractor)
   }
   override def toList(): OneToManies2SQLToList[A, B1, B2, E, Z] = {
-    new OneToManies2SQLToList[A, B1, B2, E, Z](statement, rawParameters)(one)(to1, to2)(extractor)
+    new OneToManies2SQLToList[A, B1, B2, E, Z](statement, rawParameters)(one)(to1, to2)(zExtractor)
   }
   override def toOption(): OneToManies2SQLToOption[A, B1, B2, E, Z] = {
-    new OneToManies2SQLToOption[A, B1, B2, E, Z](statement, rawParameters)(one)(to1, to2)(extractor)(true)
+    new OneToManies2SQLToOption[A, B1, B2, E, Z](statement, rawParameters)(one)(to1, to2)(zExtractor)(true)
   }
   override def toCollection: OneToManies2SQLToCollection[A, B1, B2, E, Z] = {
-    new OneToManies2SQLToCollection[A, B1, B2, E, Z](statement, rawParameters)(one)(to1, to2)(extractor)
+    new OneToManies2SQLToCollection[A, B1, B2, E, Z](statement, rawParameters)(one)(to1, to2)(zExtractor)
   }
   override def headOption(): OneToManies2SQLToOption[A, B1, B2, E, Z] = {
-    new OneToManies2SQLToOption[A, B1, B2, E, Z](statement, rawParameters)(one)(to1, to2)(extractor)(false)
+    new OneToManies2SQLToOption[A, B1, B2, E, Z](statement, rawParameters)(one)(to1, to2)(zExtractor)(false)
   }
   override def single(): OneToManies2SQLToOption[A, B1, B2, E, Z] = toOption()
   override def first(): OneToManies2SQLToOption[A, B1, B2, E, Z] = headOption()
@@ -70,10 +70,16 @@ class OneToManies2SQL[A, B1, B2, E <: WithExtractor, Z](
 
 }
 
+object OneToManies2SQL {
+  def unapply[A, B1, B2, E <: WithExtractor, Z](sqlObject: OneToManies2SQL[A, B1, B2, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A, WrappedResultSet => Option[B1], WrappedResultSet => Option[B2], (A, Seq[B1], Seq[B2]) => Z)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one, sqlObject.to1, sqlObject.to2, sqlObject.zExtractor))
+  }
+}
+
 class OneToManies2SQLToList[A, B1, B2, E <: WithExtractor, Z](
   override val statement: String,
-  override private[scalikejdbc] val rawParameters: Seq[Any]
-)(one: WrappedResultSet => A)(to1: WrappedResultSet => Option[B1], to2: WrappedResultSet => Option[B2])(extractor: (A, Seq[B1], Seq[B2]) => Z)
+  override val rawParameters: Seq[Any]
+)(val one: WrappedResultSet => A)(val to1: WrappedResultSet => Option[B1], val to2: WrappedResultSet => Option[B2])(val zExtractor: (A, Seq[B1], Seq[B2]) => Z)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-many extractor(one(RS => A).toMany(RS => Option[B1])) is specified, use #map((A,B) =>Z) instead."))
     with SQLToList[Z, E]
     with OneToManies2Extractor[A, B1, B2, E, Z] {
@@ -81,19 +87,25 @@ class OneToManies2SQLToList[A, B1, B2, E <: WithExtractor, Z](
   import GeneralizedTypeConstraintsForWithExtractor._
 
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor): List[Z] = {
-    executeQuery[List](session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor).toList)
+    executeQuery[List](session, (session: DBSession) => toTraversable(session, statement, rawParameters, zExtractor).toList)
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo1: WrappedResultSet => Option[B1] = to1
   private[scalikejdbc] def extractTo2: WrappedResultSet => Option[B2] = to2
-  private[scalikejdbc] def transform: (A, Seq[B1], Seq[B2]) => Z = extractor
+  private[scalikejdbc] def transform: (A, Seq[B1], Seq[B2]) => Z = zExtractor
+}
+
+object OneToManies2SQLToList {
+  def unapply[A, B1, B2, E <: WithExtractor, Z](sqlObject: OneToManies2SQLToList[A, B1, B2, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A, WrappedResultSet => Option[B1], WrappedResultSet => Option[B2], (A, Seq[B1], Seq[B2]) => Z)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one, sqlObject.to1, sqlObject.to2, sqlObject.zExtractor))
+  }
 }
 
 final class OneToManies2SQLToCollection[A, B1, B2, E <: WithExtractor, Z] private[scalikejdbc] (
   override val statement: String,
-  override private[scalikejdbc] val rawParameters: Seq[Any]
-)(one: WrappedResultSet => A)(to1: WrappedResultSet => Option[B1], to2: WrappedResultSet => Option[B2])(extractor: (A, Seq[B1], Seq[B2]) => Z)
+  override val rawParameters: Seq[Any]
+)(val one: WrappedResultSet => A)(val to1: WrappedResultSet => Option[B1], val to2: WrappedResultSet => Option[B2])(val zExtractor: (A, Seq[B1], Seq[B2]) => Z)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-many extractor(one(RS => A).toMany(RS => Option[B1])) is specified, use #map((A,B) =>Z) instead."))
     with SQLToCollection[Z, E]
     with OneToManies2Extractor[A, B1, B2, E, Z] {
@@ -101,19 +113,25 @@ final class OneToManies2SQLToCollection[A, B1, B2, E <: WithExtractor, Z] privat
   import GeneralizedTypeConstraintsForWithExtractor._
 
   override def apply[C[_]]()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor, cbf: CanBuildFrom[Nothing, Z, C[Z]]): C[Z] = {
-    executeQuery(session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor).to[C])
+    executeQuery(session, (session: DBSession) => toTraversable(session, statement, rawParameters, zExtractor).to[C])
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo1: WrappedResultSet => Option[B1] = to1
   private[scalikejdbc] def extractTo2: WrappedResultSet => Option[B2] = to2
-  private[scalikejdbc] def transform: (A, Seq[B1], Seq[B2]) => Z = extractor
+  private[scalikejdbc] def transform: (A, Seq[B1], Seq[B2]) => Z = zExtractor
+}
+
+object OneToManies2SQLToCollection {
+  def unapply[A, B1, B2, E <: WithExtractor, Z](sqlObject: OneToManies2SQLToCollection[A, B1, B2, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A, WrappedResultSet => Option[B1], WrappedResultSet => Option[B2], (A, Seq[B1], Seq[B2]) => Z)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one, sqlObject.to1, sqlObject.to2, sqlObject.zExtractor))
+  }
 }
 
 class OneToManies2SQLToTraversable[A, B1, B2, E <: WithExtractor, Z](
   override val statement: String,
-  override private[scalikejdbc] val rawParameters: Seq[Any]
-)(val one: WrappedResultSet => A)(to1: WrappedResultSet => Option[B1], to2: WrappedResultSet => Option[B2])(extractor: (A, Seq[B1], Seq[B2]) => Z)
+  override val rawParameters: Seq[Any]
+)(val one: WrappedResultSet => A)(val to1: WrappedResultSet => Option[B1], val to2: WrappedResultSet => Option[B2])(val zExtractor: (A, Seq[B1], Seq[B2]) => Z)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-many extractor(one(RS => A).toMany(RS => Option[B1])) is specified, use #map((A,B) =>Z) instead."))
     with SQLToTraversable[Z, E]
     with AllOutputDecisionsUnsupported[Z, E]
@@ -122,19 +140,25 @@ class OneToManies2SQLToTraversable[A, B1, B2, E <: WithExtractor, Z](
   import GeneralizedTypeConstraintsForWithExtractor._
 
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor): Traversable[Z] = {
-    executeQuery[Traversable](session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor))
+    executeQuery[Traversable](session, (session: DBSession) => toTraversable(session, statement, rawParameters, zExtractor))
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo1: WrappedResultSet => Option[B1] = to1
   private[scalikejdbc] def extractTo2: WrappedResultSet => Option[B2] = to2
-  private[scalikejdbc] def transform: (A, Seq[B1], Seq[B2]) => Z = extractor
+  private[scalikejdbc] def transform: (A, Seq[B1], Seq[B2]) => Z = zExtractor
+}
+
+object OneToManies2SQLToTraversable {
+  def unapply[A, B1, B2, E <: WithExtractor, Z](sqlObject: OneToManies2SQLToTraversable[A, B1, B2, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A, WrappedResultSet => Option[B1], WrappedResultSet => Option[B2], (A, Seq[B1], Seq[B2]) => Z)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one, sqlObject.to1, sqlObject.to2, sqlObject.zExtractor))
+  }
 }
 
 class OneToManies2SQLToOption[A, B1, B2, E <: WithExtractor, Z](
   override val statement: String,
-  override private[scalikejdbc] val rawParameters: Seq[Any]
-)(one: WrappedResultSet => A)(to1: WrappedResultSet => Option[B1], to2: WrappedResultSet => Option[B2])(extractor: (A, Seq[B1], Seq[B2]) => Z)(protected val isSingle: Boolean = true)
+  override val rawParameters: Seq[Any]
+)(val one: WrappedResultSet => A)(val to1: WrappedResultSet => Option[B1], val to2: WrappedResultSet => Option[B2])(val zExtractor: (A, Seq[B1], Seq[B2]) => Z)(val isSingle: Boolean = true)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-many extractor(one(RS => A).toMany(RS => Option[B1])) is specified, use #map((A,B) =>Z) instead."))
     with SQLToOption[Z, E]
     with AllOutputDecisionsUnsupported[Z, E]
@@ -142,11 +166,17 @@ class OneToManies2SQLToOption[A, B1, B2, E <: WithExtractor, Z](
 
   import GeneralizedTypeConstraintsForWithExtractor._
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor): Option[Z] = {
-    executeQuery[Option](session, (session: DBSession) => toSingle(toTraversable(session, statement, rawParameters, extractor)))
+    executeQuery[Option](session, (session: DBSession) => toSingle(toTraversable(session, statement, rawParameters, zExtractor)))
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo1: WrappedResultSet => Option[B1] = to1
   private[scalikejdbc] def extractTo2: WrappedResultSet => Option[B2] = to2
-  private[scalikejdbc] def transform: (A, Seq[B1], Seq[B2]) => Z = extractor
+  private[scalikejdbc] def transform: (A, Seq[B1], Seq[B2]) => Z = zExtractor
+}
+
+object OneToManies2SQLToOption {
+  def unapply[A, B1, B2, E <: WithExtractor, Z](sqlObject: OneToManies2SQLToOption[A, B1, B2, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A, WrappedResultSet => Option[B1], WrappedResultSet => Option[B2], (A, Seq[B1], Seq[B2]) => Z, Boolean)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one, sqlObject.to1, sqlObject.to2, sqlObject.zExtractor, sqlObject.isSingle))
+  }
 }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/OneToManySQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/OneToManySQL.scala
@@ -21,9 +21,9 @@ private[scalikejdbc] trait OneToManyExtractor[A, B, E <: WithExtractor, Z]
     }
   }
 
-  private[scalikejdbc] def toTraversable(session: DBSession, sql: String, params: Seq[_], extractor: (A, Seq[B]) => Z): Traversable[Z] = {
+  private[scalikejdbc] def toTraversable(session: DBSession, sql: String, params: Seq[_], zExtractor: (A, Seq[B]) => Z): Traversable[Z] = {
     session.foldLeft(statement, rawParameters: _*)(LinkedHashMap[A, (Seq[B])]())(processResultSet).map {
-      case (one, (to)) => extractor(one, to)
+      case (one, (to)) => zExtractor(one, to)
     }
   }
 
@@ -31,12 +31,12 @@ private[scalikejdbc] trait OneToManyExtractor[A, B, E <: WithExtractor, Z]
 
 class OneToManySQL[A, B, E <: WithExtractor, Z](
   override val statement: String, override val rawParameters: Seq[Any]
-)(one: WrappedResultSet => A)(toMany: WrappedResultSet => Option[B])(extractor: (A, Seq[B]) => Z)
+)(val one: WrappedResultSet => A)(val toMany: WrappedResultSet => Option[B])(val zExtractor: (A, Seq[B]) => Z)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-many extractor(one(RS => A).toMany(RS => Option[B])) is specified, use #map((A,B) =>Z) instead."))
     with AllOutputDecisionsUnsupported[Z, E] {
 
-  def map(extractor: (A, Seq[B]) => Z): OneToManySQL[A, B, HasExtractor, Z] = {
-    val q = new OneToManySQL[A, B, HasExtractor, Z](statement, rawParameters)(one)(toMany)(extractor)
+  def map(zExtractor: (A, Seq[B]) => Z): OneToManySQL[A, B, HasExtractor, Z] = {
+    val q = new OneToManySQL[A, B, HasExtractor, Z](statement, rawParameters)(one)(toMany)(zExtractor)
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
     q.tags(tags: _*)
@@ -44,7 +44,7 @@ class OneToManySQL[A, B, E <: WithExtractor, Z](
   }
 
   override def toTraversable(): OneToManySQLToTraversable[A, B, E, Z] = {
-    val q = new OneToManySQLToTraversable[A, B, E, Z](statement, rawParameters)(one)(toMany)(extractor)
+    val q = new OneToManySQLToTraversable[A, B, E, Z](statement, rawParameters)(one)(toMany)(zExtractor)
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
     q.tags(tags: _*)
@@ -52,7 +52,7 @@ class OneToManySQL[A, B, E <: WithExtractor, Z](
   }
 
   override def toList(): OneToManySQLToList[A, B, E, Z] = {
-    val q = new OneToManySQLToList[A, B, E, Z](statement, rawParameters)(one)(toMany)(extractor)
+    val q = new OneToManySQLToList[A, B, E, Z](statement, rawParameters)(one)(toMany)(zExtractor)
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
     q.tags(tags: _*)
@@ -60,7 +60,7 @@ class OneToManySQL[A, B, E <: WithExtractor, Z](
   }
 
   override def toOption(): OneToManySQLToOption[A, B, E, Z] = {
-    val q = new OneToManySQLToOption[A, B, E, Z](statement, rawParameters)(one)(toMany)(extractor)(true)
+    val q = new OneToManySQLToOption[A, B, E, Z](statement, rawParameters)(one)(toMany)(zExtractor)(true)
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
     q.tags(tags: _*)
@@ -68,7 +68,7 @@ class OneToManySQL[A, B, E <: WithExtractor, Z](
   }
 
   override def headOption(): OneToManySQLToOption[A, B, E, Z] = {
-    val q = new OneToManySQLToOption[A, B, E, Z](statement, rawParameters)(one)(toMany)(extractor)(false)
+    val q = new OneToManySQLToOption[A, B, E, Z](statement, rawParameters)(one)(toMany)(zExtractor)(false)
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
     q.tags(tags: _*)
@@ -76,7 +76,7 @@ class OneToManySQL[A, B, E <: WithExtractor, Z](
   }
 
   override def toCollection: OneToManySQLToCollection[A, B, E, Z] = {
-    val q = new OneToManySQLToCollection[A, B, E, Z](statement, rawParameters)(one)(toMany)(extractor)
+    val q = new OneToManySQLToCollection[A, B, E, Z](statement, rawParameters)(one)(toMany)(zExtractor)
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
     q.tags(tags: _*)
@@ -91,9 +91,15 @@ class OneToManySQL[A, B, E <: WithExtractor, Z](
 
 }
 
+object OneToManySQL {
+  def unapply[A, B, E <: WithExtractor, Z](sqlObject: OneToManySQL[A, B, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A, WrappedResultSet => Option[B], (A, Seq[B]) => Z)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one, sqlObject.toMany, sqlObject.zExtractor))
+  }
+}
+
 class OneToManySQLToList[A, B, E <: WithExtractor, Z](
   override val statement: String, override val rawParameters: Seq[Any]
-)(one: WrappedResultSet => A)(toMany: WrappedResultSet => Option[B])(extractor: (A, Seq[B]) => Z)
+)(val one: WrappedResultSet => A)(val toMany: WrappedResultSet => Option[B])(val zExtractor: (A, Seq[B]) => Z)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-many extractor(one(RS => A).toMany(RS => Option[B])) is specified, use #map((A,B) =>Z) instead."))
     with SQLToList[Z, E]
     with AllOutputDecisionsUnsupported[Z, E]
@@ -102,17 +108,23 @@ class OneToManySQLToList[A, B, E <: WithExtractor, Z](
   import GeneralizedTypeConstraintsForWithExtractor._
 
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor): List[Z] = {
-    executeQuery[List](session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor).toList)
+    executeQuery[List](session, (session: DBSession) => toTraversable(session, statement, rawParameters, zExtractor).toList)
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo: WrappedResultSet => Option[B] = toMany
-  private[scalikejdbc] def transform: (A, Seq[B]) => Z = extractor
+  private[scalikejdbc] def transform: (A, Seq[B]) => Z = zExtractor
+}
+
+object OneToManySQLToList {
+  def unapply[A, B, E <: WithExtractor, Z](sqlObject: OneToManySQLToList[A, B, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A, WrappedResultSet => Option[B], (A, Seq[B]) => Z)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one, sqlObject.toMany, sqlObject.zExtractor))
+  }
 }
 
 class OneToManySQLToTraversable[A, B, E <: WithExtractor, Z](
   override val statement: String, override val rawParameters: Seq[Any]
-)(one: WrappedResultSet => A)(toMany: WrappedResultSet => Option[B])(extractor: (A, Seq[B]) => Z)
+)(val one: WrappedResultSet => A)(val toMany: WrappedResultSet => Option[B])(val zExtractor: (A, Seq[B]) => Z)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-many extractor(one(RS => A).toMany(RS => Option[B])) is specified, use #map((A,B) =>Z) instead."))
     with SQLToTraversable[Z, E]
     with AllOutputDecisionsUnsupported[Z, E]
@@ -121,17 +133,23 @@ class OneToManySQLToTraversable[A, B, E <: WithExtractor, Z](
   import GeneralizedTypeConstraintsForWithExtractor._
 
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor): Traversable[Z] = {
-    executeQuery[Traversable](session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor))
+    executeQuery[Traversable](session, (session: DBSession) => toTraversable(session, statement, rawParameters, zExtractor))
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo: WrappedResultSet => Option[B] = toMany
-  private[scalikejdbc] def transform: (A, Seq[B]) => Z = extractor
+  private[scalikejdbc] def transform: (A, Seq[B]) => Z = zExtractor
+}
+
+object OneToManySQLToTraversable {
+  def unapply[A, B, E <: WithExtractor, Z](sqlObject: OneToManySQLToTraversable[A, B, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A, WrappedResultSet => Option[B], (A, Seq[B]) => Z)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one, sqlObject.toMany, sqlObject.zExtractor))
+  }
 }
 
 class OneToManySQLToCollection[A, B, E <: WithExtractor, Z](
   override val statement: String, override val rawParameters: Seq[Any]
-)(one: WrappedResultSet => A)(toMany: WrappedResultSet => Option[B])(extractor: (A, Seq[B]) => Z)
+)(val one: WrappedResultSet => A)(val toMany: WrappedResultSet => Option[B])(val zExtractor: (A, Seq[B]) => Z)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-many extractor(one(RS => A).toMany(RS => Option[B])) is specified, use #map((A,B) =>Z) instead."))
     with SQLToCollection[Z, E]
     with AllOutputDecisionsUnsupported[Z, E]
@@ -140,17 +158,23 @@ class OneToManySQLToCollection[A, B, E <: WithExtractor, Z](
   import GeneralizedTypeConstraintsForWithExtractor._
 
   override def apply[C[_]]()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor, cbf: CanBuildFrom[Nothing, Z, C[Z]]): C[Z] = {
-    executeQuery(session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor).to[C])
+    executeQuery(session, (session: DBSession) => toTraversable(session, statement, rawParameters, zExtractor).to[C])
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo: WrappedResultSet => Option[B] = toMany
-  private[scalikejdbc] def transform: (A, Seq[B]) => Z = extractor
+  private[scalikejdbc] def transform: (A, Seq[B]) => Z = zExtractor
+}
+
+object OneToManySQLToCollection {
+  def unapply[A, B, E <: WithExtractor, Z](sqlObject: OneToManySQLToCollection[A, B, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A, WrappedResultSet => Option[B], (A, Seq[B]) => Z)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one, sqlObject.toMany, sqlObject.zExtractor))
+  }
 }
 
 class OneToManySQLToOption[A, B, E <: WithExtractor, Z](
   override val statement: String, override val rawParameters: Seq[Any]
-)(one: WrappedResultSet => A)(toMany: WrappedResultSet => Option[B])(extractor: (A, Seq[B]) => Z)(protected val isSingle: Boolean = true)
+)(val one: WrappedResultSet => A)(val toMany: WrappedResultSet => Option[B])(val zExtractor: (A, Seq[B]) => Z)(val isSingle: Boolean = true)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor("one-to-many extractor(one(RS => A).toMany(RS => Option[B])) is specified, use #map((A,B) =>Z) instead."))
     with SQLToOption[Z, E]
     with AllOutputDecisionsUnsupported[Z, E]
@@ -158,10 +182,16 @@ class OneToManySQLToOption[A, B, E <: WithExtractor, Z](
 
   import GeneralizedTypeConstraintsForWithExtractor._
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor): Option[Z] = {
-    executeQuery[Option](session, (session: DBSession) => toSingle(toTraversable(session, statement, rawParameters, extractor)))
+    executeQuery[Option](session, (session: DBSession) => toSingle(toTraversable(session, statement, rawParameters, zExtractor)))
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo: WrappedResultSet => Option[B] = toMany
-  private[scalikejdbc] def transform: (A, Seq[B]) => Z = extractor
+  private[scalikejdbc] def transform: (A, Seq[B]) => Z = zExtractor
+}
+
+object OneToManySQLToOption {
+  def unapply[A, B, E <: WithExtractor, Z](sqlObject: OneToManySQLToOption[A, B, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A, WrappedResultSet => Option[B], (A, Seq[B]) => Z, Boolean)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one, sqlObject.toMany, sqlObject.zExtractor, sqlObject.isSingle))
+  }
 }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/OneToOneSQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/OneToOneSQL.scala
@@ -21,9 +21,9 @@ private[scalikejdbc] trait OneToOneExtractor[A, B, E <: WithExtractor, Z]
     }
   }
 
-  private[scalikejdbc] def toTraversable(session: DBSession, sql: String, params: Seq[_], extractor: (A, B) => Z): Traversable[Z] = {
+  private[scalikejdbc] def toTraversable(session: DBSession, sql: String, params: Seq[_], zExtractor: (A, B) => Z): Traversable[Z] = {
     session.foldLeft(statement, rawParameters: _*)(LinkedHashMap[A, Option[B]]())(processResultSet).map {
-      case (one, Some(to)) => extractor(one, to)
+      case (one, Some(to)) => zExtractor(one, to)
       case (one, None) => one.asInstanceOf[Z]
     }
   }
@@ -32,28 +32,28 @@ private[scalikejdbc] trait OneToOneExtractor[A, B, E <: WithExtractor, Z]
 
 class OneToOneSQL[A, B, E <: WithExtractor, Z](
   override val statement: String, override val rawParameters: Seq[Any]
-)(one: WrappedResultSet => A)(toOne: WrappedResultSet => Option[B])(extractor: (A, B) => Z)
+)(val one: WrappedResultSet => A)(val toOne: WrappedResultSet => Option[B])(val zExtractor: (A, B) => Z)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-one extractor(one(RS => A).toOne(RS => Option[B])) is specified, use #map((A,B) =>Z) instead."))
     with AllOutputDecisionsUnsupported[Z, E] {
 
-  def map(extractor: (A, B) => Z): OneToOneSQL[A, B, HasExtractor, Z] = {
-    new OneToOneSQL(statement, rawParameters)(one)(toOne)(extractor)
+  def map(zExtractor: (A, B) => Z): OneToOneSQL[A, B, HasExtractor, Z] = {
+    new OneToOneSQL(statement, rawParameters)(one)(toOne)(zExtractor)
   }
 
   override def toTraversable(): OneToOneSQLToTraversable[A, B, E, Z] = {
-    new OneToOneSQLToTraversable[A, B, E, Z](statement, rawParameters)(one)(toOne)(extractor)
+    new OneToOneSQLToTraversable[A, B, E, Z](statement, rawParameters)(one)(toOne)(zExtractor)
   }
   override def toList(): OneToOneSQLToList[A, B, E, Z] = {
-    new OneToOneSQLToList[A, B, E, Z](statement, rawParameters)(one)(toOne)(extractor)
+    new OneToOneSQLToList[A, B, E, Z](statement, rawParameters)(one)(toOne)(zExtractor)
   }
   override def toOption(): OneToOneSQLToOption[A, B, E, Z] = {
-    new OneToOneSQLToOption[A, B, E, Z](statement, rawParameters)(one)(toOne)(extractor)(true)
+    new OneToOneSQLToOption[A, B, E, Z](statement, rawParameters)(one)(toOne)(zExtractor)(true)
   }
   override def headOption(): OneToOneSQLToOption[A, B, E, Z] = {
-    new OneToOneSQLToOption[A, B, E, Z](statement, rawParameters)(one)(toOne)(extractor)(false)
+    new OneToOneSQLToOption[A, B, E, Z](statement, rawParameters)(one)(toOne)(zExtractor)(false)
   }
   override def toCollection: OneToOneSQLToCollection[A, B, E, Z] = {
-    new OneToOneSQLToCollection[A, B, E, Z](statement, rawParameters)(one)(toOne)(extractor)
+    new OneToOneSQLToCollection[A, B, E, Z](statement, rawParameters)(one)(toOne)(zExtractor)
   }
 
   override def single(): OneToOneSQLToOption[A, B, E, Z] = toOption()
@@ -63,9 +63,15 @@ class OneToOneSQL[A, B, E <: WithExtractor, Z](
   override def collection: OneToOneSQLToCollection[A, B, E, Z] = toCollection
 }
 
+object OneToOneSQL {
+  def unapply[A, B, E <: WithExtractor, Z](sqlObject: OneToOneSQL[A, B, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A, WrappedResultSet => Option[B], (A, B) => Z)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one, sqlObject.toOne, sqlObject.zExtractor))
+  }
+}
+
 class OneToOneSQLToTraversable[A, B, E <: WithExtractor, Z](
   override val statement: String, override private[scalikejdbc] val rawParameters: Seq[Any]
-)(one: WrappedResultSet => A)(toOne: WrappedResultSet => Option[B])(map: (A, B) => Z)
+)(val one: WrappedResultSet => A)(val toOne: WrappedResultSet => Option[B])(val zExtractor: (A, B) => Z)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-one extractor(one(RS => A).toOne(RS => Option[B])) is specified, use #map((A,B) =>Z) instead."))
     with SQLToTraversable[Z, E]
     with AllOutputDecisionsUnsupported[Z, E]
@@ -79,12 +85,18 @@ class OneToOneSQLToTraversable[A, B, E <: WithExtractor, Z](
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo: WrappedResultSet => Option[B] = toOne
-  private[scalikejdbc] def transform: (A, B) => Z = map
+  private[scalikejdbc] def transform: (A, B) => Z = zExtractor
+}
+
+object OneToOneSQLToTraversable {
+  def unapply[A, B, E <: WithExtractor, Z](sqlObject: OneToOneSQLToTraversable[A, B, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A, WrappedResultSet => Option[B], (A, B) => Z)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one, sqlObject.toOne, sqlObject.zExtractor))
+  }
 }
 
 class OneToOneSQLToList[A, B, E <: WithExtractor, Z](
   override val statement: String, override private[scalikejdbc] val rawParameters: Seq[Any]
-)(one: WrappedResultSet => A)(toOne: WrappedResultSet => Option[B])(extractor: (A, B) => Z)
+)(val one: WrappedResultSet => A)(val toOne: WrappedResultSet => Option[B])(val zExtractor: (A, B) => Z)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-one extractor(one(RS => A).toOne(RS => Option[B])) is specified, use #map((A,B) =>Z) instead."))
     with SQLToList[Z, E]
     with AllOutputDecisionsUnsupported[Z, E]
@@ -93,17 +105,23 @@ class OneToOneSQLToList[A, B, E <: WithExtractor, Z](
   import GeneralizedTypeConstraintsForWithExtractor._
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext,
     hasExtractor: ThisSQL =:= SQLWithExtractor): List[Z] = {
-    executeQuery[List](session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor).toList)
+    executeQuery[List](session, (session: DBSession) => toTraversable(session, statement, rawParameters, zExtractor).toList)
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo: WrappedResultSet => Option[B] = toOne
-  private[scalikejdbc] def transform: (A, B) => Z = extractor
+  private[scalikejdbc] def transform: (A, B) => Z = zExtractor
+}
+
+object OneToOneSQLToList {
+  def unapply[A, B, E <: WithExtractor, Z](sqlObject: OneToOneSQLToList[A, B, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A, WrappedResultSet => Option[B], (A, B) => Z)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one, sqlObject.toOne, sqlObject.zExtractor))
+  }
 }
 
 class OneToOneSQLToCollection[A, B, E <: WithExtractor, Z](
   override val statement: String, override private[scalikejdbc] val rawParameters: Seq[Any]
-)(one: WrappedResultSet => A)(toOne: WrappedResultSet => Option[B])(extractor: (A, B) => Z)
+)(val one: WrappedResultSet => A)(val toOne: WrappedResultSet => Option[B])(val zExtractor: (A, B) => Z)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-one extractor(one(RS => A).toOne(RS => Option[B])) is specified, use #map((A,B) =>Z) instead."))
     with SQLToCollection[Z, E]
     with AllOutputDecisionsUnsupported[Z, E]
@@ -112,17 +130,23 @@ class OneToOneSQLToCollection[A, B, E <: WithExtractor, Z](
   import GeneralizedTypeConstraintsForWithExtractor._
   override def apply[C[_]]()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext,
     hasExtractor: ThisSQL =:= SQLWithExtractor, cbf: CanBuildFrom[Nothing, Z, C[Z]]): C[Z] = {
-    executeQuery(session, (session: DBSession) => toTraversable(session, statement, rawParameters, extractor).to[C])
+    executeQuery(session, (session: DBSession) => toTraversable(session, statement, rawParameters, zExtractor).to[C])
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo: WrappedResultSet => Option[B] = toOne
-  private[scalikejdbc] def transform: (A, B) => Z = extractor
+  private[scalikejdbc] def transform: (A, B) => Z = zExtractor
+}
+
+object OneToOneSQLToCollection {
+  def unapply[A, B, E <: WithExtractor, Z](sqlObject: OneToOneSQLToCollection[A, B, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A, WrappedResultSet => Option[B], (A, B) => Z)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one, sqlObject.toOne, sqlObject.zExtractor))
+  }
 }
 
 class OneToOneSQLToOption[A, B, E <: WithExtractor, Z](
   override val statement: String, override private[scalikejdbc] val rawParameters: Seq[Any]
-)(one: WrappedResultSet => A)(toOne: WrappedResultSet => Option[B])(extractor: (A, B) => Z)(protected val isSingle: Boolean = true)
+)(val one: WrappedResultSet => A)(val toOne: WrappedResultSet => Option[B])(val zExtractor: (A, B) => Z)(val isSingle: Boolean = true)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-one extractor(one(RS => A).toOne(RS => Option[B])) is specified, use #map((A,B) =>Z) instead."))
     with SQLToOption[Z, E]
     with AllOutputDecisionsUnsupported[Z, E]
@@ -130,10 +154,16 @@ class OneToOneSQLToOption[A, B, E <: WithExtractor, Z](
 
   import GeneralizedTypeConstraintsForWithExtractor._
   override def apply()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor): Option[Z] = {
-    executeQuery[Option](session, (session: DBSession) => toSingle(toTraversable(session, statement, rawParameters, extractor)))
+    executeQuery[Option](session, (session: DBSession) => toSingle(toTraversable(session, statement, rawParameters, zExtractor)))
   }
 
   private[scalikejdbc] def extractOne: WrappedResultSet => A = one
   private[scalikejdbc] def extractTo: WrappedResultSet => Option[B] = toOne
-  private[scalikejdbc] def transform: (A, B) => Z = extractor
+  private[scalikejdbc] def transform: (A, B) => Z = zExtractor
+}
+
+object OneToOneSQLToOption {
+  def unapply[A, B, E <: WithExtractor, Z](sqlObject: OneToOneSQLToOption[A, B, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A, WrappedResultSet => Option[B], (A, B) => Z, Boolean)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one, sqlObject.toOne, sqlObject.zExtractor, sqlObject.isSingle))
+  }
 }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/RelationalSQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/RelationalSQL.scala
@@ -49,7 +49,7 @@ trait AllOutputDecisionsUnsupported[Z, E <: scalikejdbc.WithExtractor] extends S
  */
 class OneToXSQL[A, E <: WithExtractor, Z](
   override val statement: String, override val rawParameters: Seq[Any]
-)(one: WrappedResultSet => A)
+)(val one: WrappedResultSet => A)
     extends SQL[Z, E](statement, rawParameters)(SQL.noExtractor[Z]("one-to-one/one-to-many operation needs toOne(RS => Option[B]).map((A,B) => A) or toMany(RS => Option[B]).map((A,Seq(B) => A)."))
     with AllOutputDecisionsUnsupported[Z, E] {
 
@@ -198,6 +198,9 @@ class OneToXSQL[A, E <: WithExtractor, Z](
 }
 
 object OneToXSQL {
+  def unapply[A, E <: WithExtractor, Z](sqlObject: OneToXSQL[A, E, Z]): Option[(String, Seq[Any], WrappedResultSet => A)] = {
+    Some((sqlObject.statement, sqlObject.rawParameters, sqlObject.one))
+  }
   def handleException(e: Exception) = e match {
     case invalidColumn: InvalidColumnNameException =>
       throw new ResultSetExtractorException(


### PR DESCRIPTION
overrides #587 

After some trial-and-error, I finally gave up to provide unified interface to copy SQL in a polite way. This PR, instead, suggests to implement `unapply` method for each `SQL` class in order to enable users to implement custom `copy` functions for their own requirements. I decided to take this approach for 2 reasons.

1. It is highly improbable that we have to copy **every** SQL class in a same way. In many cases, we are going to copy just a few classes, (for example, just `SQLToList`, `SQLToOption`, `OneToManySQLToList` and `OneToManySQLToOption`).
2. We probably want to replace just one or two parameters while copying sql objects.

For these purposes, we can write a `copy` function like following:

```scala
object SQLCopyer {
  def copy[A, E](sql: SQL[A, E], newParameters: Seq[Any]): SQL[A, E] = {
    sql match {
      case SQLToListImpl(statement, _, extractor) => SQLToListImpl(statement, newParameters)(extractor)
      case SQLToOptionImpl(statement, _, extractor, isSingle) => SQLToOptionImpl(statement, newParameters)(extractor)(isSingle)
      case ... // other required types
      case _ => error("not expected")
    }
  }
}
```