### PR TITLE
Custom table types for column names introspection

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
@@ -387,7 +387,7 @@ trait DBConnection extends LogSupport with LoanPattern with AutoCloseable {
    * @param tableNamePattern table name pattern (with schema optionally)
    * @return table information
    */
-  def getTableNames(tableNamePattern: String = "%", tableTypes: Array[String] = Array("TABLE", "VIEW")): List[String] = {
+  def getTableNames(tableNamePattern: String = "%", tableTypes: Array[String] = DBConnection.tableTypes): List[String] = {
     readOnlyWithConnection { conn =>
       val meta = conn.getMetaData
       getSchemaAndTableName(meta, tableNamePattern.replaceAll("\\*", "%"), tableTypes).map {
@@ -423,7 +423,7 @@ trait DBConnection extends LogSupport with LoanPattern with AutoCloseable {
   /**
    * Returns all the column names on the matched table name
    */
-  def getColumnNames(tableName: String, tableTypes: Array[String] = Array("TABLE", "VIEW")): List[String] = {
+  def getColumnNames(tableName: String, tableTypes: Array[String] = DBConnection.tableTypes): List[String] = {
     readOnlyWithConnection { conn =>
       val meta = conn.getMetaData
       getSchemaAndTableName(meta, tableName, tableTypes).map {
@@ -439,7 +439,7 @@ trait DBConnection extends LogSupport with LoanPattern with AutoCloseable {
    * @param table table name (with schema optionally)
    * @return table information
    */
-  def getTable(table: String, tableTypes: Array[String] = Array("TABLE", "VIEW")): Option[Table] = {
+  def getTable(table: String, tableTypes: Array[String] = DBConnection.tableTypes): Option[Table] = {
     readOnlyWithConnection { conn =>
       val meta = conn.getMetaData
 
@@ -461,7 +461,7 @@ trait DBConnection extends LogSupport with LoanPattern with AutoCloseable {
    * @param tableTypes target table types
    * @return table information
    */
-  private[this] def _getTable(meta: DatabaseMetaData, schema: String, table: String, tableTypes: Array[String] = Array("TABLE", "VIEW")): Option[Table] = {
+  private[this] def _getTable(meta: DatabaseMetaData, schema: String, table: String, tableTypes: Array[String] = DBConnection.tableTypes): Option[Table] = {
     val tableList = new RSTraversable(meta.getTables(null, schema, table, tableTypes)).map {
       rs => (rs.string("TABLE_SCHEM"), rs.string("TABLE_NAME"), rs.string("REMARKS"))
     }
@@ -551,7 +551,7 @@ trait DBConnection extends LogSupport with LoanPattern with AutoCloseable {
    * @param tableTypes table types
    * @return table name list
    */
-  def showTables(tableNamePattern: String = "%", tableTypes: Array[String] = Array("TABLE", "VIEW")): String = {
+  def showTables(tableNamePattern: String = "%", tableTypes: Array[String] = DBConnection.tableTypes): String = {
     getTableNames(tableNamePattern, tableTypes).mkString("\n")
   }
 
@@ -596,4 +596,13 @@ trait DBConnection extends LogSupport with LoanPattern with AutoCloseable {
       .orElse(_getSchemaAndTableName(meta, tablePattern.toLowerCase(en), tableTypes))
   }
 
+}
+
+object DBConnection {
+
+  /**
+   * Default table types used for metadata introspection.
+   * See [[java.sql.DatabaseMetaData#getTableTypes]] for details.
+   */
+  val tableTypes = Array("TABLE", "VIEW")
 }

--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
@@ -154,7 +154,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
     def columns: Seq[String] = {
       if (columnNames.isEmpty) {
         SQLSyntaxSupportFeature.SQLSyntaxSupportLoadedColumns.getOrElseUpdate((connectionPoolName, tableNameWithSchema), {
-          NamedDB(connectionPoolName, settings).getColumnNames(tableNameWithSchema).map(_.toLowerCase(en)) match {
+          NamedDB(connectionPoolName, settings).getColumnNames(tableNameWithSchema, tableTypes).map(_.toLowerCase(en)) match {
             case Nil => throw new IllegalStateException(
               "No column found for " + tableName + ". If you use NamedDB, you must override connectionPoolName.")
             case cs => cs
@@ -181,6 +181,11 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
      * If you prefer columnNames than columns, override this method to customize.
      */
     def columnNames: Seq[String] = Nil
+
+    /**
+     * If you need some exotic table types like `MATERIALIZED VIEW` from PostgreSQL, override this method.
+     */
+    def tableTypes: Array[String] = DBConnection.tableTypes
 
     /**
      * True if you need forcing upper column names in SQL.


### PR DESCRIPTION
I've faced with the issue that can't use PostgreSQL's materialized views with scalikejdbc as far as it doesn't try to extract that table type from `DatabaseMetaData` so can't find column names. Yes, I still can override `scalikejdbc.SQLSyntaxSupportFeature.SQLSyntaxSupport#columnNames` but it looks a bit ugly when I have more than two or three columns. Seems this PR solves my problem in a pretty enough way.