### PR TITLE
Add AsyncAutoRollback for ScalaTest AsyncTestSuite

### DIFF
--- a/scalikejdbc-test/src/main/scala/scalikejdbc/scalatest/AsyncAutoRollback.scala
+++ b/scalikejdbc-test/src/main/scala/scalikejdbc/scalatest/AsyncAutoRollback.scala
@@ -1,0 +1,69 @@
+package scalikejdbc.scalatest
+
+import org.scalatest.FutureOutcome
+import org.scalatest.fixture.AsyncTestSuite
+import scalikejdbc._
+
+/**
+ * AutoRollback for ScalaTest
+ *
+ * {{{
+ * import org.scalatest.fixture.FlatSpec
+ * class MemberSpec extends FlatSpec with AutoRollback {
+ *   describe of "Member"
+ *   it should "create a new record" in { implicit session =>
+ *     Member.create(1, "Alice")
+ *     Member.find(1).isDefined should be(true)
+ *   }
+ * }
+ * class LegacyAccountSpec extends FlatSpec with AutoRollback {
+ *   override def db = NamedDB('db2).toDB
+ *   override def fixture(implicit session: DBSession) {
+ *     SQL("insert into legacy_accounts values ...").update.apply()
+ *   }
+ *
+ *   it should "create a new record" in { implicit session =>
+ *     LegacyAccount.create(2, "Bob")
+ *     LegacyAccount.find(2).isDefined should be(true)
+ *   }
+ * }
+ * }}}
+ */
+trait AsyncAutoRollback extends LoanPattern { self: AsyncTestSuite =>
+
+  type FixtureParam = DBSession
+
+  protected[this] def settingsProvider: SettingsProvider =
+    SettingsProvider.default
+
+  /**
+   * Creates a [[scalikejdbc.DB]] instance.
+   * @return DB instance
+   */
+  def db(): DB =
+    DB(conn = ConnectionPool.borrow(), settingsProvider = settingsProvider)
+
+  /**
+   * Prepares database for the test.
+   * @param session db session implicitly
+   */
+  def fixture(implicit session: DBSession): Unit = {}
+
+  /**
+   * Provides transactional block
+   * @param test one arg test
+   */
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val database = db()
+    database.begin()
+    database.withinTx { implicit session =>
+      fixture(session)
+    }
+    withFixture(test.toNoArgAsyncTest(database.withinTxSession())).onCompletedThen { _ =>
+      using(database) { d =>
+        d.rollbackIfActive()
+      }
+    }
+  }
+
+}

--- a/scalikejdbc-test/src/main/scala/scalikejdbc/scalatest/AsyncAutoRollback.scala
+++ b/scalikejdbc-test/src/main/scala/scalikejdbc/scalatest/AsyncAutoRollback.scala
@@ -5,26 +5,30 @@ import org.scalatest.fixture.AsyncTestSuite
 import scalikejdbc._
 
 /**
- * AutoRollback for ScalaTest
+ * AsyncAutoRollback for ScalaTest
  *
  * {{{
- * import org.scalatest.fixture.FlatSpec
- * class MemberSpec extends FlatSpec with AutoRollback {
+ * import org.scalatest.fixture.AsyncFlatSpec
+ * class MemberSpec extends AsyncFlatSpec with AsyncAutoRollback {
  *   describe of "Member"
  *   it should "create a new record" in { implicit session =>
- *     Member.create(1, "Alice")
- *     Member.find(1).isDefined should be(true)
+ *    Future {
+ *      Member.create(1, "Alice")
+ *      Member.find(1).isDefined should be(true)
+ *    }
  *   }
  * }
- * class LegacyAccountSpec extends FlatSpec with AutoRollback {
+ * class LegacyAccountSpec extends AsyncFlatSpec with AsyncAutoRollback {
  *   override def db = NamedDB('db2).toDB
  *   override def fixture(implicit session: DBSession) {
  *     SQL("insert into legacy_accounts values ...").update.apply()
  *   }
  *
  *   it should "create a new record" in { implicit session =>
- *     LegacyAccount.create(2, "Bob")
- *     LegacyAccount.find(2).isDefined should be(true)
+ *     Future {
+ *       LegacyAccount.create(2, "Bob")
+ *       LegacyAccount.find(2).isDefined should be(true)
+ *     }
  *   }
  * }
  * }}}

--- a/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/AsyncAutoRollbackSpec.scala
+++ b/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/AsyncAutoRollbackSpec.scala
@@ -8,7 +8,6 @@ import org.scalatest.fixture.AsyncFlatSpec
 import org.scalatest._
 
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
 
 trait AsyncFlatSpecWithCommonTraits extends AsyncFlatSpec with Matchers with DBSettings with PreparingTables
 

--- a/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/AsyncAutoRollbackSpec.scala
+++ b/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/AsyncAutoRollbackSpec.scala
@@ -1,0 +1,79 @@
+package scalikejdbc.scalatest
+
+import scalikejdbc._
+import org.joda.time.DateTime
+import scalikejdbc.NamedDB
+import unit._
+import org.scalatest.fixture.AsyncFlatSpec
+import org.scalatest._
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait AsyncFlatSpecWithCommonTraits extends AsyncFlatSpec with Matchers with DBSettings with PreparingTables
+
+class AsyncAutoRollbackSpec extends AsyncFlatSpecWithCommonTraits with AsyncAutoRollback {
+
+  override def fixture(implicit session: DBSession): Unit = {
+    SQL("insert into ScalaTest_members values (?, ?, ?)").bind(1, "Alice", DateTime.now).update.apply()
+    SQL("insert into ScalaTest_members values (?, ?, ?)").bind(2, "Bob", DateTime.now).update.apply()
+  }
+
+  behavior of "AsyncAutoRollbackFixture"
+
+  it should "be prepared and be able to create a new record" in { implicit session =>
+    Future {
+      ScalaTestMember.count() should equal(2)
+      ScalaTestMember.create(3, "Chris")
+      ScalaTestMember.count() should equal(3)
+    }
+  }
+
+  it should "be rolled back" in { implicit session =>
+    Future {
+      ScalaTestMember.count() should equal(2)
+    }
+  }
+
+}
+
+class NamedAsyncAutoRollbackSpec extends AsyncFlatSpecWithCommonTraits with AsyncAutoRollback {
+
+  override def db = NamedDB('db2).toDB
+
+  override def fixture(implicit session: DBSession): Unit = {
+    SQL("insert into scalatest_members2 values (?, ?, ?)").bind(1, "Alice", DateTime.now).update.apply()
+    SQL("insert into scalatest_members2 values (?, ?, ?)").bind(2, "Bob", DateTime.now).update.apply()
+  }
+
+  behavior of "Named AsyncAutoRollbackFixture"
+
+  it should "be prepared and be able to create a new record for NamedDB" in { implicit session =>
+    Future {
+      ScalaTestMember2.count() should equal(2)
+      ScalaTestMember2.create(3, "Chris")
+      ScalaTestMember2.count() should equal(3)
+    }
+  }
+
+  it should "be rolled back" in { implicit session =>
+    Future {
+      ScalaTestMember2.count() should equal(2)
+    }
+  }
+
+}
+
+class AsyncAutoRollbackWithNoArgTestFixtureSpec extends AsyncFlatSpecWithCommonTraits with AsyncAutoRollback with AsyncBufferMixin {
+
+  override def db = NamedDB('db2).toDB
+
+  behavior of "AsyncAutoRollback with NoArgTestFixture"
+
+  it should "call withFixture(NoArgTest)" in { implicit session =>
+    Future {
+      // "test" is appended in BufferMixin
+      assert(buffer.contains("test"))
+    }
+  }
+}

--- a/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/AsyncBufferMixin.scala
+++ b/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/AsyncBufferMixin.scala
@@ -1,0 +1,18 @@
+package scalikejdbc.scalatest
+
+import org.scalatest.FutureOutcome
+import org.scalatest.AsyncTestSuite
+import org.scalatest.AsyncTestSuiteMixin
+import scala.collection.mutable.ListBuffer
+
+trait AsyncBufferMixin extends AsyncTestSuiteMixin { this: AsyncTestSuite =>
+
+  val buffer = new ListBuffer[String]
+
+  abstract override def withFixture(test: NoArgAsyncTest): FutureOutcome = {
+    buffer.append("test")
+    super.withFixture(test).onCompletedThen { _ =>
+      buffer.clear()
+    }
+  }
+}


### PR DESCRIPTION
ScalaTest's AsyncTestSuite doesn't conform to the AutoRollback's selftype so I made a new version to enable the same functionality.