### PR TITLE
Throw exception with invalid connectionPoolFactoryName

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ConnectionPool.scala
@@ -94,8 +94,11 @@ object ConnectionPool extends LogSupport {
 
     import scalikejdbc.JDBCUrl._
 
-    val (_factory, factoryName) = Option(settings.connectionPoolFactoryName).flatMap { name =>
-      ConnectionPoolFactoryRepository.get(name).map(f => (f, name))
+    val (_factory, factoryName) = Option(settings.connectionPoolFactoryName).map { name =>
+      ConnectionPoolFactoryRepository.get(name).map(f => (f, name)).getOrElse {
+        val message = ErrorMessage.INVALID_CONNECTION_POOL_FACTORY_NAME + "(name:" + name + ")"
+        throw new IllegalArgumentException(message)
+      }
     }.getOrElse((factory, "<default>"))
 
     // register new pool or replace existing pool

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ErrorMessage.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ErrorMessage.scala
@@ -31,4 +31,6 @@ private[scalikejdbc] object ErrorMessage {
 
   val INVALID_ONE_TO_ONE_RELATION = "one-to-one relation is expected but it seems to be a one-to-many relationship."
 
+  val INVALID_CONNECTION_POOL_FACTORY_NAME = "Invalid connection pool factory name."
+
 }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/ConnectionPoolSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/ConnectionPoolSpec.scala
@@ -118,4 +118,11 @@ class ConnectionPoolSpec extends FlatSpec with Matchers {
 
   }
 
+  it should "throw exception if invalid connectionPoolFactoryName is given" in {
+    intercept[IllegalArgumentException](
+      ConnectionPool.add('xxxx, url, user, password,
+        ConnectionPoolSettings(connectionPoolFactoryName = "invalid"))
+    )
+  }
+
 }


### PR DESCRIPTION
ConnectionPool.add silently falls back to the default ConnectionPoolFactory if wrong connectionPoolFactoryName is given, that's unfriendly and error-prone.
This fix solves the issue by letting user know with throwing an exception.

Thank you all for the hard work of maintenance!