### PR TITLE
add ignore settings to mapper generator

### DIFF
--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
@@ -167,14 +167,22 @@ class CodeGenerator(table: Table, specifiedClassName: Option[String] = None)(imp
   private[this] def outputModelFile =
     new File(config.srcDir + "/" + packageName.replace(".", "/") + "/" + className + ".scala")
 
+  private[this] def shouldBeSkipped: Boolean =
+    config.tableNamesToSkip.contains(table.name.toLowerCase)
+
   /**
    * Write the source code if outputFile does not exists.
    */
-  def writeModelIfNotExist(): Unit = {
+  def writeModelIfNonexistentAndUnskippable(): Boolean = {
     if (outputModelFile.exists) {
       println("\"" + packageName + "." + className + "\"" + " already exists.")
+      false
+    } else if (shouldBeSkipped) {
+      println("\"" + packageName + "." + className + "\"" + " is skipped by settings.")
+      false
     } else {
       writeModel()
+      true
     }
   }
 

--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/Generator.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/Generator.scala
@@ -3,7 +3,7 @@ package scalikejdbc.mapper
 trait Generator {
   def modelAll(): String
   def writeModel(): Unit
-  def writeModelIfNotExist(): Unit
+  def writeModelIfNonexistentAndUnskippable(): Boolean
   def writeSpec(code: Option[String]): Unit
   def writeSpecIfNotExist(code: Option[String]): Unit
   def specAll(): Option[String]

--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/GeneratorConfig.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/GeneratorConfig.scala
@@ -15,7 +15,8 @@ case class GeneratorConfig(
   tableNameToClassName: String => String = GeneratorConfig.toCamelCase,
   columnNameToFieldName: String => String = GeneratorConfig.columnNameToFieldNameBasic andThen GeneratorConfig.addSuffixIfConflict("Column"),
   returnCollectionType: ReturnCollectionType = ReturnCollectionType.List,
-  view: Boolean = false
+  view: Boolean = false,
+  tableNamesToSkip: Seq[String] = List()
 )
 
 object GeneratorConfig {


### PR DESCRIPTION
- [x] I have read the guidelines for contributing.

# ASIS
`scalikejdbc-mapper-generator` generates all tables and this behavior cannot be controled by a user.
IMO, if the user uses flyway, flyway creates a `schema_version` table but it is unnecessary.

# TOBE
Add ignore settings that contains table names(comma separated string) to the properties file, `scalikejdbc-mapper-generator` will ignore. But `GenAllForce` creates all tables.

```
generator.tableNamesToSkip=foo,bar
```