### PR TITLE
Make result.name private because `name` column exists very often in real apps (fixes #570)

### DIFF
--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -11,16 +11,17 @@ import com.typesafe.tools.mima.plugin.MimaKeys.{mimaPreviousArtifacts, mimaRepor
  */
 object MimaSettings {
 
-  // The `previousVersions` must be *ALL* the previous versions to be binary compatible (e.g. Set("2.5.0", "2.5.1") for "2.5.2-SNAPSHOT").
+  // The `previousVersions` must be *ALL* the previous versions to be binary compatible (e.g. Set("3.0.0", "3.0.1") for "3.0.2-SNAPSHOT").
   //
   // The following bad scenario is the reason we must obey the rule:
   //
-  //  - your build is toward 2.5.2 release and the `previousVersions` is "2.5.0" only
-  //  - you've added new methods since 2.5.1
-  //  - you're going to remove some of the methods in 2.5.2
+  //  - your build is toward 3.0.2 release and the `previousVersions` is "3.0.0" only
+  //  - you've added new methods since 3.0.1
+  //  - you're going to remove some of the methods in 3.0.2
   //  - in this case, the incompatibility won't be detected
   //
-  val previousVersions = Set(0).map(patch => s"2.5.$patch")
+  //val previousVersions = Set(0).map(patch => s"3.0.$patch")
+  val previousVersions = Set.empty
 
   val mimaSettings = MimaPlugin.mimaDefaultSettings ++ Seq(
     mimaPreviousArtifacts := {

--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
@@ -273,9 +273,9 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
    * Table definition part SQLSyntax
    */
   case class TableDefSQLSyntax private[scalikejdbc] (
-    override val value: String, override val rawParameters: Seq[Any] = Vector()
-  )
-      extends SQLSyntax(value, rawParameters)
+    override val value: String,
+    override val rawParameters: Seq[Any] = Vector()
+  ) extends SQLSyntax(value, rawParameters)
 
   /**
    * SQLSyntax Provider
@@ -418,7 +418,9 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
   /**
    * SQLSyntax provider for column names.
    */
-  case class ColumnSQLSyntaxProvider[S <: SQLSyntaxSupport[A], A](support: S) extends SQLSyntaxProvider[A]
+  case class ColumnSQLSyntaxProvider[S <: SQLSyntaxSupport[A], A](
+    support: S
+  ) extends SQLSyntaxProvider[A]
       with AsteriskProvider {
 
     val nameConverters = support.nameConverters
@@ -455,8 +457,10 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
   /**
    * SQLSyntax Provider basic implementation.
    */
-  private[scalikejdbc] abstract class SQLSyntaxProviderCommonImpl[S <: SQLSyntaxSupport[A], A](support: S, tableAliasName: String)
-      extends SQLSyntaxProvider[A] {
+  private[scalikejdbc] abstract class SQLSyntaxProviderCommonImpl[S <: SQLSyntaxSupport[A], A](
+      support: S,
+      tableAliasName: String
+  ) extends SQLSyntaxProvider[A] {
 
     val nameConverters = support.nameConverters
     val forceUpperCase = support.forceUpperCase
@@ -475,8 +479,10 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
   /**
    * SQLSyntax provider for query parts.
    */
-  case class QuerySQLSyntaxProvider[S <: SQLSyntaxSupport[A], A](support: S, tableAliasName: String)
-      extends SQLSyntaxProviderCommonImpl[S, A](support, tableAliasName)
+  case class QuerySQLSyntaxProvider[S <: SQLSyntaxSupport[A], A](
+    support: S,
+    tableAliasName: String
+  ) extends SQLSyntaxProviderCommonImpl[S, A](support, tableAliasName)
       with ResultAllProvider
       with AsteriskProvider {
 
@@ -487,7 +493,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
 
     override def resultAll: SQLSyntax = result.*
 
-    val resultName: BasicResultNameSQLSyntaxProvider[S, A] = result.name
+    val resultName: BasicResultNameSQLSyntaxProvider[S, A] = result.nameProvider
 
     lazy val * : SQLSyntax = SQLSyntax(columns.map(c => s"${tableAliasName}.${c.value}").mkString(", "))
 
@@ -515,11 +521,13 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
   /**
    * SQLSyntax provider for result parts.
    */
-  case class ResultSQLSyntaxProvider[S <: SQLSyntaxSupport[A], A](support: S, tableAliasName: String)
-      extends SQLSyntaxProviderCommonImpl[S, A](support, tableAliasName) {
+  case class ResultSQLSyntaxProvider[S <: SQLSyntaxSupport[A], A](
+      support: S,
+      tableAliasName: String
+  ) extends SQLSyntaxProviderCommonImpl[S, A](support, tableAliasName) {
     import SQLSyntaxProvider._
 
-    val name: BasicResultNameSQLSyntaxProvider[S, A] = BasicResultNameSQLSyntaxProvider[S, A](support, tableAliasName)
+    private[scalikejdbc] val nameProvider: BasicResultNameSQLSyntaxProvider[S, A] = BasicResultNameSQLSyntaxProvider[S, A](support, tableAliasName)
 
     lazy val * : SQLSyntax = SQLSyntax(columns.map { c =>
       val name = toAliasName(c.value, support)
@@ -544,8 +552,11 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
     })
   }
 
-  case class PartialResultSQLSyntaxProvider[S <: SQLSyntaxSupport[A], A](support: S, aliasName: String, syntax: SQLSyntax)
-      extends SQLSyntaxProviderCommonImpl[S, A](support, aliasName) {
+  case class PartialResultSQLSyntaxProvider[S <: SQLSyntaxSupport[A], A](
+      support: S,
+      aliasName: String,
+      syntax: SQLSyntax
+  ) extends SQLSyntaxProviderCommonImpl[S, A](support, aliasName) {
     import SQLSyntaxProvider._
 
     private[this] lazy val cachedColumns = {
@@ -565,7 +576,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
   }
 
   /**
-   * SQLSyntax provider for result names.
+   * SQLSyntax provider for result.nameProviders.
    */
   trait ResultNameSQLSyntaxProvider[S <: SQLSyntaxSupport[A], A] extends SQLSyntaxProvider[A] {
     def * : SQLSyntax
@@ -575,10 +586,14 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
   }
 
   /**
-   * Basic Query SQLSyntax Provider for result names.
+   * Basic Query SQLSyntax Provider for result.nameProviders.
    */
-  case class BasicResultNameSQLSyntaxProvider[S <: SQLSyntaxSupport[A], A](support: S, tableAliasName: String)
-      extends SQLSyntaxProviderCommonImpl[S, A](support, tableAliasName) with ResultNameSQLSyntaxProvider[S, A] {
+  case class BasicResultNameSQLSyntaxProvider[S <: SQLSyntaxSupport[A], A](
+    support: S,
+    tableAliasName: String
+  ) extends SQLSyntaxProviderCommonImpl[S, A](support, tableAliasName)
+      with ResultNameSQLSyntaxProvider[S, A] {
+
     import SQLSyntaxProvider._
 
     lazy val * : SQLSyntax = SQLSyntax(columns.map { c =>
@@ -656,12 +671,11 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
     aliasName: String,
     delimiterForResultName: String,
     resultNames: Seq[BasicResultNameSQLSyntaxProvider[_, _]]
-  )
-      extends ResultAllProvider
+  ) extends ResultAllProvider
       with AsteriskProvider {
 
     val result: SubQueryResultSQLSyntaxProvider = SubQueryResultSQLSyntaxProvider(aliasName, delimiterForResultName, resultNames)
-    val resultName: SubQueryResultNameSQLSyntaxProvider = result.name
+    val resultName: SubQueryResultNameSQLSyntaxProvider = result.nameProvider
 
     override def resultAll: SQLSyntax = result.*
 
@@ -694,7 +708,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
       resultNames: Seq[BasicResultNameSQLSyntaxProvider[_, _]]
   ) {
 
-    def name: SubQueryResultNameSQLSyntaxProvider = SubQueryResultNameSQLSyntaxProvider(aliasName, delimiterForResultName, resultNames)
+    private[scalikejdbc] val nameProvider: SubQueryResultNameSQLSyntaxProvider = SubQueryResultNameSQLSyntaxProvider(aliasName, delimiterForResultName, resultNames)
 
     def * : SQLSyntax = SQLSyntax(resultNames.map { rn =>
       rn.namedColumns.map { c =>
@@ -761,15 +775,14 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
     aliasName: String,
     override val delimiterForResultName: String,
     underlying: BasicResultNameSQLSyntaxProvider[S, A]
-  )
-      extends SQLSyntaxProviderCommonImpl[S, A](underlying.support, aliasName)
+  ) extends SQLSyntaxProviderCommonImpl[S, A](underlying.support, aliasName)
       with AsteriskProvider {
 
     val result: PartialSubQueryResultSQLSyntaxProvider[S, A] = {
       PartialSubQueryResultSQLSyntaxProvider(aliasName, delimiterForResultName, underlying)
     }
 
-    val resultName: PartialSubQueryResultNameSQLSyntaxProvider[S, A] = result.name
+    val resultName: PartialSubQueryResultNameSQLSyntaxProvider[S, A] = result.nameProvider
 
     lazy val * : SQLSyntax = SQLSyntax(resultName.namedColumns.map { c => s"${aliasName}.${c.value}" }.mkString(", "))
 
@@ -798,13 +811,12 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
   }
 
   case class PartialSubQueryResultSQLSyntaxProvider[S <: SQLSyntaxSupport[A], A](
-    aliasName: String,
-    override val delimiterForResultName: String,
-    underlying: BasicResultNameSQLSyntaxProvider[S, A]
-  )
-      extends SQLSyntaxProviderCommonImpl[S, A](underlying.support, aliasName) {
+      aliasName: String,
+      override val delimiterForResultName: String,
+      underlying: BasicResultNameSQLSyntaxProvider[S, A]
+  ) extends SQLSyntaxProviderCommonImpl[S, A](underlying.support, aliasName) {
 
-    val name: PartialSubQueryResultNameSQLSyntaxProvider[S, A] = {
+    private[scalikejdbc] val nameProvider: PartialSubQueryResultNameSQLSyntaxProvider[S, A] = {
       PartialSubQueryResultNameSQLSyntaxProvider(aliasName, delimiterForResultName, underlying)
     }
 
@@ -834,8 +846,8 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
     aliasName: String,
     override val delimiterForResultName: String,
     underlying: BasicResultNameSQLSyntaxProvider[S, A]
-  )
-      extends SQLSyntaxProviderCommonImpl[S, A](underlying.support, aliasName) with ResultNameSQLSyntaxProvider[S, A] {
+  ) extends SQLSyntaxProviderCommonImpl[S, A](underlying.support, aliasName)
+      with ResultNameSQLSyntaxProvider[S, A] {
     import SQLSyntaxProvider._
 
     lazy val * : SQLSyntax = SQLSyntax(underlying.namedColumns.map { c =>

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -206,8 +206,7 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
             .where(sqls.toAndConditionOpt(
               accountName.map(sqls.eq(a.name, _))
             ))
-        }.map {
-          rs => Order(o, p)(rs)
+        }.map { rs => Order(o, p)(rs)
         }.list.apply()
 
         findByOptionalAccountName(Some("Alice")).size should be(4)
@@ -790,5 +789,9 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
     }
   }
 
+  it should "have result.name" in {
+    select(Product.syntax("p").result.name)
+    select(Product.column.name)
+  }
 }
 


### PR DESCRIPTION
Currently, `select(c.result.name)` cannot compile because a same named attribute which returns `BasicResultNameSQLSyntaxProvider[S, A]` exists [here](https://github.com/scalikejdbc/scalikejdbc/blob/3.0.0-M1/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala#L522).

This pull request removes `result.name` from the public APIs.

see also: 
- https://twitter.com/nazoking/status/619434904841891840 (Japanese tweet)
- https://gitter.im/scalikejdbc/ja?at=55a17e853cc28b2c216ceef1 (Japanese discussion)