### PR TITLE
add ResultSetIterator. deprecate ResultSetTraversable

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DBSession.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DBSession.scala
@@ -260,7 +260,7 @@ trait DBSession extends LogSupport with LoanPattern with AutoCloseable {
     using(createStatementExecutor(conn, template, params)) {
       executor =>
         val proxy = new DBConnectionAttributesWiredResultSet(executor.executeQuery(), connectionAttributes)
-        val resultSet = new ResultSetTraversable(proxy)
+        val resultSet = new ResultSetIterator(proxy)
         val rows = (resultSet map extract).toList
         rows match {
           case Nil => None
@@ -310,7 +310,7 @@ trait DBSession extends LogSupport with LoanPattern with AutoCloseable {
     using(createStatementExecutor(conn, template, params)) {
       executor =>
         val proxy = new DBConnectionAttributesWiredResultSet(executor.executeQuery(), connectionAttributes)
-        new ResultSetTraversable(proxy).map(extract)(breakOut)
+        new ResultSetIterator(proxy).map(extract).to[C]
     }
   }
 
@@ -326,7 +326,7 @@ trait DBSession extends LogSupport with LoanPattern with AutoCloseable {
     using(createStatementExecutor(conn, template, params)) {
       executor =>
         val proxy = new DBConnectionAttributesWiredResultSet(executor.executeQuery(), connectionAttributes)
-        new ResultSetTraversable(proxy) foreach f
+        new ResultSetIterator(proxy) foreach f
     }
   }
 
@@ -343,7 +343,7 @@ trait DBSession extends LogSupport with LoanPattern with AutoCloseable {
     using(createStatementExecutor(conn, template, params)) {
       executor =>
         val proxy = new DBConnectionAttributesWiredResultSet(executor.executeQuery(), connectionAttributes)
-        new ResultSetTraversable(proxy).foldLeft(z)(op)
+        new ResultSetIterator(proxy).foldLeft(z)(op)
     }
   }
 
@@ -739,7 +739,7 @@ trait DBSession extends LogSupport with LoanPattern with AutoCloseable {
               executor.addBatch()
           }
           executor.executeBatch()
-          new ResultSetTraversable(executor.generatedKeysResultSet).map(_.long(1)).to[C]
+          new ResultSetIterator(executor.generatedKeysResultSet).map(_.long(1)).to[C]
         }
     }
   }
@@ -770,7 +770,7 @@ trait DBSession extends LogSupport with LoanPattern with AutoCloseable {
               executor.addBatch()
           }
           executor.executeBatch()
-          new ResultSetTraversable(executor.generatedKeysResultSet).map(_.long(key)).to[C]
+          new ResultSetIterator(executor.generatedKeysResultSet).map(_.long(key)).to[C]
         }
     }
   }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ResultSetIterator.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ResultSetIterator.scala
@@ -1,0 +1,46 @@
+package scalikejdbc
+
+import java.sql.ResultSet
+
+/**
+ * scala.collection.Iterator object which wraps java.sql.ResultSet.
+ */
+class ResultSetIterator(rs: ResultSet) extends Iterator[WrappedResultSet] {
+
+  private[this] val cursor: ResultSetCursor = new ResultSetCursor(0)
+  private[this] var nextOpt: WrappedResultSet = null
+  private[this] var closed: Boolean = false
+
+  override def hasNext: Boolean = {
+    if (nextOpt != null) {
+      true
+    } else if (closed) {
+      false
+    } else if (rs.next) {
+      cursor.position += 1
+      nextOpt = new WrappedResultSet(rs, cursor, cursor.position)
+      true
+    } else {
+      rs.close()
+      closed = true
+      false
+    }
+  }
+
+  override def next: WrappedResultSet = {
+    if (nextOpt != null) {
+      val result = nextOpt
+      nextOpt = null
+      result
+    } else if (closed) {
+      Iterator.empty.next
+    } else if (rs.next) {
+      cursor.position += 1
+      new WrappedResultSet(rs, cursor, cursor.position)
+    } else {
+      rs.close()
+      closed = true
+      Iterator.empty.next
+    }
+  }
+}

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ResultSetTraversable.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ResultSetTraversable.scala
@@ -5,6 +5,7 @@ import java.sql.ResultSet
 /**
  * scala.collection.Traversable object which wraps java.sql.ResultSet.
  */
+@deprecated(message = "use ResultSetIterator instead", since = "3.3.0")
 class ResultSetTraversable(rs: ResultSet) extends Traversable[WrappedResultSet] with LoanPattern {
 
   private[this] val cursor: ResultSetCursor = new ResultSetCursor(0)

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/ResultSetIteratorSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/ResultSetIteratorSpec.scala
@@ -1,0 +1,158 @@
+package scalikejdbc
+
+import util.control.Exception._
+import org.scalatest._
+import java.sql.ResultSet
+import java.util.NoSuchElementException
+import scalikejdbc.LoanPattern._
+
+class ResultSetIteratorSpec extends FlatSpec with Matchers with Settings {
+
+  val tableNamePrefix = "emp_ResultSetIteratorSpec" + System.currentTimeMillis()
+
+  behavior of "ResultSetIterator"
+
+  it can "call hasNext many times" in {
+    val tableName = tableNamePrefix + "_hasNext_many_times"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      using(ConnectionPool.borrow()) { conn =>
+        val rs: ResultSet = conn.prepareStatement("select * from " + tableName + " where id = 9999999999").executeQuery()
+        val i = new ResultSetIterator(rs)
+        assert(i.hasNext === false)
+        assert(i.hasNext === false)
+        assert(i.hasNext === false)
+        assert(i.size === 0)
+        intercept[NoSuchElementException] {
+          i.next
+        }
+        intercept[NoSuchElementException] {
+          i.next
+        }
+      }
+
+      (1 to 2).foreach { count =>
+        using(ConnectionPool.borrow()) { conn =>
+          val rs: ResultSet = {
+            try {
+              conn.prepareStatement(s"select * from $tableName order by id limit $count").executeQuery()
+            } catch {
+              case e: Exception =>
+                conn.prepareStatement(s"select * from $tableName order by id fetch first $count rows only").executeQuery()
+            }
+          }
+
+          val i = new ResultSetIterator(rs)
+          assert(i.hasNext === true)
+          assert(i.hasNext === true)
+          assert(i.hasNext === true)
+          assert(i.size === count) // consume all elements
+          assert(i.hasNext === false)
+          assert(i.hasNext === false)
+          assert(i.hasNext === false)
+          intercept[NoSuchElementException] {
+            i.next
+          }
+          intercept[NoSuchElementException] {
+            i.next
+          }
+        }
+      }
+    }
+  }
+
+  it should "be available (result size 0)" in {
+    val tableName = tableNamePrefix + "_fetchSize0"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      using(ConnectionPool.borrow()) { conn =>
+        val rs: ResultSet = conn.prepareStatement("select * from " + tableName + " where id = 9999999999").executeQuery()
+        new ResultSetIterator(rs).foreach(rs => rs.int("id") should not equal (null))
+      }
+    }
+  }
+
+  it should "be available (result size 1)" in {
+    val tableName = tableNamePrefix + "_fetchSize1"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      using(ConnectionPool.borrow()) { conn =>
+        val rs: ResultSet = {
+          try {
+            conn.prepareStatement("select * from " + tableName + " order by id limit 1").executeQuery()
+          } catch {
+            case e: Exception =>
+              conn.prepareStatement("select * from " + tableName + " order by id fetch first 1 rows only").executeQuery()
+          }
+        }
+        new ResultSetIterator(rs).foreach(_.int("id") should not equal (null))
+      }
+    }
+  }
+
+  it should "be available (result size 2)" in {
+    val tableName = tableNamePrefix + "_fetchSize2"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      using(ConnectionPool.borrow()) { conn =>
+        val rs: ResultSet = {
+          try {
+            conn.prepareStatement("select * from " + tableName + " order by id limit 2").executeQuery()
+          } catch {
+            case e: Exception =>
+              conn.prepareStatement("select * from " + tableName + " order by id fetch first 2 rows only").executeQuery()
+          }
+        }
+        new ResultSetIterator(rs).foreach(_.int("id") should not equal (null))
+      }
+    }
+  }
+
+  it should "be enable to fold (result size 0)" in {
+    val tableName = tableNamePrefix + "_fetchSize0"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      using(ConnectionPool.borrow()) { conn =>
+        val rs: ResultSet = conn.prepareStatement("select * from " + tableName + " where id = 9999999999").executeQuery()
+        new ResultSetIterator(rs).foldLeft[List[Int]](Nil) { case (r, rs) => rs.int("id") :: r } should not be null
+      }
+    }
+  }
+
+  it should "be enable to fold (result size 1)" in {
+    val tableName = tableNamePrefix + "_fetchSize1"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      using(ConnectionPool.borrow()) { conn =>
+        val rs: ResultSet = {
+          try {
+            conn.prepareStatement("select * from " + tableName + " order by id limit 1").executeQuery()
+          } catch {
+            case e: Exception =>
+              conn.prepareStatement("select * from " + tableName + " order by id fetch first 1 rows only").executeQuery()
+          }
+        }
+        new ResultSetIterator(rs).foldLeft[List[Int]](Nil) { case (r, rs) => rs.int("id") :: r } should not be null
+      }
+    }
+  }
+
+  it should "be enable to fold (result size 2)" in {
+    val tableName = tableNamePrefix + "_fetchSize2"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      using(ConnectionPool.borrow()) { conn =>
+        val rs: ResultSet = {
+          try {
+            conn.prepareStatement("select * from " + tableName + " order by id limit 2").executeQuery()
+          } catch {
+            case e: Exception =>
+              conn.prepareStatement("select * from " + tableName + " order by id fetch first 2 rows only").executeQuery()
+          }
+        }
+        new ResultSetIterator(rs).foldLeft[List[Int]](Nil) { case (r, rs) => rs.int("id") :: r } should not be null
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
There are two reasons.

1. `scala.Traversable` deprecated since Scala 2.13.0-M4.
2. I think we should not use Traversable/Iterable in this case. Because `scala.Traversable#isTraversableAgain` return true (and final). But `ResultSetTraversable` is not reusable.

https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSet.html


> A default ResultSet object is not updatable and has a cursor that moves forward only. Thus, you can iterate through it only once and only from the first row to the last row.

- https://github.com/scala/scala/blob/v2.13.0-M4/src/library/scala/package.scala#L44-L47
- https://github.com/scala/scala/blob/v2.12.6/src/library/scala/collection/TraversableLike.scala#L89