### PR TITLE
Remove null patterns from DatabaseSubscription, StreamResultSetIterator

### DIFF
--- a/scalikejdbc-streams/src/main/scala/scalikejdbc/streams/StreamResultSetIterator.scala
+++ b/scalikejdbc-streams/src/main/scala/scalikejdbc/streams/StreamResultSetIterator.scala
@@ -2,10 +2,10 @@ package scalikejdbc.streams
 
 import java.io.Closeable
 import java.sql.ResultSet
-
 import scalikejdbc.{ LogSupport, ResultSetCursor, WrappedResultSet }
-
 import scala.util.control.NonFatal
+
+import scalikejdbc.streams.StreamResultSetIterator._
 
 /**
  * An iterator which handles JDBC ResultSet in the fashion of Reactive Streams.
@@ -15,11 +15,6 @@ private[streams] class StreamResultSetIterator[+A](
     extractor: WrappedResultSet => A,
     autoClose: Boolean = true
 ) extends BufferedIterator[A] with Closeable with LogSupport { self =>
-
-  private sealed trait InternalState
-  private case object NeedToPrefetchNextValue extends InternalState
-  private case object NextInvocationReady extends InternalState
-  private case object AlreadyConsumed extends InternalState
 
   private[this] var internalState: InternalState = NeedToPrefetchNextValue
   private[this] var fetchedNextValue: Option[A] = None
@@ -101,5 +96,14 @@ private[streams] class StreamResultSetIterator[+A](
       None
     }
   }
+
+}
+
+private[streams] object StreamResultSetIterator {
+
+  private sealed trait InternalState
+  private case object NeedToPrefetchNextValue extends InternalState
+  private case object NextInvocationReady extends InternalState
+  private case object AlreadyConsumed extends InternalState
 
 }

--- a/scalikejdbc-streams/src/main/scala/scalikejdbc/streams/StreamResultSetIterator.scala
+++ b/scalikejdbc-streams/src/main/scala/scalikejdbc/streams/StreamResultSetIterator.scala
@@ -16,8 +16,13 @@ private[streams] class StreamResultSetIterator[+A](
     autoClose: Boolean = true
 ) extends BufferedIterator[A] with Closeable with LogSupport { self =>
 
-  private[this] var state = 0 // 0: no data, 1: cached, 2: finished
-  private[this] var preFetchedNextValue: A = null.asInstanceOf[A]
+  private sealed trait InternalState
+  private case object NeedToPrefetchNextValue extends InternalState
+  private case object NextInvocationReady extends InternalState
+  private case object AlreadyConsumed extends InternalState
+
+  private[this] var internalState: InternalState = NeedToPrefetchNextValue
+  private[this] var fetchedNextValue: Option[A] = None
   private[this] val cursor: ResultSetCursor = new ResultSetCursor(0)
 
   // ------------------------------------
@@ -25,22 +30,28 @@ private[streams] class StreamResultSetIterator[+A](
   // ------------------------------------
 
   override def head: A = {
-    update()
-    if (state == 1) preFetchedNextValue
-    else throw new NoSuchElementException("head on empty iterator")
+    tryFetchingNextIfNeeded()
+    (internalState, fetchedNextValue) match {
+      case (NextInvocationReady, Some(nextValue)) => nextValue
+      case _ => throw new NoSuchElementException("head on empty iterator")
+    }
   }
 
   override def hasNext: Boolean = {
-    update()
-    state == 1
+    tryFetchingNextIfNeeded()
+    internalState == NextInvocationReady
   }
 
   override def next(): A = {
-    update()
-    if (state == 1) {
-      state = 0
-      preFetchedNextValue
-    } else throw new NoSuchElementException("next on empty iterator")
+    tryFetchingNextIfNeeded()
+    try {
+      (internalState, fetchedNextValue) match {
+        case (NextInvocationReady, Some(nextValue)) => nextValue
+        case _ => throw new NoSuchElementException("head on empty iterator")
+      }
+    } finally {
+      internalState = NeedToPrefetchNextValue
+    }
   }
 
   // ------------------------------------
@@ -63,27 +74,31 @@ private[streams] class StreamResultSetIterator[+A](
   // Internal APIs
   // ------------------------------------
 
-  private[this] def markedAsFinishedAndReturnNullValue(): A = {
-    state = 2
-    null.asInstanceOf[A]
-  }
-
-  private[this] def update(): Unit = {
-    if (state == 0) {
-      preFetchedNextValue = fetchNext()
-      if (state == 0) state = 1
+  private[this] def tryFetchingNextIfNeeded(): Unit = {
+    internalState match {
+      case NeedToPrefetchNextValue =>
+        fetchNext() match {
+          case None =>
+            internalState = AlreadyConsumed
+            fetchedNextValue = None
+          case nextValue =>
+            internalState = NextInvocationReady
+            fetchedNextValue = nextValue
+        }
+      case _ =>
     }
   }
 
-  private[this] def fetchNext(): A = {
+  private[this] def fetchNext(): Option[A] = {
     if (rs.next()) {
       cursor.position += 1
-      extractor.apply(WrappedResultSet(rs, cursor, cursor.position))
+      // NOTE: intentionally allowing the possibility of Some(null) here
+      Some(extractor.apply(WrappedResultSet(rs, cursor, cursor.position)))
     } else {
       if (autoClose) {
         close()
       }
-      markedAsFinishedAndReturnNullValue()
+      None
     }
   }
 


### PR DESCRIPTION
This pull request removed all null patterns from scalikejdbc-streams. These changes won't bring major impact on runtime performance (they should be ignorable enough).

cc: @yoskhdia 
