### PR TITLE
Make StreamReadySQL public

### DIFF
--- a/scalikejdbc-streams/src/main/scala/scalikejdbc/streams/StreamReadySQL.scala
+++ b/scalikejdbc-streams/src/main/scala/scalikejdbc/streams/StreamReadySQL.scala
@@ -7,7 +7,7 @@ import scalikejdbc._
  *
  * The primary constructor is intentionally hidden, use only StreamSQL object's apply method to instantiate.
  */
-private[streams] case class StreamReadySQL[A] private (underlying: SQL[A, HasExtractor]) {
+case class StreamReadySQL[A] private (private[streams] val underlying: SQL[A, HasExtractor]) {
 
   private[streams] lazy val extractor: (WrappedResultSet) => A = underlying.extractor
 


### PR DESCRIPTION
we can not explicit type when using mapper.

```scala
case class Foo(id: Int, groupId: Int)
object Foo extends SQLSyntaxSupport[Foo] {
  def streamBy(groupId: Int): StreamReadySQL[Foo] = {  // compile error, not found: type StreamReadySQL
    ???
  }
}

DB readOnlyStream {
  Foo.streamBy(1)
}
```