### PR TITLE
fix SQLSyntaxSupportCachedColumns

### DIFF
--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
@@ -172,7 +172,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
       SQLSyntaxSupportFeature.SQLSyntaxSupportLoadedColumns.remove((connectionPoolName, tableNameWithSchema))
 
       SQLSyntaxSupportFeature.SQLSyntaxSupportCachedColumns
-        .find { case (cp, tb) => cp == connectionPoolName && tb == tableNameWithSchema }
+        .find { case ((cp, tb), _) => cp == connectionPoolName && tb == tableNameWithSchema }
         .foreach {
           case (_, caches) =>
             caches.foreach { case (_, cache: TrieMap[String, SQLSyntax]) => cache.clear() }
@@ -443,7 +443,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
       cc
     }
 
-    def column(name: String): SQLSyntax = cachedColumns.getOrElse(name, {
+    def column(name: String): SQLSyntax = cachedColumns.getOrElseUpdate(name, {
       columns.find(_.value.equalsIgnoreCase(name)).map { c =>
         SQLSyntax(c.value)
       }.getOrElse {
@@ -507,7 +507,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
       cc
     }
 
-    def column(name: String): SQLSyntax = cachedColumns.getOrElse(name, {
+    def column(name: String): SQLSyntax = cachedColumns.getOrElseUpdate(name, {
       columns.find(_.value.equalsIgnoreCase(name)).map { c =>
         SQLSyntax(s"${tableAliasName}.${c.value}")
       }.getOrElse {
@@ -544,7 +544,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
       cc
     }
 
-    def column(name: String): SQLSyntax = cachedColumns.getOrElse(name, {
+    def column(name: String): SQLSyntax = cachedColumns.getOrElseUpdate(name, {
       columns.find(_.value.equalsIgnoreCase(name)).map { c =>
         val name = toAliasName(c.value, support)
         SQLSyntax(s"${tableAliasName}.${c.value} as ${name}${delimiterForResultName}${tableAliasName}")
@@ -567,7 +567,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
       cc
     }
 
-    def column(name: String): SQLSyntax = cachedColumns.getOrElse(name, {
+    def column(name: String): SQLSyntax = cachedColumns.getOrElseUpdate(name, {
       columns.find(_.value.equalsIgnoreCase(name)).map { c =>
         val name = toAliasName(c.value, support)
         SQLSyntax(s"${syntax.value} as ${name}${delimiterForResultName}${aliasName}", syntax.rawParameters)
@@ -623,7 +623,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
       cc
     }
 
-    def column(name: String): SQLSyntax = cachedColumns.getOrElse(name, {
+    def column(name: String): SQLSyntax = cachedColumns.getOrElseUpdate(name, {
       columns.find(_.value.equalsIgnoreCase(name)).map { c =>
         val name = toAliasName(c.value, support)
         SQLSyntax(s"${name}${delimiterForResultName}${tableAliasName}")
@@ -804,7 +804,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
       cc
     }
 
-    def column(name: String) = cachedColumns.getOrElse(name, {
+    def column(name: String) = cachedColumns.getOrElseUpdate(name, {
       SQLSyntax(s"${aliasName}.${underlying.column(name).value}")
     })
 
@@ -832,7 +832,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
       cc
     }
 
-    def column(name: String): SQLSyntax = cachedColumns.getOrElse(name, {
+    def column(name: String): SQLSyntax = cachedColumns.getOrElseUpdate(name, {
       underlying.namedColumns.find(_.value.equalsIgnoreCase(name)).map { nc =>
         SQLSyntax(s"${aliasName}.${nc.value} as ${nc.value}${delimiterForResultName}${aliasName}")
       }.getOrElse {
@@ -865,7 +865,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
       cc
     }
 
-    def column(name: String): SQLSyntax = cachedColumns.getOrElse(name, {
+    def column(name: String): SQLSyntax = cachedColumns.getOrElseUpdate(name, {
       underlying.columns.find(_.value.equalsIgnoreCase(name)).map { original: SQLSyntax =>
         val name = toAliasName(original.value, underlying.support)
         SQLSyntax(s"${name}${delimiterForResultName}${underlying.tableAliasName}${delimiterForResultName}${aliasName}")
@@ -886,7 +886,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
       cc
     }
 
-    def namedColumn(name: String) = cachedNamedColumns.getOrElse(name, {
+    def namedColumn(name: String) = cachedNamedColumns.getOrElseUpdate(name, {
       underlying.namedColumns.find(_.value.equalsIgnoreCase(name)).getOrElse {
         throw notFoundInColumns(aliasName, name, namedColumns.map(_.value).mkString(","))
       }

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
@@ -7,7 +7,7 @@ import org.slf4j._
 import scala.collection.concurrent.TrieMap
 import scala.util.control.NonFatal
 
-class SQLInterpolationSpec extends FlatSpec with Matchers with DBSettings with SQLInterpolation {
+class SQLInterpolationSpec extends FlatSpec with Matchers with DBSettings with SQLInterpolation with OptionValues {
 
   val logger: Logger = LoggerFactory.getLogger(classOf[SQLInterpolationSpec])
 
@@ -862,8 +862,16 @@ class SQLInterpolationSpec extends FlatSpec with Matchers with DBSettings with S
     sql.parameters should equal(Seq(123, "Alice"))
   }
 
+  it should "cache columns" in {
+    SQLSyntaxSupportFeature.SQLSyntaxSupportCachedColumns
+      .get(Order.connectionPoolName, Order.tableName).value.values.forall(_.nonEmpty) should be(true)
+  }
+
   it should "clear loaded columns" in {
     Order.clearLoadedColumns()
+    SQLSyntaxSupportFeature.SQLSyntaxSupportCachedColumns
+      .get(Order.connectionPoolName, Order.tableName).value.values.forall(_.isEmpty) should be(true)
+
     SQLSyntaxSupport.clearLoadedColumns(ConnectionPool.DEFAULT_NAME)
     SQLSyntaxSupport.clearAllLoadedColumns()
   }


### PR DESCRIPTION
`SQLSyntaxSupportCachedColumns` seems to have always empty `TrieMap[String, SQLSyntax]`.