### PR TITLE
[3.2.x backport] #838 Add more support for logging global settings to scalikejdbc-config

### DIFF
--- a/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfigReader.scala
+++ b/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfigReader.scala
@@ -97,24 +97,28 @@ trait TypesafeConfigReader extends NoEnvPrefix with LogSupport { self: TypesafeC
   }
 
   def loadGlobalSettings(): Unit = {
-    for {
-      globalConfig <- readConfig(config, envPrefix + "scalikejdbc.global")
-      logConfig <- readConfig(globalConfig, "loggingSQLAndTime")
-    } {
-      val enabled = readBoolean(logConfig, "enabled").getOrElse(false)
-      if (enabled) {
-        val default = LoggingSQLAndTimeSettings()
-        GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
-          enabled = enabled,
-          singleLineMode = readBoolean(logConfig, "singleLineMode").getOrElse(default.singleLineMode),
-          printUnprocessedStackTrace = readBoolean(logConfig, "printUnprocessedStackTrace").getOrElse(default.printUnprocessedStackTrace),
-          stackTraceDepth = readInt(logConfig, "stackTraceDepth").getOrElse(default.stackTraceDepth),
-          logLevel = readString(logConfig, "logLevel").map(v => Symbol(v)).getOrElse(default.logLevel),
-          warningEnabled = readBoolean(logConfig, "warningEnabled").getOrElse(default.warningEnabled),
-          warningThresholdMillis = readLong(logConfig, "warningThresholdMillis").getOrElse(default.warningThresholdMillis),
-          warningLogLevel = readString(logConfig, "warningLogLevel").map(v => Symbol(v)).getOrElse(default.warningLogLevel))
-      } else {
-        GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(enabled = false)
+    readConfig(config, envPrefix + "scalikejdbc.global").foreach { globalConfig =>
+      GlobalSettings.loggingSQLErrors = readBoolean(globalConfig, "loggingSQLErrors").getOrElse(false)
+      GlobalSettings.loggingConnections = readBoolean(globalConfig, "loggingConnections").getOrElse(false)
+
+      for {
+        logConfig <- readConfig(globalConfig, "loggingSQLAndTime")
+      } {
+        val enabled = readBoolean(logConfig, "enabled").getOrElse(false)
+        if (enabled) {
+          val default = LoggingSQLAndTimeSettings()
+          GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
+            enabled = enabled,
+            singleLineMode = readBoolean(logConfig, "singleLineMode").getOrElse(default.singleLineMode),
+            printUnprocessedStackTrace = readBoolean(logConfig, "printUnprocessedStackTrace").getOrElse(default.printUnprocessedStackTrace),
+            stackTraceDepth = readInt(logConfig, "stackTraceDepth").getOrElse(default.stackTraceDepth),
+            logLevel = readString(logConfig, "logLevel").map(v => Symbol(v)).getOrElse(default.logLevel),
+            warningEnabled = readBoolean(logConfig, "warningEnabled").getOrElse(default.warningEnabled),
+            warningThresholdMillis = readLong(logConfig, "warningThresholdMillis").getOrElse(default.warningThresholdMillis),
+            warningLogLevel = readString(logConfig, "warningLogLevel").map(v => Symbol(v)).getOrElse(default.warningLogLevel))
+        } else {
+          GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(enabled = false)
+        }
       }
     }
   }

--- a/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfigReader.scala
+++ b/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfigReader.scala
@@ -98,13 +98,13 @@ trait TypesafeConfigReader extends NoEnvPrefix with LogSupport { self: TypesafeC
 
   def loadGlobalSettings(): Unit = {
     readConfig(config, envPrefix + "scalikejdbc.global").foreach { globalConfig =>
-      GlobalSettings.loggingSQLErrors = readBoolean(globalConfig, "loggingSQLErrors").getOrElse(false)
-      GlobalSettings.loggingConnections = readBoolean(globalConfig, "loggingConnections").getOrElse(false)
+      GlobalSettings.loggingSQLErrors = readBoolean(globalConfig, "loggingSQLErrors").getOrElse(GlobalSettings.loggingSQLErrors)
+      GlobalSettings.loggingConnections = readBoolean(globalConfig, "loggingConnections").getOrElse(GlobalSettings.loggingConnections)
 
       for {
         logConfig <- readConfig(globalConfig, "loggingSQLAndTime")
       } {
-        val enabled = readBoolean(logConfig, "enabled").getOrElse(false)
+        val enabled = readBoolean(logConfig, "enabled").getOrElse(GlobalSettings.loggingSQLAndTime.enabled)
         if (enabled) {
           val default = LoggingSQLAndTimeSettings()
           GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(

--- a/scalikejdbc-config/src/test/resources/application-bad-logenabled.conf
+++ b/scalikejdbc-config/src/test/resources/application-bad-logenabled.conf
@@ -30,6 +30,8 @@ db.baz.driver="org.h2.Driver"
 db.baz.user="sa4"
 db.baz.password="secret4"
 
+scalikejdbc.global.loggingSQLErrors=true
+scalikejdbc.global.loggingConnections=true
 scalikejdbc.global.loggingSQLAndTime.enabled=true
 scalikejdbc.global.loggingSQLAndTime.logLeve=debug
 scalikejdbc.global.loggingSQLAndTime.warningEnable=true

--- a/scalikejdbc-config/src/test/resources/application-bad.conf
+++ b/scalikejdbc-config/src/test/resources/application-bad.conf
@@ -30,6 +30,8 @@ db.baz.driver="org.h2.Driver"
 db.baz.user="sa4"
 db.baz.password="secret4"
 
+scalikejdbc.global.loggingSQLErrors=true
+scalikejdbc.global.loggingConnections=true
 scalikejdbc.global.loggingSQLAndTime.enable=true
 scalikejdbc.global.loggingSQLAndTime.logLeve=debug
 scalikejdbc.global.loggingSQLAndTime.warningEnable=true

--- a/scalikejdbc-config/src/test/resources/application-empty-global.conf
+++ b/scalikejdbc-config/src/test/resources/application-empty-global.conf
@@ -1,0 +1,1 @@
+scalikejdbc.global.loggingSQLAndTime = {}

--- a/scalikejdbc-config/src/test/resources/application.conf
+++ b/scalikejdbc-config/src/test/resources/application.conf
@@ -55,6 +55,8 @@ db {
   }
 }
 
+scalikejdbc.global.loggingSQLErrors=true
+scalikejdbc.global.loggingConnections=true
 scalikejdbc.global.loggingSQLAndTime.enabled=true
 scalikejdbc.global.loggingSQLAndTime.singleLineMode=false
 scalikejdbc.global.loggingSQLAndTime.printUnprocessedStackTrace=false

--- a/scalikejdbc-config/src/test/scala/scalikejdbc/config/TypesafeConfigReaderSpec.scala
+++ b/scalikejdbc-config/src/test/scala/scalikejdbc/config/TypesafeConfigReaderSpec.scala
@@ -203,6 +203,14 @@ class TypesafeConfigReaderSpec extends FunSpec with Matchers {
         TypesafeConfigReader.loadGlobalSettings()
       }
 
+      it("should load global settings loggingSQLErrors & loggingConnections") {
+        GlobalSettings.loggingSQLErrors = false
+        GlobalSettings.loggingConnections = false
+        TypesafeConfigReader.loadGlobalSettings()
+        GlobalSettings.loggingSQLErrors should be(true)
+        GlobalSettings.loggingConnections should be(true)
+      }
+
       describe("When the format of config file is bad") {
         it("should not throw Exception") {
           badConfigReader.loadGlobalSettings()

--- a/scalikejdbc-config/src/test/scala/scalikejdbc/config/TypesafeConfigReaderSpec.scala
+++ b/scalikejdbc-config/src/test/scala/scalikejdbc/config/TypesafeConfigReaderSpec.scala
@@ -14,6 +14,10 @@ class TypesafeConfigReaderSpec extends FunSpec with Matchers {
     override lazy val config: Config = ConfigFactory.load("empty.conf")
   }
 
+  val emptyGlobalConfigReader = new TypesafeConfigReader with TypesafeConfig {
+    override lazy val config: Config = ConfigFactory.load("application-empty-global.conf")
+  }
+
   val badConfigReader = new TypesafeConfigReader with TypesafeConfig {
     override lazy val config: Config = ConfigFactory.load("application-bad.conf")
   }
@@ -221,6 +225,17 @@ class TypesafeConfigReaderSpec extends FunSpec with Matchers {
       describe("When the config file is empty") {
         it("should not throw Exception") {
           emptyConfigReader.loadGlobalSettings()
+        }
+
+        it("set default value(true) to logging settings") {
+          emptyConfigReader.loadGlobalSettings()
+          GlobalSettings.loggingSQLErrors should be(true)
+          GlobalSettings.loggingConnections should be(true)
+          GlobalSettings.loggingSQLAndTime.enabled should be(true)
+          emptyGlobalConfigReader.loadGlobalSettings()
+          GlobalSettings.loggingSQLErrors should be(true)
+          GlobalSettings.loggingConnections should be(true)
+          GlobalSettings.loggingSQLAndTime.enabled should be(true)
         }
       }
     }


### PR DESCRIPTION
This pull request backports #383 to 3.2.x series.