### PR TITLE
s/newInstance()/getDeclaredConstructor().newInstance()

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/SQLFormatterSettings.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/SQLFormatterSettings.scala
@@ -8,7 +8,7 @@ case class SQLFormatterSettings(formatterClassName: Option[String]) extends LogS
   lazy val formatter: Option[SQLFormatter] = formatterClassName.flatMap { className =>
     try {
       val clazz = Class.forName(className)
-      Some(clazz.newInstance().asInstanceOf[SQLFormatter])
+      Some(clazz.getDeclaredConstructor().newInstance().asInstanceOf[SQLFormatter])
     } catch {
       case e: Exception =>
         log.warn("Failed to load " + className)

--- a/scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/gen/build.sbt
+++ b/scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/gen/build.sbt
@@ -29,7 +29,7 @@ TaskKey[Unit]("createTestDatabase") := {
 testOptions in Test += Tests.Setup{ loader =>
   type Initializer = {def run(url: String, username: String, password: String)}
   val setting = (scalikejdbc.mapper.SbtKeys.scalikejdbcJDBCSettings in Compile).value
-  val initializer = loader.loadClass("app.Initializer").newInstance().asInstanceOf[Initializer]
+  val initializer = loader.loadClass("app.Initializer").getDeclaredConstructor().newInstance().asInstanceOf[Initializer]
   initializer.run(setting.url, setting.username, setting.password)
 }
 


### PR DESCRIPTION
`java.lang.Class#newInstance` deprecated since Java 9

http://download.java.net/java/jdk9/docs/api/java/lang/Class.html#newInstance--

```
Deprecated. This method propagates any exception thrown by the nullary constructor, including a checked exception. Use of this method effectively bypasses the compile-time exception checking that would otherwise be performed by the compiler. The Constructor.newInstance method avoids this problem by wrapping any exception thrown by the constructor in a (checked) InvocationTargetException.
The call

 clazz.newInstance()

can be replaced by

 clazz.getDeclaredConstructor().newInstance()

The latter sequence of calls is inferred to be able to throw the additional exception types InvocationTargetException and NoSuchMethodException. Both of these exception types are subclasses of ReflectiveOperationException.
Creates a new instance of the class represented by this Class object. The class is instantiated as if by a new expression with an empty argument list. The class is initialized if it has not already been initialized.
```