### PR TITLE
mapper-generator: use java.sql.JDBCType instead of java.sql.Types

### DIFF
--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
@@ -10,7 +10,7 @@ import java.util.Locale.{ ENGLISH => en }
 class CodeGenerator(table: Table, specifiedClassName: Option[String] = None)(implicit config: GeneratorConfig = GeneratorConfig())
   extends Generator with LoanPattern {
 
-  import java.sql.{ Types => JavaSqlTypes }
+  import java.sql.{ JDBCType => JavaSqlTypes }
   import java.io.{ OutputStreamWriter, FileOutputStream, File }
 
   private val packageName = config.packageName

--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/Column.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/Column.scala
@@ -1,4 +1,6 @@
 package scalikejdbc.mapper
 
-case class Column(name: String, dataType: Int, isNotNull: Boolean, isAutoIncrement: Boolean)
+import java.sql.JDBCType
+
+case class Column(name: String, dataType: JDBCType, isNotNull: Boolean, isAutoIncrement: Boolean)
 

--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/Model.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/Model.scala
@@ -1,6 +1,8 @@
 package scalikejdbc.mapper
 
+import java.sql.JDBCType
 import java.util.UUID
+
 import scalikejdbc._
 import scalikejdbc.{ ResultSetTraversable => RSTraversable }
 
@@ -18,7 +20,7 @@ case class Model(url: String, username: String, password: String) extends AutoCl
 
   private def columnName(implicit rs: WrappedResultSet): String = rs.string("COLUMN_NAME")
 
-  private def columnDataType(implicit rs: WrappedResultSet): Int = rs.string("DATA_TYPE").toInt
+  private def columnDataType(implicit rs: WrappedResultSet): JDBCType = JDBCType.valueOf(rs.string("DATA_TYPE").toInt)
 
   private def isNotNull(implicit rs: WrappedResultSet): Boolean = {
     val isNullable = rs.string("IS_NULLABLE")

--- a/scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/gen/build.sbt
+++ b/scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/gen/build.sbt
@@ -67,12 +67,12 @@ libraryDependencies ++= Seq(
 )
 
 TaskKey[Unit]("generateCodeForIssue339") := {
-  import java.sql.Types
+  import java.sql.JDBCType
   import scalikejdbc.mapper._
-  val key = Column("key", Types.INTEGER, true, true)
+  val key = Column("key", JDBCType.INTEGER, true, true)
   val other = List(
-    Column("column1", Types.OTHER, true, false),
-    Column("column2", Types.OTHER, false, false)
+    Column("column1", JDBCType.OTHER, true, false),
+    Column("column2", JDBCType.OTHER, false, false)
   )
   val all = key :: other
   val table = Table("Issue339table", all, all.filter(_.isAutoIncrement), key :: Nil)

--- a/scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/no-database/build.sbt
+++ b/scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/no-database/build.sbt
@@ -23,11 +23,11 @@ libraryDependencies ++= Seq(
 )
 
 (scalikejdbcCodeGeneratorAll in Compile) := { (_, generatorSettings) =>
-  val idColumn = Column("id", java.sql.Types.INTEGER, true, true)
+  val idColumn = Column("id", java.sql.JDBCType.INTEGER, true, true)
   val columns = List(
     idColumn,
-    Column("name", java.sql.Types.VARCHAR, true, false),
-    Column("updated_at", java.sql.Types.TIMESTAMP, false, false)
+    Column("name", java.sql.JDBCType.VARCHAR, true, false),
+    Column("updated_at", java.sql.JDBCType.TIMESTAMP, false, false)
   )
   val table = Table(
     "Programmers",


### PR DESCRIPTION
Related issue is #637 

I tried to change Int to Enum. Please check them when you have time.

<s>
I didn't chenge java.sql.Types of the following to java.sql.JDBCType. I don't know whether it is correct.

```
scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/gen/build.sbt|70| import java.sql.Types
scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/gen/build.sbt|72| val key = Column("key", Types.INTEGER, true, true)
scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/gen/build.sbt|74| Column("column1", Types.OTHER, true, false),
scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/gen/build.sbt|75| Column("column2", Types.OTHER, false, false)
scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/no-database/build.sbt|26| val idColumn = Column("id", java.sql.Types.INTEGER, true, true)
scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/no-database/build.sbt|29| Column("name", java.sql.Types.VARCHAR, true, false),
scalikejdbc-mapper-generator/src/sbt-test/scalikejdbc-mapper-generator/no-database/build.sbt|30| Column("updated_at", java.sql.Types.TIMESTAMP, false, false)
```
</s>