### PR TITLE
fix namedColumn

### DIFF
--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
@@ -706,7 +706,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
 
     def column(name: String): SQLSyntax = cachedColumns.getOrElseUpdate(name, {
       resultNames.find(rn => rn.namedColumns.exists(_.value.equalsIgnoreCase(name))).map { rn =>
-        SQLSyntax(s"${aliasName}.${rn.column(name)} as ${rn.column(name)}${delimiterForResultName}${aliasName}")
+        SQLSyntax(s"${aliasName}.${rn.namedColumn(name).value} as ${rn.namedColumn(name).value}${delimiterForResultName}${aliasName}")
       }.getOrElse {
         val registeredNames = resultNames.map { rn => rn.namedColumns.map(_.value).mkString(",") }.mkString(",")
         throw new InvalidColumnNameException(ErrorMessage.INVALID_COLUMN_NAME + s" (name: ${name}, registered names: ${registeredNames})")
@@ -831,8 +831,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
     import SQLSyntaxProvider._
 
     lazy val * : SQLSyntax = SQLSyntax(underlying.namedColumns.map { c =>
-      val name = toAliasName(c.value, underlying.support)
-      s"${name}${delimiterForResultName}${aliasName}"
+      s"${c.value}${delimiterForResultName}${aliasName}"
     }.mkString(", "))
 
     override lazy val columns: Seq[SQLSyntax] = underlying.namedColumns.map { c => SQLSyntax(s"${c.value}${delimiterForResultName}${aliasName}") }


### PR DESCRIPTION
Before:

```
scala> import scalikejdbc._
scala> case class Member(id: Long, groupId: Long)
scala> object Member extends SQLSyntaxSupport[Member] { override val columnNames = Seq("id", "group_id") }
scala> val m = Member.syntax("m")
scala> val s = SubQuery.syntax("s").include(m)
scala> s.result.column("gi_on_m")  // scalikejdbc.InvalidColumnNameException: Invalid column name. (name: m.gi_on_m, registered names: id,group_id)
scala> s(m).resultName.*           // SQLSyntax(value: iom_on_s, gom_on_s, parameters: List())
```

After:

```
scala> import scalikejdbc._
scala> case class Member(id: Long, groupId: Long)
scala> object Member extends SQLSyntaxSupport[Member] { override val columnNames = Seq("id", "group_id") }
scala> val m = Member.syntax("m")
scala> val s = SubQuery.syntax("s").include(m)
scala> s.result.column("gi_on_m")    // SQLSyntax(value: s.gi_on_m as gi_on_m_on_s, parameters: List())
scala> s(m).resultName.*             // SQLSyntax(value: i_on_m_on_s, gi_on_m_on_s, parameters: List())
```
