### PR TITLE
add plus method for SQLSyntax

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
@@ -34,6 +34,7 @@ class SQLSyntax private[scalikejdbc] (val value: String, private[scalikejdbc] va
   }
 
   def append(syntax: SQLSyntax): SQLSyntax = sqls"${this} ${syntax}"
+  def +(syntax: SQLSyntax): SQLSyntax = this.append(syntax)
 
   def groupBy(columns: SQLSyntax*): SQLSyntax = {
     if (columns.isEmpty) this else sqls"${this} group by ${csv(columns: _*)}"

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/interpolation/SQLSyntaxSpec.scala
@@ -20,6 +20,14 @@ class SQLSyntaxSpec extends FlatSpec with Matchers {
     s.parameters should equal(Seq(123))
   }
 
+  it should "have #+" in {
+    val baseSql = sqls"select id from users"
+    val whereSql = SQLSyntax.eq(sqls"where id", 234)
+    val s = baseSql + whereSql
+    s.value should equal("select id from users  where id = ?")
+    s.parameters should equal(Seq(234))
+  }
+
   it should "have #join" in {
     val s = SQLSyntax.join(Seq(sqls"id", sqls"name"), sqls"and")
     s.value should equal("id and name")


### PR DESCRIPTION
Related issue is https://github.com/scalikejdbc/scalikejdbc/issues/774

If you need plus method for SQLSyntax, this pull request is merged maybe. But you don't like a redundancy space, this pull request should be closed. Please, take a look at a test case.