### PR TITLE
Fix toOptionalOne to wrap value with Option.

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/RelationalSQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/RelationalSQL.scala
@@ -57,8 +57,8 @@ class OneToXSQL[A, E <: WithExtractor, Z](
     new OneToOneSQL(statement, rawParameters)(one)(to.andThen((b: B) => Option(b)))((a, b) => a.asInstanceOf[Z])
   }
 
-  def toOptionalOne[B](to: WrappedResultSet => Option[B]): OneToOneSQL[A, B, E, Z] = {
-    new OneToOneSQL(statement, rawParameters)(one)(to)((a, b) => a.asInstanceOf[Z])
+  def toOptionalOne[B](to: WrappedResultSet => Option[B]): OneToOneSQL[A, Option[B], E, Z] = {
+    new OneToOneSQL(statement, rawParameters)(one)(to.andThen((maybeB: Option[B]) => Option(maybeB)))((a, maybeB) => a.asInstanceOf[Z])
   }
 
   def toMany[B](to: WrappedResultSet => Option[B]): OneToManySQL[A, B, E, Z] = {

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/RelationalSQLSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/RelationalSQLSpec.scala
@@ -98,7 +98,7 @@ class RelationalSQLSpec extends FlatSpec with Matchers with BeforeAndAfter with 
               " on u.group_id = g.id where u.id = 7")
               .one(rs => User(rs.intOpt("u_id").getOrElse(0), rs.intOpt("u_group_id").getOrElse(0), None))
               .toOptionalOne(rs => rs.intOpt("g_id").map(id => Group(id, rs.string("g_name"))))
-              .map((u: User, g: Group) => u.copy(group = Some(g)))
+              .map((u: User, g: Option[Group]) => u.copy(group = g))
               .list.apply()
 
             users.size should equal(1)
@@ -113,7 +113,7 @@ class RelationalSQLSpec extends FlatSpec with Matchers with BeforeAndAfter with 
               " on u.group_id = g.id where u.id = 7")
               .one(rs => User(rs.intOpt("u_id").getOrElse(0), rs.intOpt("u_group_id").getOrElse(0), None))
               .toOptionalOne(rs => rs.intOpt("g_id").map(id => Group(id, rs.string("g_name"))))
-              .map((u: User, g: Group) => u.copy(group = Some(g)))
+              .map((u: User, g: Option[Group]) => u.copy(group = g))
               .collection[Vector]()
 
             users.size should equal(1)

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
@@ -593,7 +593,7 @@ class SQLInterpolationSpec extends FlatSpec with Matchers with DBSettings with S
           """
               .one(Customer(sq(c).resultName))
               .toOptionalOne(rs => rs.intOpt(cg.resultName.id).map(id => CustomerGroup(id, rs.string(cg.resultName.name))))
-              .map { (c, cg) => c.copy(group = Some(cg)) }
+              .map { (c, cg) => c.copy(group = cg) }
               .list
               .apply()
 
@@ -612,7 +612,7 @@ class SQLInterpolationSpec extends FlatSpec with Matchers with DBSettings with S
                 .orderBy(sq(c).id)
             }.one(Customer(sq(c).resultName))
               .toOptionalOne(rs => rs.intOpt(cg.resultName.id).map(id => CustomerGroup(id, rs.string(cg.resultName.name))))
-              .map { (c, cg) => c.copy(group = Some(cg)) }
+              .map { (c, cg) => c.copy(group = cg) }
               .list
               .apply()
 
@@ -636,7 +636,7 @@ class SQLInterpolationSpec extends FlatSpec with Matchers with DBSettings with S
           """
               .one(rs => Customer(rs.int(sq(c).resultName.id), rs.string(sq(c).resultName.name)))
               .toOptionalOne(rs => rs.intOpt(cg.resultName.id).map(id => CustomerGroup(id, rs.string(cg.resultName.name))))
-              .map { (c, cg) => c.copy(group = Some(cg)) }
+              .map { (c, cg) => c.copy(group = cg) }
               .traversable
               .apply()
 
@@ -660,7 +660,7 @@ class SQLInterpolationSpec extends FlatSpec with Matchers with DBSettings with S
           """
               .one(rs => Customer(rs.int(sq(c).resultName.id), rs.string(sq(c).resultName.name)))
               .toOptionalOne(rs => rs.intOpt(cg.resultName.id).map(id => CustomerGroup(id, rs.string(cg.resultName.name))))
-              .map { (c, cg) => c.copy(group = Some(cg)) }
+              .map { (c, cg) => c.copy(group = cg) }
               .single
               .apply()
 


### PR DESCRIPTION
The code in http://scalikejdbc.org/documentation/one-to-x.html does not pass comile.

Here is a sample code.
```scala
import scalikejdbc._

object OneToOptionalOneTest {

  object Group extends SQLSyntaxSupport[Group] {
    override val tableName = "groups"

    def apply(g: SyntaxProvider[Group])(rs: WrappedResultSet): Group = apply(g.resultName)(rs)

    def apply(g: ResultName[Group])(rs: WrappedResultSet): Group = new Group(rs.get(g.id), rs.get(g.name))
  }

  object Owner extends SQLSyntaxSupport[Owner] {
    override val tableName = "owners"

    def apply(m: SyntaxProvider[Owner])(rs: WrappedResultSet): Owner = apply(m.resultName)(rs)

    def apply(m: ResultName[Owner])(rs: WrappedResultSet): Owner =
      new Owner(rs.get(m.id), rs.get(m.name))

    def opt(m: SyntaxProvider[Owner])(rs: WrappedResultSet): Option[Owner] =
      rs.longOpt(m.resultName.id).map(_ => Owner(m)(rs))
  }


  //The code below is in http://scalikejdbc.org/documentation/one-to-x.html

  case class Owner(id: Long, name: String)

  case class Group(id: Long, name: String,
                   ownerId: Option[Long] = None, owner: Option[Owner] = None)

  val (g, o) = (Group.syntax, Owner.syntax)

  val groups: Seq[Group] =
    withSQL {
      select.from(Group as g).leftJoin(Owner as o).on(g.ownerId, o.id)
    }
      .one(Group(g))
      .toOptionalOne(Owner.opt(o))
      .map { (group, owner) => group.copy(owner = owner) }
      .list
      .apply()

  // The code above is in http://scalikejdbc.org/documentation/one-to-x.html
}
```

When I compile above code with scalikejdbc 3.1.0,  I get compile error below
```shell
sbt:one-to-optional-one> compile
[info] Compiling 1 Scala source to /Users/katainaka/Desktop/one-to-optional-one/target/scala-2.12/classes ...
[error] /Users/katainaka/Desktop/one-to-optional-one/src/main/scala/Main.scala:41:51: type mismatch;
[error]  found   : OneToOptionalOneTest.Owner
[error]  required: Option[OneToOptionalOneTest.Owner]
[error]       .map { (group, owner) => group.copy(owner = owner) }
[error]                                                   ^
[error] one error found
[error] (compile:compileIncremental) Compilation failed
[error] Total time: 1 s, completed 2017/10/11 12:46:18
```

The document says the type of argment of map in OneToOneSQL should be `(A, Optional[B]) => Z`,
but actually it's type is `(A, B) => Z`.
In addition when `Z` is not a type which `A` can cast to, it's looks that If `B` is absent, a runtime error occurs.

This PR fixes this problem.

If the way to fix this is wrong or something is wrong, please close this PR.