### PR TITLE
fix sqlString to print not param type but param value

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
@@ -152,7 +152,7 @@ case class StatementExecutor(
             case Some(p) => normalize(p)
             case p: String => p
             case p: java.util.Date => p.toSqlTimestamp.toString
-            case _ =>
+            case p =>
               param.getClass().getCanonicalName match {
                 case "org.joda.time.DateTime" =>
                   param.asInstanceOf[{ def toDate: java.util.Date }].toDate.toSqlTimestamp.toString
@@ -163,7 +163,7 @@ case class StatementExecutor(
                 case "org.joda.time.LocalTime" =>
                   val millis = param.asInstanceOf[{ def toDateTimeToday: { def getMillis: Long } }].toDateTimeToday.getMillis
                   new java.sql.Time(millis)
-                case p => p
+                case _ => p
               }
           }
         }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/StatementExecutorSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/StatementExecutorSpec.scala
@@ -3,6 +3,7 @@ package scalikejdbc
 import org.scalatest._
 import org.scalatest.mockito.MockitoSugar
 import java.sql.PreparedStatement
+import scala.reflect.runtime.{ universe => ru }
 
 class StatementExecutorSpec extends FlatSpec with Matchers with MockitoSugar {
 
@@ -21,9 +22,11 @@ class StatementExecutorSpec extends FlatSpec with Matchers with MockitoSugar {
     val template: String = "select id, name from members where id = ? and name = ?"
     val params: Seq[Any] = Seq(1, "name1")
     val instance = new StatementExecutor(underlying, template, DBConnectionAttributes(), params)
-    val m = instance.getClass.getDeclaredMethod("sqlString$lzycompute")
-    m.setAccessible(true)
-    m.invoke(instance) should equal("select id, name from members where id = 1 and name = 'name1'")
+    val runtimeMirror = ru.runtimeMirror(instance.getClass.getClassLoader)
+    val instanceMirror = runtimeMirror.reflect(instance)
+    val method = ru.typeOf[StatementExecutor].member(ru.newTermName("sqlString")).asMethod
+    val m = instanceMirror.reflectMethod(method)
+    m.apply() should equal("select id, name from members where id = 1 and name = 'name1'")
   }
 
 }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/StatementExecutorSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/StatementExecutorSpec.scala
@@ -1,9 +1,10 @@
 package scalikejdbc
 
 import org.scalatest._
+import org.scalatest.mockito.MockitoSugar
 import java.sql.PreparedStatement
 
-class StatementExecutorSpec extends FlatSpec with Matchers {
+class StatementExecutorSpec extends FlatSpec with Matchers with MockitoSugar {
 
   behavior of "StatementExecutor"
 
@@ -13,6 +14,16 @@ class StatementExecutorSpec extends FlatSpec with Matchers {
     val params: Seq[Any] = Nil
     val instance = new StatementExecutor(underlying, template, DBConnectionAttributes(), params)
     instance should not be null
+  }
+
+  it should "print sql string" in {
+    val underlying: PreparedStatement = mock[PreparedStatement]
+    val template: String = "select id, name from members where id = ? and name = ?"
+    val params: Seq[Any] = Seq(1, "name1")
+    val instance = new StatementExecutor(underlying, template, DBConnectionAttributes(), params)
+    val m = instance.getClass.getDeclaredMethod("sqlString$lzycompute")
+    m.setAccessible(true)
+    m.invoke(instance) should equal("select id, name from members where id = 1 and name = 'name1'")
   }
 
 }


### PR DESCRIPTION
* before
```sql
insert into emp_DBObjectSpec47824_singleInAutoCommitBlock (id, name) values ('java.lang.Integer', 'name1')
insert into emp_DBObjectSpec47824_singleInAutoCommitBlock (id, name) values ('java.lang.Integer', 'name2')
select id from emp_DBObjectSpec47824_singleInAutoCommitBlock where id = 'java.lang.Integer'
```

* after
```sql
insert into emp_DBObjectSpec66015_singleInAutoCommitBlock (id, name) values (1, 'name1')
insert into emp_DBObjectSpec66015_singleInAutoCommitBlock (id, name) values (2, 'name2')
select id from emp_DBObjectSpec66015_singleInAutoCommitBlock where id = 1
```