### PR TITLE
sbt 1.1.5 requires Scala 2.12.4

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.4
+sbt.version=1.1.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+scalaVersion := "2.12.4"
 resolvers ++= Seq(
   "sonatype releases" at "http://oss.sonatype.org/content/repositories/releases",
   "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"


### PR DESCRIPTION
Scala 2.12.6 in ScalikeJDBC causes java.lang.StackOverflowError. This is a workaround.
