### PR TITLE
fix exhaustive warnings. change "sealed abstract class" and "case object"

### DIFF
--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/GeneratorConfig.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/GeneratorConfig.scala
@@ -4,7 +4,7 @@ case class GeneratorConfig(
   srcDir: String = "src/main/scala",
   testDir: String = "src/test/scala",
   packageName: String = "models",
-  template: GeneratorTemplate = GeneratorTemplate("queryDsl"),
+  template: GeneratorTemplate = GeneratorTemplate.queryDsl,
   testTemplate: GeneratorTestTemplate = GeneratorTestTemplate(""),
   lineBreak: LineBreak = LineBreak("\n"),
   caseClassOnly: Boolean = false,

--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/GeneratorTemplate.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/GeneratorTemplate.scala
@@ -1,8 +1,15 @@
 package scalikejdbc.mapper
 
-case class GeneratorTemplate(name: String)
+sealed abstract class GeneratorTemplate(val name: String) extends Product with Serializable
 
 object GeneratorTemplate {
-  val interpolation = GeneratorTemplate("interpolation")
-  val queryDsl = GeneratorTemplate("queryDsl")
+  case object interpolation extends GeneratorTemplate("interpolation")
+  case object queryDsl extends GeneratorTemplate("queryDsl")
+
+  private[this] val all = Set(interpolation, queryDsl)
+  private[this] val map: Map[String, GeneratorTemplate] =
+    all.map(t => t.name -> t).toMap
+
+  def apply(name: String): GeneratorTemplate =
+    map.getOrElse(name, sys.error(s"$name is not valid template name"))
 }


### PR DESCRIPTION
before
https://travis-ci.org/scalikejdbc/scalikejdbc/jobs/210757869#L869


```
[warn] /home/travis/build/scalikejdbc/scalikejdbc/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala:327: match may not be exhaustive.
[warn] It would fail on the following input: GeneratorTemplate(_)
[warn]       val placeHolderPart: String = config.template match {
[warn]                                            ^
[warn] /home/travis/build/scalikejdbc/scalikejdbc/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala:347: match may not be exhaustive.
[warn] It would fail on the following input: GeneratorTemplate(_)
[warn]         (config.template match {
[warn]                 ^
[warn] /home/travis/build/scalikejdbc/scalikejdbc/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala:354: match may not be exhaustive.
[warn] It would fail on the following input: GeneratorTemplate(_)
[warn]         (config.template match {
[warn]                 ^
[warn] /home/travis/build/scalikejdbc/scalikejdbc/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala:361: match may not be exhaustive.
[warn] It would fail on the following input: GeneratorTemplate(_)
[warn]         (config.template match {
[warn]                 ^
[warn] /home/travis/build/scalikejdbc/scalikejdbc/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala:413: match may not be exhaustive.
[warn] It would fail on the following input: GeneratorTemplate(_)
[warn]       val placeHolderPart: String = config.template match {
[warn]                                            ^
[warn] /home/travis/build/scalikejdbc/scalikejdbc/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala:425: match may not be exhaustive.
[warn] It would fail on the following input: GeneratorTemplate(_)
[warn]       val wherePart = config.template match {
[warn]                              ^
```