### PR TITLE
[3.2.x] library dependencies upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,13 +46,13 @@ env:
 matrix:
   include:
     - scala: scripted-test
-      env: SCALIKEJDBC_DATABASE="mysql" TEST_SBT_VERSION="0.13.16"
+      env: SCALIKEJDBC_DATABASE="mysql" TEST_SBT_VERSION="0.13.17"
     - scala: scripted-test
-      env: SCALIKEJDBC_DATABASE="mysql" TEST_SBT_VERSION="1.1.0"
+      env: SCALIKEJDBC_DATABASE="mysql" TEST_SBT_VERSION="1.1.1"
     - scala: scripted-test
-      env: SCALIKEJDBC_DATABASE="postgresql" TEST_SBT_VERSION="1.1.0"
+      env: SCALIKEJDBC_DATABASE="postgresql" TEST_SBT_VERSION="1.1.1"
     - scala: scripted-test
-      env: SCALIKEJDBC_DATABASE="h2" TEST_SBT_VERSION="1.1.0"
+      env: SCALIKEJDBC_DATABASE="h2" TEST_SBT_VERSION="1.1.1"
     - scala: 2.12.5
       env: SCALIKEJDBC_DATABASE="h2"
     - scala: 2.12.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 scala:
   - 2.10.6
   - 2.11.12
-  - 2.12.4
+  - 2.12.5
 
 jdk:
   - oraclejdk8
@@ -53,9 +53,9 @@ matrix:
       env: SCALIKEJDBC_DATABASE="postgresql" TEST_SBT_VERSION="1.1.0"
     - scala: scripted-test
       env: SCALIKEJDBC_DATABASE="h2" TEST_SBT_VERSION="1.1.0"
-    - scala: 2.12.4
+    - scala: 2.12.5
       env: SCALIKEJDBC_DATABASE="h2"
-    - scala: 2.12.4
+    - scala: 2.12.5
       env: SCALIKEJDBC_DATABASE="hsqldb"
     - scala: 2.13.0-M2
       env: SCALIKEJDBC_DATABASE="mysql"

--- a/build.sbt
+++ b/build.sbt
@@ -116,7 +116,8 @@ lazy val scalikejdbcJodaTime = Project(
   libraryDependencies ++= Seq(
     "org.mockito" % "mockito-core" % mockitoVersion % "test",
     "joda-time" % "joda-time" % "2.9.9",
-    "org.joda" % "joda-convert" % "2.0.1"
+    // upgrading joda-convert to 2.x is bin-incompatible
+    "org.joda" % "joda-convert" % "1.9.2"
   )
 ).dependsOn(
   scalikejdbcLibrary,

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val baseSettings = Seq(
   // https://github.com/sbt/sbt/issues/2217
   fullResolvers ~= { _.filterNot(_.name == "jcenter") },
   transitiveClassifiers in Global := Seq(Artifact.SourceClassifier),
-  scalatestVersion := "3.0.4",
+  scalatestVersion := "3.0.5",
   specs2Version := {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 10)) =>
@@ -243,7 +243,7 @@ lazy val scalikejdbcMapperGenerator = Project(
 ).settings(
   baseSettings,
   sbtPlugin := true,
-  crossSbtVersions := Vector("0.13.16", "1.1.0"),
+  crossSbtVersions := Vector("0.13.17", "1.1.1"),
   resolvers += Classpaths.sbtPluginReleases, // for sbt 0.13 test
   scriptedBufferLog := false,
   scriptedLaunchOpts ++= sys.process.javaVmArguments.filter(

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,9 @@ lazy val baseSettings = Seq(
         // specs2 4 does not support Scala 2.10
         // https://repo1.maven.org/maven2/org/specs2/specs2-core_2.10/
         "3.9.5"
+      case Some((2, 13)) =>
+        // http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.specs2%22%20AND%20a%3A%22specs2-core_2.13.0-M2%22
+        "4.0.2"
       case _ =>
         "4.0.3"
     }
@@ -176,6 +179,8 @@ lazy val scalikejdbcCore = Project(
       "org.hibernate"           %  "hibernate-core"  % _hibernateVersion % "test",
       "org.mockito"             %  "mockito-core"    % mockitoVersion    % "test"
     ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, scalaMajor)) if scalaMajor >= 13 =>
+        Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.7" % "compile")
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>
         Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.0" % "compile")
       case Some((2, 10)) =>

--- a/build.sbt
+++ b/build.sbt
@@ -6,19 +6,19 @@ lazy val _organization = "org.scalikejdbc"
 
 // published dependency version
 lazy val _slf4jApiVersion = "1.7.25"
-lazy val _typesafeConfigVersion = "1.3.2"
+lazy val _typesafeConfigVersion = "1.3.3"
 lazy val _reactiveStreamsVersion = "1.0.2"
 
 // internal only
 lazy val _logbackVersion = "1.2.3"
-lazy val _h2Version = "1.4.196"
+lazy val _h2Version = "1.4.197"
 // 6.0.x is still under development? https://dev.mysql.com/downloads/connector/j/
-lazy val _mysqlVersion = "5.1.45"
+lazy val _mysqlVersion = "5.1.46"
 lazy val _postgresqlVersion = "9.4.1212"
-lazy val _hibernateVersion = "5.2.12.Final"
+lazy val _hibernateVersion = "5.2.16.Final"
 lazy val scalatestVersion = SettingKey[String]("scalatestVersion")
 lazy val specs2Version = SettingKey[String]("specs2Version")
-lazy val mockitoVersion = "2.13.0"
+lazy val mockitoVersion = "2.16.0"
 
 def gitHash: String = try {
   sys.process.Process("git rev-parse HEAD").lineStream_!.head
@@ -45,7 +45,7 @@ lazy val baseSettings = Seq(
         // https://repo1.maven.org/maven2/org/specs2/specs2-core_2.10/
         "3.9.5"
       case _ =>
-        "4.0.2"
+        "4.0.3"
     }
   },
   //scalaVersion := "2.11.12",
@@ -116,7 +116,7 @@ lazy val scalikejdbcJodaTime = Project(
   libraryDependencies ++= Seq(
     "org.mockito" % "mockito-core" % mockitoVersion % "test",
     "joda-time" % "joda-time" % "2.9.9",
-    "org.joda" % "joda-convert" % "1.9.2"
+    "org.joda" % "joda-convert" % "2.0.1"
   )
 ).dependsOn(
   scalikejdbcLibrary,
@@ -170,13 +170,13 @@ lazy val scalikejdbcCore = Project(
       "commons-dbcp"            %  "commons-dbcp"    % "1.4"             % "provided",
       "com.jolbox"              %  "bonecp"          % "0.8.0.RELEASE"   % "provided",
       // scope: test
-      "com.zaxxer"              %  "HikariCP"        % "2.7.6"           % "test",
+      "com.zaxxer"              %  "HikariCP"        % "2.7.8"           % "test",
       "ch.qos.logback"          %  "logback-classic" % _logbackVersion   % "test",
       "org.hibernate"           %  "hibernate-core"  % _hibernateVersion % "test",
       "org.mockito"             %  "mockito-core"    % mockitoVersion    % "test"
     ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-        Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6" % "compile")
+        Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.0" % "compile")
       case Some((2, 10)) =>
         libraryDependencies.value ++ Seq(
           compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.1.1

--- a/sandbox/build.sbt
+++ b/sandbox/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(ScalikejdbcPlugin)
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.5"
 lazy val scalikejdbcVersion = scalikejdbc.ScalikejdbcBuildInfo.version
 resolvers ++= Seq(
   "Sonatype releases"  at "https://oss.sonatype.org/content/repositories/releases",

--- a/sandbox/project/build.properties
+++ b/sandbox/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.1.1

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/jsr310/StatementExecutorSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/jsr310/StatementExecutorSpec.scala
@@ -15,7 +15,7 @@ class StatementExecutorSpec extends FunSpec with Matchers {
     it("should work with JSR-310 APIs") {
       implicit val session = NamedAutoSession('jsr310)
 
-      sql"create table accounts (id bigserial not null, birthday date not null, alert_time time not null, local_created_at timestamp not null, created_at timestamp not null, updated_at timestamp not null )"
+      sql"create table accounts (id bigserial not null, birthday date not null, alert_time time(3) not null, local_created_at timestamp not null, created_at timestamp not null, updated_at timestamp not null )"
         .execute.apply()
 
       val birthday = LocalDate.now

--- a/scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/gen/build.sbt
+++ b/scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/gen/build.sbt
@@ -49,7 +49,7 @@ testOptions in Test += {
 
 val scalikejdbcVersion = System.getProperty("plugin.version")
 
-crossScalaVersions := List("2.12.4", "2.11.12", "2.10.6")
+crossScalaVersions := List("2.12.5", "2.11.12", "2.10.6")
 
 scalacOptions ++= Seq("-Xlint", "-language:_", "-deprecation", "-unchecked")
 

--- a/scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/no-database/build.sbt
+++ b/scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/no-database/build.sbt
@@ -4,7 +4,7 @@ val root = project.in(file(".")).enablePlugins(ScalikejdbcPlugin)
 
 val scalikejdbcVersion = System.getProperty("plugin.version")
 
-crossScalaVersions := List("2.12.4", "2.11.12", "2.10.6")
+crossScalaVersions := List("2.12.5", "2.11.12", "2.10.6")
 
 scalacOptions ++= Seq("-Xlint", "-language:_", "-deprecation", "-unchecked")
 

--- a/scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/twenty-three/test
+++ b/scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/twenty-three/test
@@ -17,7 +17,7 @@
 > compile
 > test:compile
 
-> set scalaVersion :="2.12.4"
+> set scalaVersion :="2.12.5"
 > compile
 > test:compile
 

--- a/scripts/release_all.sh
+++ b/scripts/release_all.sh
@@ -3,18 +3,18 @@
 cd `dirname $0`/..
 rm -rf */target
 
-sbt 'set scalaVersion := "2.12.4"' \
+sbt 'set scalaVersion := "2.12.5"' \
   clean \
-  "project core" 'set scalaVersion := "2.12.4"' publishSigned \
-  "project config" 'set scalaVersion := "2.12.4"' publishSigned \
-  "project interpolation-macro" 'set scalaVersion := "2.12.4"' publishSigned \
-  "project interpolation" 'set scalaVersion := "2.12.4"' publishSigned \
-  "project library" 'set scalaVersion := "2.12.4"' publishSigned \
-  "project joda-time" 'set scalaVersion := "2.12.4"' publishSigned \
-  "project streams" 'set scalaVersion := "2.12.4"' publishSigned \
-  "project syntax-support-macro" 'set scalaVersion := "2.12.4"' publishSigned \
-  "project test" 'set scalaVersion := "2.12.4"' publishSigned \
-  "project mapper-generator-core" 'set scalaVersion := "2.12.4"' publishSigned \
+  "project core" 'set scalaVersion := "2.12.5"' publishSigned \
+  "project config" 'set scalaVersion := "2.12.5"' publishSigned \
+  "project interpolation-macro" 'set scalaVersion := "2.12.5"' publishSigned \
+  "project interpolation" 'set scalaVersion := "2.12.5"' publishSigned \
+  "project library" 'set scalaVersion := "2.12.5"' publishSigned \
+  "project joda-time" 'set scalaVersion := "2.12.5"' publishSigned \
+  "project streams" 'set scalaVersion := "2.12.5"' publishSigned \
+  "project syntax-support-macro" 'set scalaVersion := "2.12.5"' publishSigned \
+  "project test" 'set scalaVersion := "2.12.5"' publishSigned \
+  "project mapper-generator-core" 'set scalaVersion := "2.12.5"' publishSigned \
   'set scalaVersion := "2.11.12"' \
   clean \
   "project core" 'set scalaVersion := "2.11.12"' publishSigned \

--- a/travis.sh
+++ b/travis.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [[ ${TRAVIS_SCALA_VERSION} = "scripted-test" ]]; then
-  if [[ "${TEST_SBT_VERSION}" = "0.13.16" ]]; then
+  if [[ "${TEST_SBT_VERSION}" = "0.13.17" ]]; then
     sbt \
     '++ 2.12.5! -v' \
     root211/publishLocal \

--- a/travis.sh
+++ b/travis.sh
@@ -5,7 +5,7 @@ set -e
 if [[ ${TRAVIS_SCALA_VERSION} = "scripted-test" ]]; then
   if [[ "${TEST_SBT_VERSION}" = "0.13.16" ]]; then
     sbt \
-    '++ 2.12.4! -v' \
+    '++ 2.12.5! -v' \
     root211/publishLocal \
     '++ 2.11.12! -v' \
     root211/publishLocal \
@@ -25,7 +25,7 @@ if [[ ${TRAVIS_SCALA_VERSION} = "scripted-test" ]]; then
   else
     sbt \
     "^^ $TEST_SBT_VERSION" \
-    '++ 2.12.4! -v' \
+    '++ 2.12.5! -v' \
     publishLocal \
     '++ 2.11.12! -v' \
     root211/publishLocal \


### PR DESCRIPTION
This pull request bumps the version of the following ones:

- sbt 0.13.16 -> 0.13.17, 1.1.0 -> 1.1.1
- scala 2.12.4 -> 2.12.5
- batch versions of libraryDependencies

After merging this pull request, I will release ScalikeJDBC version 3.2.2.