### PR TITLE
Fix IllegalArgumentException: Illegal group reference when a param which contains '$'

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
@@ -2,6 +2,8 @@ package scalikejdbc
 
 import java.sql.PreparedStatement
 
+import org.slf4j.LoggerFactory
+
 import scala.language.reflectiveCalls
 import scala.util.control.NonFatal
 
@@ -26,9 +28,15 @@ object StatementExecutor {
   object PrintableQueryBuilder extends PrintableQueryBuilder {
     // Find ? placeholders, but ignore ?? because that's an escaped question mark.
     private val substituteRegex = "(?<!\\?)(\\?)(?!\\?)".r
+
+    /**
+     * Logger
+     */
+    private val log = new Log(LoggerFactory.getLogger(classOf[PrintableQueryBuilder]))
+
   }
 
-  trait PrintableQueryBuilder extends UnixTimeInMillisConverterImplicits with LogSupport {
+  trait PrintableQueryBuilder extends UnixTimeInMillisConverterImplicits {
 
     import PrintableQueryBuilder._
 

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
@@ -1,7 +1,9 @@
 package scalikejdbc
 
 import java.sql.PreparedStatement
+
 import scala.language.reflectiveCalls
+import scala.util.control.NonFatal
 
 /**
  * Companion object.
@@ -21,81 +23,92 @@ object StatementExecutor {
 
   private val LocalDateEpoch = java.time.LocalDate.ofEpochDay(0)
 
-  object PrintableQueryBuilder extends PrintableQueryBuilder
+  object PrintableQueryBuilder extends PrintableQueryBuilder {
+    // Find ? placeholders, but ignore ?? because that's an escaped question mark.
+    private val substituteRegex = "(?<!\\?)(\\?)(?!\\?)".r
+  }
 
-  trait PrintableQueryBuilder extends UnixTimeInMillisConverterImplicits {
+  trait PrintableQueryBuilder extends UnixTimeInMillisConverterImplicits with LogSupport {
+
+    import PrintableQueryBuilder._
+
     def build(
       template: String,
       settingsProvider: SettingsProvider,
       params: Seq[Any]): String = {
-
-      def toPrintable(param: Any): String = {
-        @annotation.tailrec
-        def normalize(param: Any): Any = {
-          param match {
-            case null => null
-            case ParameterBinder(v) => normalize(v)
-            case None => null
-            case Some(p) => normalize(p)
-            case p: String => p
-            case p: java.util.Date => p.toSqlTimestamp.toString
-            case p =>
-              param.getClass().getCanonicalName match {
-                case "org.joda.time.DateTime" =>
-                  param.asInstanceOf[{ def toDate: java.util.Date }].toDate.toSqlTimestamp.toString
-                case "org.joda.time.LocalDateTime" =>
-                  param.asInstanceOf[{ def toDate: java.util.Date }].toDate.toSqlTimestamp
-                case "org.joda.time.LocalDate" =>
-                  param.asInstanceOf[{ def toDate: java.util.Date }].toDate.toSqlDate
-                case "org.joda.time.LocalTime" =>
-                  val millis = param.asInstanceOf[{ def toDateTimeToday: { def getMillis: Long } }].toDateTimeToday.getMillis
-                  new java.sql.Time(millis)
-                case _ => p
-              }
+      try {
+        def toPrintable(param: Any): String = {
+          @annotation.tailrec
+          def normalize(param: Any): Any = {
+            param match {
+              case null => null
+              case ParameterBinder(v) => normalize(v)
+              case None => null
+              case Some(p) => normalize(p)
+              case p: String => p
+              case p: java.util.Date => p.toSqlTimestamp.toString
+              case p =>
+                param.getClass().getCanonicalName match {
+                  case "org.joda.time.DateTime" =>
+                    param.asInstanceOf[{ def toDate: java.util.Date }].toDate.toSqlTimestamp.toString
+                  case "org.joda.time.LocalDateTime" =>
+                    param.asInstanceOf[{ def toDate: java.util.Date }].toDate.toSqlTimestamp
+                  case "org.joda.time.LocalDate" =>
+                    param.asInstanceOf[{ def toDate: java.util.Date }].toDate.toSqlDate
+                  case "org.joda.time.LocalTime" =>
+                    val millis = param.asInstanceOf[{ def toDateTimeToday: { def getMillis: Long } }].toDateTimeToday.getMillis
+                    new java.sql.Time(millis)
+                  case _ => p
+                }
+            }
           }
+
+          (normalize(param) match {
+            case null => "null"
+            case result: String =>
+              settingsProvider.loggingSQLAndTime(GlobalSettings.loggingSQLAndTime).maxColumnSize.collect {
+                case maxSize if result.length > maxSize =>
+                  "'" + result.take(maxSize) + "... (" + result.length + ")" + "'"
+              }.getOrElse {
+                "'" + result + "'"
+              }
+            case result => result.toString
+          }).replaceAll("\r", "\\\\r")
+            .replaceAll("\n", "\\\\n")
         }
 
-        (normalize(param) match {
-          case null => "null"
-          case result: String =>
-            settingsProvider.loggingSQLAndTime(GlobalSettings.loggingSQLAndTime).maxColumnSize.collect {
-              case maxSize if result.length > maxSize =>
-                "'" + result.take(maxSize) + "... (" + result.length + ")" + "'"
-            }.getOrElse {
-              "'" + result + "'"
-            }
-          case result => result.toString
-        }).replaceAll("\r", "\\\\r")
-          .replaceAll("\n", "\\\\n")
-      }
+        var i = 0
+        @annotation.tailrec
+        def trimSpaces(s: String, i: Int = 0): String = i match {
+          case i if i > 10 => s
+          case i => trimSpaces(s.replaceAll("  ", " "), i + 1)
+        }
 
-      var i = 0
-      @annotation.tailrec
-      def trimSpaces(s: String, i: Int = 0): String = i match {
-        case i if i > 10 => s
-        case i => trimSpaces(s.replaceAll("  ", " "), i + 1)
-      }
+        val sqlWithPlaceholders = trimSpaces(SQLTemplateParser.trimComments(template)
+          .replaceAll("[\r\n\t]", " "))
 
-      // Find ? placeholders, but ignore ?? because that's an escaped question mark.
-      val substituteRegex = "(?<!\\?)(\\?)(?!\\?)".r
-
-      val sqlWithPlaceholders = trimSpaces(SQLTemplateParser.trimComments(template)
-        .replaceAll("[\r\n\t]", " "))
-
-      sqlWithPlaceholders.split('\'').zipWithIndex.map {
-        // Even numbered parts are outside quotes, odd numbered are inside
-        case (s, quoteCount) if (quoteCount % 2 == 0) => substituteRegex.replaceAllIn(s, m => {
-          i += 1
-          if (params.size >= i) {
-            toPrintable(params(i - 1))
-          } else {
-            // In this case, SQLException will be thrown later.
-            // At least, throwing java.lang.IndexOutOfBoundsException here is meaningless.
-            m.source.toString()
+        sqlWithPlaceholders.split('\'').zipWithIndex.map {
+          // Even numbered parts are outside quotes, odd numbered are inside
+          case (target, quoteCount) if (quoteCount % 2 == 0) => {
+            substituteRegex.replaceAllIn(target, m => {
+              i += 1
+              if (params.size >= i) {
+                toPrintable(params(i - 1)).replace("\\", "\\\\").replace("$", "\\$")
+              } else {
+                // In this case, SQLException will be thrown later.
+                // At least, throwing java.lang.IndexOutOfBoundsException here is meaningless.
+                m.source.toString()
+              }
+            })
           }
-        })
-        case (s, quoteCount) if (quoteCount % 2 == 1) => s
-      }.mkString
+          case (s, quoteCount) if (quoteCount % 2 == 1) => s
+        }.mkString
+
+      } catch {
+        case NonFatal(e) =>
+          log.debug(s"Failed to build a printable SQL statement with ${template}, params: ${params}", e)
+          template
+      }
     }
   }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/StatementExecutorSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/StatementExecutorSpec.scala
@@ -63,6 +63,29 @@ class StatementExecutorSpec extends FlatSpec with Matchers with MockitoSugar {
         params = Seq("key"))
       sql should equal("select id, data from some_table where data ?? 'key'")
     }
+
+    /*
+      [info] - should have PrintableQueryBuilder inside *** FAILED ***
+      [info]   java.lang.IllegalArgumentException: Illegal group reference
+      [info]   at java.util.regex.Matcher.appendReplacement(Matcher.java:857)
+      [info]   at scala.util.matching.Regex$Replacement.replace(Regex.scala:897)
+      [info]   at scala.util.matching.Regex$Replacement.replace$(Regex.scala:897)
+      [info]   at scala.util.matching.Regex$MatchIterator$$anon$1.replace(Regex.scala:875)
+      [info]   at scala.util.matching.Regex.$anonfun$replaceAllIn$1(Regex.scala:505)
+      [info]   at scala.collection.Iterator.foreach(Iterator.scala:929)
+      [info]   at scala.collection.Iterator.foreach$(Iterator.scala:929)
+      [info]   at scala.collection.AbstractIterator.foreach(Iterator.scala:1417)
+      [info]   at scala.util.matching.Regex.replaceAllIn(Regex.scala:505)
+      [info]   at scalikejdbc.StatementExecutor$PrintableQueryBuilder.$anonfun$build$2(StatementExecutor.scala:87)
+      [info]   ...
+     */
+    {
+      val sql = StatementExecutor.PrintableQueryBuilder.build(
+        template = "select * from users where foo = ? and bar = ?",
+        settingsProvider = SettingsProvider.default,
+        params = Seq("foo$", "^bar$\\+$"))
+      sql should equal("select * from users where foo = 'foo$' and bar = '^bar$\\+$'")
+    }
   }
 
 }


### PR DESCRIPTION
This pull request fixes a bug where StatementExecutor.PrintableQueryBuilder doesn't handle params which contain '$' and unexpectedly throws exceptions in that case. Not only fixing the pattern but I've added try-catch clause not to prevent the SQL execution anyway.