### PR TITLE
Add single-character arrow → operator support, in addition to the ascii arrow ->

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
@@ -199,6 +199,8 @@ class SQLSyntax private[scalikejdbc] (val value: String, private[scalikejdbc] va
 
   def -> [A](value: A)(implicit ev: ParameterBinderFactory[A]): (SQLSyntax, ParameterBinder) = (this, ev(value))
   def -> (value: ParameterBinder): (SQLSyntax, ParameterBinder) = (this, value)
+  @inline def → [A](value: A)(implicit ev: ParameterBinderFactory[A]): (SQLSyntax, ParameterBinder) = ->(value)
+  @inline def → (value: ParameterBinder): (SQLSyntax, ParameterBinder) = ->(value)
 }
 
 /**

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
@@ -484,4 +484,13 @@ class SQLSyntaxSpec extends FlatSpec with Matchers {
          /""".stripMargin('/').statement.replaceAll("""\\r\\n""", """\n""") should equal("a =\n?\n")
   }
 
+  it should "create a name->parameterBinder pair" in {
+    val p: (SQLSyntax, ParameterBinder) = SQLSyntax("name") -> "paramValue"
+    p._2.asInstanceOf[ParameterBinderWithValue].value should equal("paramValue")
+  }
+
+  it should "create a name→parameterBinder pair" in {
+    val p: (SQLSyntax, ParameterBinder) = SQLSyntax("name") → "paramValue"
+    p._2.asInstanceOf[ParameterBinderWithValue].value should equal("paramValue")
+  }
 }


### PR DESCRIPTION
This is very useful for projects that have automatic reformatting set up that
turns -> into →

This is what happens on my project. I write a block of code like this:
```scala
      withSQL {
        insert.into(Token).namedValues(
          Token.column.deviceToken -> token.deviceToken,
          Token.column.userId -> token.userId,
          Token.column.deviceId -> token.deviceId,
          Token.column.lastAccessedAt -> token.lastAccessedAt,
          Token.column.createdAt -> token.createdAt
        )
      }.update.apply()
```

That compiles and works, but after the auto-formatting in sbt kicks in, it turns into:
```scala
      withSQL {
        insert.into(Token).namedValues(
          Token.column.deviceToken → token.deviceToken,
          Token.column.userId → token.userId,
          Token.column.deviceId → token.deviceId,
          Token.column.lastAccessedAt → token.lastAccessedAt,
          Token.column.createdAt → token.createdAt
        )
      }.update.apply()
```
which doesn't even compile.

By adding extra definitions for → that delegate to the current definitions, this reformatted version compiles and works just like the original version using ->.

I've marked them as @inline to avoid any extra overhead.