### PR TITLE
use ArrayBuffer instead of MutableList

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/StatementExecutor.scala
@@ -12,8 +12,6 @@ import scala.util.control.NonFatal
  */
 object StatementExecutor {
 
-  type MutableList[A] = collection.mutable.MutableList[A]
-
   val eol: String = System.getProperty("line.separator")
 
   private trait Executor {
@@ -141,7 +139,7 @@ case class StatementExecutor(
 
   import StatementExecutor._
 
-  private[this] lazy val batchParamsList = new MutableList[Seq[Any]]
+  private[this] lazy val batchParamsList = scala.collection.mutable.ArrayBuffer.empty[Seq[Any]]
 
   initialize()
 


### PR DESCRIPTION
prepare Scala 2.13
MutableList deleted since Scala 2.13.0-M4

- https://github.com/scala/scala/commit/6ff3facb1791f54ad10fbf44059d892e5fd00510#diff-dbfbed0f077885a45f3e7a1e2b8e0177
- https://github.com/scala/scala/blob/v2.13.0-M4/src/library/scala/collection/mutable/ArrayBuffer.scala
- https://github.com/scala/scala/blob/v2.13.0-M4/src/library/scala/collection/mutable/MutableList.scala (this url 404)