### PR TITLE
Update Reactive Streams v1.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val _organization = "org.scalikejdbc"
 // published dependency version
 lazy val _slf4jApiVersion = "1.7.25"
 lazy val _typesafeConfigVersion = "1.3.1"
-lazy val _reactiveStreamsVersion = "1.0.0"
+lazy val _reactiveStreamsVersion = "1.0.1-RC1"
 
 // internal only
 lazy val _logbackVersion = "1.2.3"

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val _organization = "org.scalikejdbc"
 // published dependency version
 lazy val _slf4jApiVersion = "1.7.25"
 lazy val _typesafeConfigVersion = "1.3.1"
-lazy val _reactiveStreamsVersion = "1.0.1-RC1"
+lazy val _reactiveStreamsVersion = "1.0.1-RC2"
 
 // internal only
 lazy val _logbackVersion = "1.2.3"

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val _organization = "org.scalikejdbc"
 // published dependency version
 lazy val _slf4jApiVersion = "1.7.25"
 lazy val _typesafeConfigVersion = "1.3.1"
-lazy val _reactiveStreamsVersion = "1.0.1-RC2"
+lazy val _reactiveStreamsVersion = "1.0.1"
 
 // internal only
 lazy val _logbackVersion = "1.2.3"

--- a/scalikejdbc-streams/src/test/scala/somewhere/DatabasePublisherSpec.scala
+++ b/scalikejdbc-streams/src/test/scala/somewhere/DatabasePublisherSpec.scala
@@ -47,7 +47,7 @@ class DatabasePublisherSpec
     val subscriber: SyncSubscriber[Int] = new SyncSubscriber[Int] {
       private[this] val consumedCount = new AtomicInteger(0)
 
-      override def foreach(element: Int): Boolean = {
+      override def whenNext(element: Int): Boolean = {
         val consumed = consumedCount.incrementAndGet()
         log.info(s"foreach element: $element, consumed: $consumed")
         true
@@ -77,7 +77,7 @@ class DatabasePublisherSpec
     val actualElements = new ListBuffer[Int]
     val consumedCountPromise: Promise[ListBuffer[Int]] = Promise[ListBuffer[Int]]()
     val subscriber: SyncSubscriber[Int] = new SyncSubscriber[Int] {
-      override def foreach(element: Int): Boolean = {
+      override def whenNext(element: Int): Boolean = {
         actualElements += element
         log.info(s"foreach element: $element")
         true
@@ -110,7 +110,7 @@ class DatabasePublisherSpec
     val subscriber: SyncSubscriber[Int] = new SyncSubscriber[Int] {
       private[this] val consumedCount = new AtomicInteger(0)
 
-      override def foreach(element: Int): Boolean = {
+      override def whenNext(element: Int): Boolean = {
         val consumed = consumedCount.incrementAndGet()
         log.info(s"foreach element: $element, consumed: $consumed")
         true

--- a/scalikejdbc-streams/src/test/scala/somewhere/DatabasePublisherTckTest.scala
+++ b/scalikejdbc-streams/src/test/scala/somewhere/DatabasePublisherTckTest.scala
@@ -113,7 +113,8 @@ class DatabasePublisherTckTest
 
 object DatabasePublisherTckTest {
 
-  val environment = new TestEnvironment(150L, false)
+  val timeoutMillis = 150L
+  val environment = new TestEnvironment(timeoutMillis, timeoutMillis, false)
 
   case class User(id: Int)
 


### PR DESCRIPTION
Release notes:
https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.1-RC1/RELEASE-NOTES.md
Changes:
https://github.com/reactive-streams/reactive-streams-jvm/compare/v1.0.0...v1.0.1-RC1

Reactive Streams is now v1.0.1 RC1.
I will update the GA version after it is released.