### PR TITLE
make ThreadLocalDB#create strict

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ThreadLocalDB.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ThreadLocalDB.scala
@@ -15,7 +15,7 @@ object ThreadLocalDB {
    * @param conn
    * @return
    */
-  def create(conn: => Connection): DB = {
+  def create(conn: Connection): DB = {
     _db.value = DB(conn, DBConnectionAttributes(), SettingsProvider.default)
     _db.value
   }


### PR DESCRIPTION
because `scalikejdbc.DB.apply` is strict

https://github.com/scalikejdbc/scalikejdbc/blob/3.0.1/scalikejdbc-core/src/main/scala/scalikejdbc/DB.scala#L61