### PR TITLE
Bump Scala version from 2.12.2 to 2.12.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 scala:
   - 2.10.6
   - 2.11.11
-  - 2.12.2
+  - 2.12.3
 
 jdk:
   - oraclejdk8
@@ -49,18 +49,18 @@ matrix:
     #  env: SCALIKEJDBC_DATABASE="mysql" SBT_1_BUILD=true
     #  script:
     #  - echo "sbt.version=0.13.16-M1" > project/build.properties
-    #  - sbt '++ 2.12.2' root211/publishLocal '++ 2.11.11' root211/publishLocal '++ 2.10.6' publishLocal
+    #  - sbt '++ 2.12.3' root211/publishLocal '++ 2.11.11' root211/publishLocal '++ 2.10.6' publishLocal
     #  - find ./scalikejdbc-mapper-generator/src/sbt-test/ -name build.properties | xargs rm
-    #  - sbt '++ 2.12.2' "project mapper-generator" "^^ 1.0.0-RC2" scripted
+    #  - sbt '++ 2.12.3' "project mapper-generator" "^^ 1.0.0-RC2" scripted
     - scala: scripted-test
       env: SCALIKEJDBC_DATABASE="mysql"
     - scala: scripted-test
       env: SCALIKEJDBC_DATABASE="postgresql"
     - scala: scripted-test
       env: SCALIKEJDBC_DATABASE="h2"
-    - scala: 2.12.2
+    - scala: 2.12.3
       env: SCALIKEJDBC_DATABASE="h2"
-    - scala: 2.12.2
+    - scala: 2.12.3
       env: SCALIKEJDBC_DATABASE="hsqldb"
     - scala: 2.13.0-M1
       env: SCALIKEJDBC_DATABASE="mysql"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16-RC1
+sbt.version=0.13.16

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16-RC1

--- a/sandbox/build.sbt
+++ b/sandbox/build.sbt
@@ -1,6 +1,6 @@
 scalikejdbcSettings
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.3"
 lazy val scalikejdbcVersion = scalikejdbc.ScalikejdbcBuildInfo.version
 resolvers ++= Seq(
   "Sonatype releases"  at "https://oss.sonatype.org/content/repositories/releases",

--- a/sandbox/project/build.properties
+++ b/sandbox/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16-RC1
+sbt.version=0.13.16

--- a/sandbox/project/build.properties
+++ b/sandbox/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.16-RC1

--- a/scripts/release_2.12.sh
+++ b/scripts/release_2.12.sh
@@ -3,14 +3,14 @@
 cd `dirname $0`/..
 rm -rf */target
 
-sbt 'set scalaVersion := "2.12.2"' \
+sbt 'set scalaVersion := "2.12.3"' \
   clean \
-  "project core" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project config" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project interpolation-macro" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project interpolation" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project library" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project streams" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project syntax-support-macro" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project test" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project mapper-generator-core" 'set scalaVersion := "2.12.2"' publishSigned
+  "project core" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project config" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project interpolation-macro" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project interpolation" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project library" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project streams" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project syntax-support-macro" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project test" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project mapper-generator-core" 'set scalaVersion := "2.12.3"' publishSigned

--- a/scripts/release_all.sh
+++ b/scripts/release_all.sh
@@ -3,17 +3,17 @@
 cd `dirname $0`/..
 rm -rf */target
 
-sbt 'set scalaVersion := "2.12.2"' \
+sbt 'set scalaVersion := "2.12.3"' \
   clean \
-  "project core" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project config" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project interpolation-macro" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project interpolation" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project library" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project streams" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project syntax-support-macro" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project test" 'set scalaVersion := "2.12.2"' publishSigned \
-  "project mapper-generator-core" 'set scalaVersion := "2.12.2"' publishSigned \
+  "project core" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project config" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project interpolation-macro" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project interpolation" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project library" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project streams" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project syntax-support-macro" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project test" 'set scalaVersion := "2.12.3"' publishSigned \
+  "project mapper-generator-core" 'set scalaVersion := "2.12.3"' publishSigned \
   'set scalaVersion := "2.11.11"' \
   clean \
   "project core" 'set scalaVersion := "2.11.11"' publishSigned \

--- a/travis.sh
+++ b/travis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ ${TRAVIS_SCALA_VERSION} = "scripted-test" ]]; then
-  sbt '++ 2.12.2' root211/publishLocal '++ 2.11.11' root211/publishLocal '++ 2.10.6' publishLocal checkScalariform &&
+  sbt '++ 2.12.3' root211/publishLocal '++ 2.11.11' root211/publishLocal '++ 2.10.6' publishLocal checkScalariform &&
   sbt -J-XX:+CMSClassUnloadingEnabled -J-Xmx512M -J-Xms512M mapper-generator/scripted
 else
   sbt ++${TRAVIS_SCALA_VERSION} "project root211" test:compile checkScalariform testSequential


### PR DESCRIPTION
This pull request bumps patch versions for:
- Scala lang (2.12.2 -> 2.12.3)
  - https://github.com/scala/scala/releases/tag/v2.12.3
- sbt (0.13.15 -> 0.13.16-RC1)
  - https://github.com/sbt/sbt/releases/tag/v0.13.16
