### PR TITLE
use def instead of lazy val

### DIFF
--- a/scalikejdbc-streams/src/main/scala/scalikejdbc/streams/DatabaseSubscription.scala
+++ b/scalikejdbc-streams/src/main/scala/scalikejdbc/streams/DatabaseSubscription.scala
@@ -34,7 +34,7 @@ private[streams] class DatabaseSubscription[A](
   /**
    * Stream ready SQL object.
    */
-  private lazy val sql: StreamReadySQL[A] = publisher.sql
+  private def sql: StreamReadySQL[A] = publisher.sql
 
   /**
    * A volatile variable to enforce the happens-before relationship when executing something in a synchronous action context.

--- a/scalikejdbc-streams/src/main/scala/scalikejdbc/streams/StreamReadySQL.scala
+++ b/scalikejdbc-streams/src/main/scala/scalikejdbc/streams/StreamReadySQL.scala
@@ -15,9 +15,9 @@ case class StreamReadySQL[A] private (
 
   private[streams] lazy val extractor: (WrappedResultSet) => A = underlying.extractor
 
-  private[streams] lazy val statement: String = underlying.statement
-  private[streams] lazy val rawParameters: Seq[Any] = underlying.rawParameters
-  private[streams] lazy val parameters: Seq[Any] = underlying.parameters
+  private[streams] def statement: String = underlying.statement
+  private[streams] def rawParameters: Seq[Any] = underlying.rawParameters
+  private[streams] def parameters: Seq[Any] = underlying.parameters
 
   private[streams] lazy val fetchSize: Option[Int] = underlying.fetchSize
   private[streams] lazy val tags: Seq[String] = underlying.tags


### PR DESCRIPTION
I think there is no benefit following pattern

```scala
class A(val x)

class B(y: A) {
  lazy val z = y.x
}
```