### PR TITLE
avoid java.lang.Integer constructor

### DIFF
--- a/scalikejdbc-core/src/test/scala/scalikejdbc/WrappedResultSetSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/WrappedResultSetSpec.scala
@@ -30,7 +30,7 @@ class WrappedResultSetSpec extends FlatSpec with Matchers with MockitoSugar {
     import java.net.URL
 
     val underlying: ResultSet = mock[ResultSet]
-    val (one: AnyRef, zero: AnyRef, minusOne: AnyRef) = (new java.lang.Integer(1), new java.lang.Integer(0), new java.lang.Integer(-1))
+    val (one: AnyRef, zero: AnyRef, minusOne: AnyRef) = (1: Integer, 0: Integer, -1: Integer)
     when(underlying.getObject("one")).thenReturn(one, Array[Object](): _*)
     // TODO this code doesn't work as expected, should I use ScalaMock?
     // when(underlying.getObject("zero")).thenReturn(zero, Array[Object](): _*)


### PR DESCRIPTION
http://download.java.net/java/jdk9/docs/api/java/lang/Integer.html#Integer-int-

deprecated since Java 9

```
Deprecated. It is rarely appropriate to use this constructor. The static factory valueOf(int) is generally a better choice, as it is likely to yield significantly better space and time performance.
```