### PR TITLE
avoid NPEs when constrcting sql string

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
@@ -147,6 +147,7 @@ case class StatementExecutor(
         @annotation.tailrec
         def normalize(param: Any): Any = {
           param match {
+            case null => null
             case ParameterBinder(v) => normalize(v)
             case None => null
             case Some(p) => normalize(p)


### PR DESCRIPTION
When using the dsl to insert data, `None` gets at some point converted to
`null` causing NPEs.
The null was hadled correctly before 3.2.x, when joda time was in the
other cases.

I see the NPEs when I do things like:

```scala
withSQL {
  insert.into(MyEntity)
    .namedValues(
      column.id -> "my-id",
      column.value -> None
    )
}.execute().apply()
```