### PR TITLE
remove redundant `new`

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DBSession.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DBSession.scala
@@ -271,7 +271,7 @@ trait DBSession extends LogSupport with LoanPattern with AutoCloseable {
         rows match {
           case Nil => None
           case one :: Nil => Option(one)
-          case _ => throw new TooManyRowsException(1, rows.size)
+          case _ => throw TooManyRowsException(1, rows.size)
         }
     }
   }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/OneToOneSQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/OneToOneSQL.scala
@@ -15,7 +15,7 @@ private[scalikejdbc] trait OneToOneExtractor[A, B, E <: WithExtractor, Z]
   private[scalikejdbc] def processResultSet(oneToOne: (LinkedHashMap[A, Option[B]]), rs: WrappedResultSet): LinkedHashMap[A, Option[B]] = {
     val o = extractOne(rs)
     if (oneToOne.contains(o)) {
-      throw new IllegalRelationshipException(ErrorMessage.INVALID_ONE_TO_ONE_RELATION)
+      throw IllegalRelationshipException(ErrorMessage.INVALID_ONE_TO_ONE_RELATION)
     } else {
       oneToOne += (o -> extractTo(rs))
     }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/RelationalSQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/RelationalSQL.scala
@@ -9,7 +9,7 @@ import scala.language.higherKinds
 private[scalikejdbc] trait RelationalSQLResultSetOperations[Z] {
 
   private[scalikejdbc] def toSingle(rows: Traversable[Z]): Option[Z] = {
-    if (rows.size > 1) throw new TooManyRowsException(1, rows.size)
+    if (rows.size > 1) throw TooManyRowsException(1, rows.size)
     else rows.headOption
   }
 
@@ -203,7 +203,7 @@ object OneToXSQL {
   }
   def handleException(e: Exception) = e match {
     case invalidColumn: InvalidColumnNameException =>
-      throw new ResultSetExtractorException(
+      throw ResultSetExtractorException(
         "Failed to extract ResultSet because the specified column name (" + invalidColumn.name + ") is invalid." +
           " If you're using SQLInterpolation, you may mistake u.id for u.resultName.id."
       )

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ResultSetTraversable.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ResultSetTraversable.scala
@@ -18,7 +18,7 @@ class ResultSetTraversable(rs: ResultSet) extends Traversable[WrappedResultSet] 
     using(rs) { rs =>
       while (rs.next()) {
         cursor.position += 1
-        f.apply(new WrappedResultSet(rs, cursor, cursor.position))
+        f.apply(WrappedResultSet(rs, cursor, cursor.position))
       }
     }
   }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/WrappedResultSet.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/WrappedResultSet.scala
@@ -31,7 +31,7 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
     try {
       op
     } catch {
-      case e: Exception => throw new ResultSetExtractorException(
+      case e: Exception => throw ResultSetExtractorException(
         "Failed to retrieve value because " + e.getMessage + ". If you're using SQLInterpolation, you may mistake u.id for u.resultName.id.", Some(e)
       )
     }

--- a/scalikejdbc-core/src/test/scala/BasicUsageSpec.scala
+++ b/scalikejdbc-core/src/test/scala/BasicUsageSpec.scala
@@ -19,7 +19,7 @@ class BasicUsageSpec extends FlatSpec with Matchers with LoanPattern {
   val driverClassName = props.getProperty("driverClassName")
   Class.forName(driverClassName)
   // preparing the connection pool settings
-  val poolSettings = new ConnectionPoolSettings(initialSize = 100, maxSize = 100)
+  val poolSettings = ConnectionPoolSettings(initialSize = 100, maxSize = 100)
   // JDBC settings
   val url = props.getProperty("url")
   val user = props.getProperty("user")
@@ -317,7 +317,7 @@ class BasicUsageSpec extends FlatSpec with Matchers with LoanPattern {
           SQL("insert into  logging_sql_and_timing values (?,?)").bind(i, "id_%010d".format(i)).update.apply()
         }
 
-        GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings(
+        GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
           enabled = true,
           warningEnabled = true,
           warningLogLevel = 'INFO,

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/ActiveSessionSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/ActiveSessionSpec.scala
@@ -13,7 +13,7 @@ class ActiveSessionSpec extends FlatSpec with Matchers {
     val conn: Connection = mock(classOf[Connection])
     val tx: Option[Tx] = None
     val isReadOnly: Boolean = false
-    new ActiveSession(conn, DBConnectionAttributes(), tx, isReadOnly)
+    ActiveSession(conn, DBConnectionAttributes(), tx, isReadOnly)
   }
 
   it should "be available with inactive tx" in {
@@ -22,7 +22,7 @@ class ActiveSessionSpec extends FlatSpec with Matchers {
     val isReadOnly: Boolean = false
 
     intercept[java.lang.IllegalStateException] {
-      new ActiveSession(conn, DBConnectionAttributes(), tx, isReadOnly)
+      ActiveSession(conn, DBConnectionAttributes(), tx, isReadOnly)
     }
   }
 
@@ -35,7 +35,7 @@ class ActiveSessionSpec extends FlatSpec with Matchers {
 
     val isReadOnly: Boolean = false
 
-    new ActiveSession(conn, DBConnectionAttributes(), txOpt, isReadOnly)
+    ActiveSession(conn, DBConnectionAttributes(), txOpt, isReadOnly)
   }
 
 }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/ConnectionPoolSettingsSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/ConnectionPoolSettingsSpec.scala
@@ -11,7 +11,7 @@ class ConnectionPoolSettingsSpec extends FlatSpec with Matchers {
     val maxSize: Int = 0
     val connectionTimeoutMillis: Long = 2000L
     val validationQuery: String = ""
-    val instance = new ConnectionPoolSettings(initialSize, maxSize, connectionTimeoutMillis, validationQuery)
+    val instance = ConnectionPoolSettings(initialSize, maxSize, connectionTimeoutMillis, validationQuery)
     instance should not be null
   }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/ConnectionPoolSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/ConnectionPoolSpec.scala
@@ -21,7 +21,7 @@ class ConnectionPoolSpec extends FlatSpec with Matchers {
   Class.forName(driverClassName)
 
   it should "be available" in {
-    val poolSettings = new ConnectionPoolSettings(initialSize = 50, maxSize = 50)
+    val poolSettings = ConnectionPoolSettings(initialSize = 50, maxSize = 50)
     ConnectionPool.singleton(url, user, password, poolSettings)
 
     using(ConnectionPool.borrow()) { conn =>

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DBSessionSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DBSessionSpec.scala
@@ -255,7 +255,7 @@ class DBSessionSpec extends FlatSpec with Matchers with BeforeAndAfter with Sett
     val tableName = tableNamePrefix + "_batchInLocalTx"
     ultimately(TestUtils.deleteTable(tableName)) {
       TestUtils.initialize(tableName)
-      GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings(
+      GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
         enabled = false
       )
       val batchTime: Long = DB localTx {

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DB_SQLOperationSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DB_SQLOperationSpec.scala
@@ -542,7 +542,7 @@ class DB_SQLOperationSpec extends FlatSpec with Matchers with BeforeAndAfter wit
   }
 
   it should "solve issue #30" in {
-    GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings(
+    GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
       enabled = true,
       logLevel = 'info
     )
@@ -570,7 +570,7 @@ class DB_SQLOperationSpec extends FlatSpec with Matchers with BeforeAndAfter wit
           SQL("drop table issue30;").execute.apply()
         }
       } catch { case e: Exception => }
-      GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings()
+      GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings()
     }
   }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/EntityEqualitySpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/EntityEqualitySpec.scala
@@ -16,9 +16,9 @@ class EntityEqualitySpec extends FlatSpec with Matchers {
   }
 
   it should "be available with case classes" in {
-    val h1 = new Hoge(1, "Alice")
-    val h2 = new Hoge(1, "Alice")
-    val h3 = new Hoge(1, "Bob")
+    val h1 = Hoge(1, "Alice")
+    val h2 = Hoge(1, "Alice")
+    val h3 = Hoge(1, "Bob")
 
     (h1 == h2) should be(true)
     (h1 == h3) should be(false)

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/GlobalSettingsSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/GlobalSettingsSpec.scala
@@ -16,10 +16,10 @@ class GlobalSettingsSpec extends FlatSpec with Matchers with Settings with LogSu
         SQL("create table settings_example (id int primary key, name varchar(13) not null)")
           .execute.apply()
         1 to 20000 foreach { i =>
-          GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings()
+          GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings()
           SQL("insert into settings_example values (?,?)").bind(i, "id_%010d".format(i)).update.apply()
         }
-        GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings(
+        GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
           enabled = true,
           warningEnabled = true,
           warningLogLevel = 'INFO,
@@ -27,7 +27,7 @@ class GlobalSettingsSpec extends FlatSpec with Matchers with Settings with LogSu
         )
         SQL("select  * from settings_example").map(rs => rs.int("id")).list.apply()
       } finally {
-        GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings()
+        GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings()
         try {
           SQL("drop table settings_example").execute.apply()
         } catch { case e: Exception => }
@@ -42,7 +42,7 @@ class GlobalSettingsSpec extends FlatSpec with Matchers with Settings with LogSu
           SQL("drop table issue22").execute.apply()
         } catch { case e: Exception => }
         SQL("create table issue22 (id int primary key, created_at timestamp)").execute.apply()
-        GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings(
+        GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
           enabled = true,
           warningEnabled = true,
           warningLogLevel = 'INFO,
@@ -53,7 +53,7 @@ class GlobalSettingsSpec extends FlatSpec with Matchers with Settings with LogSu
         SQL("insert into issue22 values (?,?)").bind(11, Option(DateTime.now)).update.apply()
         SQL("insert into issue22 values (?,?)").bind(12, Option(new java.util.Date)).update.apply()
       } finally {
-        GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings()
+        GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings()
         try {
           SQL("drop table issue22").execute.apply()
         } catch { case e: Exception => }
@@ -62,7 +62,7 @@ class GlobalSettingsSpec extends FlatSpec with Matchers with Settings with LogSu
   }
 
   it should "support singleLineMode logging" in {
-    GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings(
+    GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
       enabled = true,
       singleLineMode = true,
       logLevel = 'ERROR
@@ -76,7 +76,7 @@ class GlobalSettingsSpec extends FlatSpec with Matchers with Settings with LogSu
         SQL("create table issue118 (id int primary key, created_at timestamp)").execute.apply()
         SQL("insert into issue118 values (?,?)").bind(1, DateTime.now).update.apply()
       } finally {
-        GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings()
+        GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings()
         try {
           SQL("drop table issue118").execute.apply()
         } catch { case e: Exception => }
@@ -214,10 +214,10 @@ class GlobalSettingsSpec extends FlatSpec with Matchers with Settings with LogSu
         SQL("create table logging_stacktrace (id int primary key, name varchar(13) not null)").execute.apply()
 
         1 to 20000 foreach { i =>
-          GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings()
+          GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings()
           SQL("insert into logging_stacktrace values (?,?)").bind(i, "id_%010d".format(i)).update.apply()
         }
-        GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings(
+        GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
           enabled = true,
           logLevel = 'WARN,
           printUnprocessedStackTrace = true,
@@ -226,7 +226,7 @@ class GlobalSettingsSpec extends FlatSpec with Matchers with Settings with LogSu
         SQL("select  * from logging_stacktrace").map(rs => rs.int("id")).list.apply()
 
       } finally {
-        GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings()
+        GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings()
         try SQL("drop table logging_stacktrace").execute.apply()
         catch { case e: Exception => }
       }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/IllegalRelationshipExceptionSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/IllegalRelationshipExceptionSpec.scala
@@ -8,7 +8,7 @@ class IllegalRelationshipExceptionSpec extends FlatSpec with Matchers {
 
   it should "be available" in {
     val message = "foo"
-    val exception = new IllegalRelationshipException(message)
+    val exception = IllegalRelationshipException(message)
     exception should not be null
   }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/InvalidColumnNameExceptionSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/InvalidColumnNameExceptionSpec.scala
@@ -8,7 +8,7 @@ class InvalidColumnNameExceptionSpec extends FlatSpec with Matchers {
 
   it should "be available" in {
     val message = "foo"
-    val exception = new InvalidColumnNameException(message)
+    val exception = InvalidColumnNameException(message)
     exception should not be null
   }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/JDBCSettingsSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/JDBCSettingsSpec.scala
@@ -11,7 +11,7 @@ class JDBCSettingsSpec extends FlatSpec with Matchers {
     val user: String = ""
     val password: String = ""
     val driverName: String = ""
-    val instance = new JDBCSettings(url, user, password, driverName)
+    val instance = JDBCSettings(url, user, password, driverName)
     instance should not be null
   }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/NameBindingSQLValidatorSettingsSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/NameBindingSQLValidatorSettingsSpec.scala
@@ -9,7 +9,7 @@ class NameBindingSQLValidatorSettingsSpec extends FlatSpec with Matchers {
 
   it should "be available" in {
     val ignoredParams: IgnoredParamsValidation = null
-    val instance = new NameBindingSQLValidatorSettings(ignoredParams)
+    val instance = NameBindingSQLValidatorSettings(ignoredParams)
     instance should not be null
   }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/NamedAutoSessionSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/NamedAutoSessionSpec.scala
@@ -10,7 +10,7 @@ class NamedAutoSessionSpec extends FlatSpec with Matchers {
 
   it should "be available" in {
     val name: Any = null
-    val instance = new NamedAutoSession(name)
+    val instance = NamedAutoSession(name)
     instance should not be null
   }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/ResultSetExtractorExceptionSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/ResultSetExtractorExceptionSpec.scala
@@ -9,7 +9,7 @@ class ResultSetExtractorExceptionSpec extends FlatSpec with Matchers {
   it should "be available" in {
     val message = "foo"
     val e = Some(new RuntimeException)
-    val exception = new ResultSetExtractorException(message, e)
+    val exception = ResultSetExtractorException(message, e)
     exception should not be null
   }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
@@ -18,7 +18,7 @@ class SQLInterpolationSpec extends FlatSpec with Matchers with LogSupport with L
   val password = props.getProperty("password")
 
   Class.forName(driverClassName)
-  val poolSettings = new ConnectionPoolSettings(initialSize = 50, maxSize = 50)
+  val poolSettings = ConnectionPoolSettings(initialSize = 50, maxSize = 50)
   ConnectionPool.singleton(url, user, password, poolSettings)
 
   case class Group(id: Int, websiteUrl: Option[String], members: Seq[User] = Nil)

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/TooManyRowsExceptionSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/TooManyRowsExceptionSpec.scala
@@ -9,7 +9,7 @@ class TooManyRowsExceptionSpec extends FlatSpec with Matchers {
   it should "be available" in {
     val expected: Int = 0
     val actual: Int = 0
-    val instance = new TooManyRowsException(expected, actual)
+    val instance = TooManyRowsException(expected, actual)
     instance should not be null
   }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/WrappedResultSetSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/WrappedResultSetSpec.scala
@@ -13,7 +13,7 @@ class WrappedResultSetSpec extends FlatSpec with Matchers with MockitoSugar {
   it should "be available" in {
     val underlying: ResultSet = null
     val cursor: ResultSetCursor = new ResultSetCursor(0)
-    val instance = new WrappedResultSet(underlying, cursor, cursor.position)
+    val instance = WrappedResultSet(underlying, cursor, cursor.position)
     instance should not be null
   }
 
@@ -39,7 +39,7 @@ class WrappedResultSetSpec extends FlatSpec with Matchers with MockitoSugar {
     when(underlying.getObject("str")).thenReturn("abc", Array[Object](): _*)
 
     val cursor: ResultSetCursor = new ResultSetCursor(0)
-    val rs = new WrappedResultSet(underlying, cursor, cursor.position)
+    val rs = WrappedResultSet(underlying, cursor, cursor.position)
 
     {
       val res1: sqlArray = rs.array("foo")

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/cpcontext/ConnectionPoolContextSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/cpcontext/ConnectionPoolContextSpec.scala
@@ -164,7 +164,7 @@ trait DefaultSettings {
 
 trait InMemoryDB {
   Class.forName("org.h2.Driver")
-  implicit val context: ConnectionPoolContext = new MultipleConnectionPoolContext(
+  implicit val context: ConnectionPoolContext = MultipleConnectionPoolContext(
     'CPContextWithAutoSessionSpec -> CommonsConnectionPoolFactory.apply("jdbc:h2:mem:CPContextWithAutoSessionSpec", "", "")
   )
   NamedDB('CPContextWithAutoSessionSpec) localTx { implicit session =>

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/metadata/ColumnSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/metadata/ColumnSpec.scala
@@ -16,7 +16,7 @@ class ColumnSpec extends FlatSpec with Matchers {
     val isAutoIncrement: Boolean = false
     val description: String = ""
     val defaultValue: String = ""
-    val instance = new Column(name, typeCode, typeName, size, isRequired, isPrimaryKey, isAutoIncrement, description, defaultValue)
+    val instance = Column(name, typeCode, typeName, size, isRequired, isPrimaryKey, isAutoIncrement, description, defaultValue)
     instance should not be null
   }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/metadata/ForeignKeySpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/metadata/ForeignKeySpec.scala
@@ -10,7 +10,7 @@ class ForeignKeySpec extends FlatSpec with Matchers {
     val name: String = ""
     val foreignColumnName: String = ""
     val foreignTableName: String = ""
-    val instance = new ForeignKey(name, foreignColumnName, foreignTableName)
+    val instance = ForeignKey(name, foreignColumnName, foreignTableName)
     instance should not be null
   }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/metadata/TableSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/metadata/TableSpec.scala
@@ -13,7 +13,7 @@ class TableSpec extends FlatSpec with Matchers {
     val columns: List[Column] = Nil
     val foreignKeys: List[ForeignKey] = Nil
     val indices: List[Index] = Nil
-    val instance = new Table(name, schema, description, columns, foreignKeys, indices)
+    val instance = Table(name, schema, description, columns, foreignKeys, indices)
     instance should not be null
   }
 


### PR DESCRIPTION
I have removed (all?) redundant new keyword in the `scalikejdbc-core` module.