### PR TITLE
Update Reactive Streams v1.0.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val _organization = "org.scalikejdbc"
 // published dependency version
 lazy val _slf4jApiVersion = "1.7.25"
 lazy val _typesafeConfigVersion = "1.3.2"
-lazy val _reactiveStreamsVersion = "1.0.1"
+lazy val _reactiveStreamsVersion = "1.0.2"
 
 // internal only
 lazy val _logbackVersion = "1.2.3"


### PR DESCRIPTION
Release Note:
http://www.reactive-streams.org/announce-1.0.2
Changes:
https://github.com/reactive-streams/reactive-streams-jvm/compare/v1.0.1...v1.0.2

```
* Specification
  * Glossary term added for Thread-safe
  * No breaking/semantical changes
  * Rule clarifications
* Interfaces
  * No changes
* Technology Compatibility Kit (TCK)
  * Improved coverage
    * Supports Publishers/Processors which do coordinated emission.
  * Improved JavaDoc
```

It is bin-incompatible with 1.0.0 & 1.0.1 .