### PR TITLE
add cross join support in query DSL

### DIFF
--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
@@ -405,6 +405,16 @@ trait QueryDSLFeature { self: SQLInterpolationFeature with SQLSyntaxSupportFeatu
     def rightJoin(table: Option[TableAsAliasSQLSyntax]): SelectSQLBuilder[A] =
       table.map(rightJoin) getOrElse copy(ignoreOnClause = true)
 
+    def crossJoin(table: TableAsAliasSQLSyntax): SelectSQLBuilder[A] = this.copy(
+      sql = sqls"${sql} cross join ${table}",
+      resultAllProviders = appendResultAllProvider(table, resultAllProviders),
+      ignoreOnClause = false
+    )
+
+    // if table is none, this join part will be skipped
+    def crossJoin(table: Option[TableAsAliasSQLSyntax]): SelectSQLBuilder[A] =
+      table.map(crossJoin) getOrElse copy(ignoreOnClause = true)
+
     def on(onClause: SQLSyntax): SelectSQLBuilder[A] = {
       if (ignoreOnClause) this.copy(ignoreOnClause = false)
       else this.copy(sql = sqls"${sql} on ${onClause}", ignoreOnClause = false)

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -183,6 +183,19 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
         cookieOrders(1).product.isEmpty should be(false)
         cookieOrders(1).account.isEmpty should be(false)
 
+        // cross join query
+        val ordersAndProducts = withSQL {
+          select
+            .from(Order as o)
+            .crossJoin(Product as p)
+        }.map(Order(o, p)).list.apply()
+
+        val productNum = withSQL(select.from(Product as p)).map(Product(p)).list.apply().size
+        val orderNum = withSQL(select.from(Order as o)).map(Order(o)).list.apply().size
+        ordersAndProducts.size should equal(productNum * orderNum)
+        ordersAndProducts.head.id should equal(11)
+        ordersAndProducts.head.productId should equal(1)
+
         // dynamic query
 
         def findCookieOrder(accountRequired: Boolean) = withSQL {


### PR DESCRIPTION
# Abstract
fix #525
I lack knowledge of QueryDSL business logics, so it may break...

# Known Issue
When the `on` clause added to after `crossJoin`, it will throw RuntimeException (it is not type safe).