### PR TITLE
Add "true" and "false" in Build-in Binders

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/Binders.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/Binders.scala
@@ -89,6 +89,7 @@ object Binders {
     case null => null
     case b: java.lang.Boolean => b
     case b: Boolean => b.asInstanceOf[java.lang.Boolean]
+    case s: String if s == "false" || s == "true" => s.toBoolean
     case s: String => {
       try s.toInt != 0
       catch { case e: NumberFormatException => s.nonEmpty }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/TypeBinderSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/TypeBinderSpec.scala
@@ -162,4 +162,12 @@ class TypeBinderSpec extends FlatSpec with Matchers with MockitoSugar with UnixT
     implicitly[TypeBinder[Option[java.net.URL]]].apply(rs, 1) should be(None)
   }
 
+  it should "handle result values of type java.lang.Boolean" in {
+    val rs: ResultSet = mock[ResultSet]
+    when(rs.getObject("boolean")).thenReturn("true", Array[Object](): _*)
+    when(rs.getObject(1)).thenReturn("false", Array[Object](): _*)
+    implicitly[TypeBinder[Boolean]].apply(rs, "boolean") should be(true)
+    implicitly[TypeBinder[Boolean]].apply(rs, 1) should be(false)
+  }
+
 }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/WrappedResultSetSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/WrappedResultSetSpec.scala
@@ -124,6 +124,8 @@ class WrappedResultSetSpec extends FlatSpec with Matchers with MockitoSugar {
       val res2: java.lang.Boolean = rs.nullableBoolean(0)
       val res3: Option[scala.Boolean] = rs.booleanOpt("foo")
       val res4: Option[scala.Boolean] = rs.booleanOpt(0)
+      when(underlying.getObject("boolean")).thenReturn("true", Array[Object](): _*)
+      when(underlying.getObject(1)).thenReturn("false", Array[Object](): _*)
       res1 should be(null)
       res2 should be(null)
       res3.isDefined should be(false)
@@ -135,6 +137,8 @@ class WrappedResultSetSpec extends FlatSpec with Matchers with MockitoSugar {
       rs.boolean("zero") should be(false)
       rs.boolean("minusOne") should be(true)
       rs.boolean("str") should be(true)
+      rs.boolean("boolean") should be(true)
+      rs.boolean(1) should be(false)
     }
 
     {


### PR DESCRIPTION
Dear Developers

I am using [scalikejdbc-bigquery](https://github.com/ocadaruma/scalikejdbc-bigquery). version is 0.0.7. Then I happened a problem that boolean value false become true. the following is a sample code.

### build.sbt

``` build.sbt
lazy val root = (project in file("."))
  .settings(
    name := "MyProject",
    scalaVersion := "2.11.12"
  )

libraryDependencies ++= Seq(
  "com.mayreh" %% "scalikejdbc-bigquery" % "0.0.7",
  "com.google.cloud" % "google-cloud-bigquery" % "0.30.0-beta",
  "org.scalikejdbc" %% "scalikejdbc" % "3.0.0" // specify scalikejdbc version you want. 
)
```

### Main.scala

```
import com.google.auth.oauth2.GoogleCredentials
import com.google.cloud.bigquery.{BigQueryOptions, DatasetId}
import scalikejdbc._
import scalikejdbc.bigquery._
import java.io.FileInputStream

object Main extends App {
  // instantiate BigQuery service and DatsetId
  val credentials = GoogleCredentials.fromStream(new FileInputStream("/path/to/key.json"))
  val bigQuery = BigQueryOptions.newBuilder()
    .setCredentials(credentials)
    .setProjectId("your-gcp-project-id")
    .build()
    .getService

    val dataset = DatasetId.of("your-gcp-project-id", "your-dataset")

    // build query by QueryDSL then execute
    val executor = new QueryExecutor(bigQuery, QueryConfig())

    case class Hoge(
      id: Int,
      status: Boolean
    )

    object Hoge extends SQLSyntaxSupport[Hoge] {
      override val columns = Seq("id", "status")

      val h = this.syntax("h")

      def apply(rs: WrappedResultSet): Hoge = apply(rs, h.resultName)
      def apply(rs: WrappedResultSet, rn: ResultName[Hoge]): Hoge = new Hoge(
        id = rs.get[Int](rn.id),
        status = rs.get[Boolean](rn.status))
    }

    import Hoge._

    val response = bq {
      selectFrom(Hoge in dataset as h)
        .where.eq(h.id, 1)
    }.map(Hoge(_)).single.run(executor)

    val rs = response.result
    println(if (rs.get.status) "True" else "False")

}
```

### Table hoge

#### Schema

|  |  |
| --- | --- |
| id | INTEGER | REQUIRED |
| status | BOOLEAN | REQUIRED |

| Row | id | status |
| --- | --- | --- |
| 1 | 1 | false |
| 2 | 2 | true |

### TSV file

I used tsv file to create table hoge.

```
1	false
2	true
```

This PR is an implementation to solve the problem. It is the solution that I was able to find.

I know that does not occur problem if changing the `rs.get[Boolean](rn.status)` to `rs.getBoolean(rn.status)`. But, I use `autoConstruct`. `autoConstruct` use `get`.