### PR TITLE
call `.toSeq` method when varargs methods

### DIFF
--- a/project/GenerateOneToManies.scala
+++ b/project/GenerateOneToManies.scala
@@ -74,7 +74,7 @@ s"          to$i.map(t => Vector(t)).getOrElse(Vector.empty)"
 
   private[scalikejdbc] def toTraversable(session: DBSession, sql: String, params: scala.collection.Seq[_], zExtractor: (A, $seq) => Z): Traversable[Z] = {
     val attributesSwitcher = createDBSessionAttributesSwitcher()
-    DBSessionWrapper(session, attributesSwitcher).foldLeft(statement, rawParameters: _*)(LinkedHashMap[A, ($seq)]())(processResultSet).map {
+    DBSessionWrapper(session, attributesSwitcher).foldLeft(statement, rawParameters.toSeq: _*)(LinkedHashMap[A, ($seq)]())(processResultSet).map {
       case (one, (${(1 to n).map("t" + _).mkString(", ")})) => zExtractor(one, ${(1 to n).map("t" + _).mkString(", ")})
     }
   }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DBSessionAttributesSwitcher.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DBSessionAttributesSwitcher.scala
@@ -46,7 +46,7 @@ private[scalikejdbc] class DBSessionAttributesSwitcher(sql: SQL[_, _]) {
         this.queryTimeoutCameFromSQLObject.foreach(seconds => session.queryTimeout(seconds))
         // Adding a tag to a session means session scope tagging.
         // So, concatenation of session.tags and this(SQL).tags would be equal to full tags.
-        session.tags(session.tags ++ this.tagsCameFromSQLObject: _*)
+        session.tags((session.tags ++ this.tagsCameFromSQLObject).toSeq: _*)
       case _ =>
         throw new IllegalStateException(ErrorMessage.THIS_IS_A_BUG)
     }
@@ -61,7 +61,7 @@ private[scalikejdbc] class DBSessionAttributesSwitcher(sql: SQL[_, _]) {
         case Some(session) =>
           session
             .fetchSize(this.originalFetchSize)
-            .tags(this.originalTags: _*)
+            .tags(this.originalTags.toSeq: _*)
             .queryTimeout(this.originalQueryTimeout)
         case _ =>
           throw new IllegalStateException(ErrorMessage.THIS_IS_A_BUG)

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/OneToManySQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/OneToManySQL.scala
@@ -39,7 +39,7 @@ class OneToManySQL[A, B, E <: WithExtractor, Z](
     val q = new OneToManySQL[A, B, HasExtractor, Z](statement, rawParameters)(one)(toMany)(zExtractor)
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
     q
   }
 
@@ -47,7 +47,7 @@ class OneToManySQL[A, B, E <: WithExtractor, Z](
     val q = new OneToManySQLToTraversable[A, B, E, Z](statement, rawParameters)(one)(toMany)(zExtractor)
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
     q
   }
 
@@ -55,7 +55,7 @@ class OneToManySQL[A, B, E <: WithExtractor, Z](
     val q = new OneToManySQLToList[A, B, E, Z](statement, rawParameters)(one)(toMany)(zExtractor)
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
     q
   }
 
@@ -63,7 +63,7 @@ class OneToManySQL[A, B, E <: WithExtractor, Z](
     val q = new OneToManySQLToOption[A, B, E, Z](statement, rawParameters)(one)(toMany)(zExtractor)(true)
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
     q
   }
 
@@ -71,7 +71,7 @@ class OneToManySQL[A, B, E <: WithExtractor, Z](
     val q = new OneToManySQLToOption[A, B, E, Z](statement, rawParameters)(one)(toMany)(zExtractor)(false)
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
     q
   }
 
@@ -79,7 +79,7 @@ class OneToManySQL[A, B, E <: WithExtractor, Z](
     val q = new OneToManySQLToCollection[A, B, E, Z](statement, rawParameters)(one)(toMany)(zExtractor)
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
     q
   }
 

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/OneToOneSQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/OneToOneSQL.scala
@@ -24,7 +24,7 @@ private[scalikejdbc] trait OneToOneExtractor[A, B, E <: WithExtractor, Z]
   private[scalikejdbc] def toTraversable(session: DBSession, sql: String, params: scala.collection.Seq[_], zExtractor: (A, B) => Z): Traversable[Z] = {
     val attributesSwitcher = createDBSessionAttributesSwitcher()
     DBSessionWrapper(session, attributesSwitcher)
-      .foldLeft(statement, rawParameters: _*)(LinkedHashMap[A, Option[B]]())(processResultSet).map {
+      .foldLeft(statement, rawParameters.toSeq: _*)(LinkedHashMap[A, Option[B]]())(processResultSet).map {
         case (one, Some(to)) => zExtractor(one, to)
         case (one, None) => one.asInstanceOf[Z]
       }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/RelationalSQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/RelationalSQL.scala
@@ -64,7 +64,7 @@ class OneToXSQL[A, E <: WithExtractor, Z](
     val q: OneToManySQL[A, B, E, Z] = new OneToManySQL(statement, rawParameters)(one)(to)((a, bs) => a.asInstanceOf[Z])
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
     q
   }
 
@@ -75,7 +75,7 @@ class OneToXSQL[A, E <: WithExtractor, Z](
       statement, rawParameters)(one)(to1, to2)((a, bs1, bs2) => a.asInstanceOf[Z])
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
     q
   }
 
@@ -87,7 +87,7 @@ class OneToXSQL[A, E <: WithExtractor, Z](
       statement, rawParameters)(one)(to1, to2, to3)((a, bs1, bs2, bs3) => a.asInstanceOf[Z])
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
     q
   }
 
@@ -100,7 +100,7 @@ class OneToXSQL[A, E <: WithExtractor, Z](
       statement, rawParameters)(one)(to1, to2, to3, to4)((a, bs1, bs2, bs3, bs4) => a.asInstanceOf[Z])
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
   }
 
   def toManies[B1, B2, B3, B4, B5](
@@ -113,7 +113,7 @@ class OneToXSQL[A, E <: WithExtractor, Z](
       statement, rawParameters)(one)(to1, to2, to3, to4, to5)((a, bs1, bs2, bs3, bs4, bs5) => a.asInstanceOf[Z])
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
   }
 
   def toManies[B1, B2, B3, B4, B5, B6](
@@ -127,7 +127,7 @@ class OneToXSQL[A, E <: WithExtractor, Z](
       statement, rawParameters)(one)(to1, to2, to3, to4, to5, to6)((a, bs1, bs2, bs3, bs4, bs5, bs6) => a.asInstanceOf[Z])
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
   }
 
   def toManies[B1, B2, B3, B4, B5, B6, B7](
@@ -142,7 +142,7 @@ class OneToXSQL[A, E <: WithExtractor, Z](
       statement, rawParameters)(one)(to1, to2, to3, to4, to5, to6, to7)((a, bs1, bs2, bs3, bs4, bs5, bs6, bs7) => a.asInstanceOf[Z])
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
   }
 
   def toManies[B1, B2, B3, B4, B5, B6, B7, B8](
@@ -158,7 +158,7 @@ class OneToXSQL[A, E <: WithExtractor, Z](
       statement, rawParameters)(one)(to1, to2, to3, to4, to5, to6, to7, to8)((a, bs1, bs2, bs3, bs4, bs5, bs6, bs7, bs8) => a.asInstanceOf[Z])
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
   }
 
   def toManies[B1, B2, B3, B4, B5, B6, B7, B8, B9](
@@ -175,7 +175,7 @@ class OneToXSQL[A, E <: WithExtractor, Z](
       statement, rawParameters)(one)(to1, to2, to3, to4, to5, to6, to7, to8, to9)((a, bs1, bs2, bs3, bs4, bs5, bs6, bs7, bs8, bs9) => a.asInstanceOf[Z])
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
   }
 
 }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/SQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/SQL.scala
@@ -249,7 +249,7 @@ abstract class SQL[A, E <: WithExtractor](
     val q: OneToXSQL[A, E, Z] = new OneToXSQL[A, E, Z](statement, rawParameters)(f)
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags: _*)
+    q.tags(tags.toSeq: _*)
     q
   }
 
@@ -260,7 +260,7 @@ abstract class SQL[A, E <: WithExtractor](
    * @return SQL instance
    */
   def bind(parameters: Any*): SQL[A, E] = {
-    withParameters(parameters).fetchSize(fetchSize).tags(tags: _*).queryTimeout(queryTimeout)
+    withParameters(parameters).fetchSize(fetchSize).tags(tags.toSeq: _*).queryTimeout(queryTimeout)
   }
 
   /**
@@ -271,7 +271,7 @@ abstract class SQL[A, E <: WithExtractor](
    */
   def bindByName(parametersByName: (Symbol, Any)*): SQL[A, E] = {
     val (_statement, _parameters) = validateAndConvertToNormalStatement(statement, _settings, parametersByName)
-    withStatementAndParameters(_statement, _parameters).fetchSize(fetchSize).tags(tags: _*).queryTimeout(queryTimeout)
+    withStatementAndParameters(_statement, _parameters).fetchSize(fetchSize).tags(tags.toSeq: _*).queryTimeout(queryTimeout)
   }
 
   /**
@@ -338,7 +338,7 @@ abstract class SQL[A, E <: WithExtractor](
   def foreach(op: WrappedResultSet => Unit)(implicit session: DBSession): Unit = {
     val attributesSwitcher = createDBSessionAttributesSwitcher()
     val f: DBSession => Unit =
-      DBSessionWrapper(_, attributesSwitcher).foreach(statement, rawParameters: _*)(op)
+      DBSessionWrapper(_, attributesSwitcher).foreach(statement, rawParameters.toSeq: _*)(op)
     // format: OFF
     session match {
       case AutoSession                       => DB.autoCommit(f)
@@ -359,7 +359,7 @@ abstract class SQL[A, E <: WithExtractor](
   def foldLeft[A](z: A)(op: (A, WrappedResultSet) => A)(implicit session: DBSession): A = {
     val attributesSwitcher = createDBSessionAttributesSwitcher()
     val f: DBSession => A =
-      DBSessionWrapper(_, attributesSwitcher).foldLeft(statement, rawParameters: _*)(z)(op)
+      DBSessionWrapper(_, attributesSwitcher).foldLeft(statement, rawParameters.toSeq: _*)(z)(op)
     // format: OFF
     session match {
       case AutoSession                       => DB.autoCommit(f)
@@ -379,7 +379,7 @@ abstract class SQL[A, E <: WithExtractor](
    * @return SQL instance
    */
   def map[A](f: WrappedResultSet => A): SQL[A, HasExtractor] = {
-    withExtractor[A](f).fetchSize(fetchSize).tags(tags: _*).queryTimeout(queryTimeout)
+    withExtractor[A](f).fetchSize(fetchSize).tags(tags.toSeq: _*).queryTimeout(queryTimeout)
   }
 
   /**
@@ -396,7 +396,7 @@ abstract class SQL[A, E <: WithExtractor](
    */
   def toOption(): SQLToOption[A, E] = {
     new SQLToOptionImpl[A, E](statement, rawParameters)(extractor)(isSingle = true)
-      .fetchSize(fetchSize).tags(tags: _*).queryTimeout(queryTimeout)
+      .fetchSize(fetchSize).tags(tags.toSeq: _*).queryTimeout(queryTimeout)
   }
 
   /**
@@ -413,7 +413,7 @@ abstract class SQL[A, E <: WithExtractor](
    */
   def headOption(): SQLToOption[A, E] = {
     new SQLToOptionImpl[A, E](statement, rawParameters)(extractor)(isSingle = false)
-      .fetchSize(fetchSize).tags(tags: _*).queryTimeout(queryTimeout)
+      .fetchSize(fetchSize).tags(tags.toSeq: _*).queryTimeout(queryTimeout)
   }
 
   /**
@@ -430,7 +430,7 @@ abstract class SQL[A, E <: WithExtractor](
    */
   def toList(): SQLToList[A, E] = {
     new SQLToListImpl[A, E](statement, rawParameters)(extractor)
-      .fetchSize(fetchSize).tags(tags: _*).queryTimeout(queryTimeout)
+      .fetchSize(fetchSize).tags(tags.toSeq: _*).queryTimeout(queryTimeout)
   }
 
   /**
@@ -447,7 +447,7 @@ abstract class SQL[A, E <: WithExtractor](
    */
   def toCollection: SQLToCollection[A, E] = {
     new SQLToCollectionImpl[A, E](statement, rawParameters)(extractor)
-      .fetchSize(fetchSize).tags(tags: _*).queryTimeout(queryTimeout)
+      .fetchSize(fetchSize).tags(tags.toSeq: _*).queryTimeout(queryTimeout)
   }
 
   /**
@@ -464,7 +464,7 @@ abstract class SQL[A, E <: WithExtractor](
    */
   def toTraversable(): SQLToTraversable[A, E] = {
     new SQLToTraversableImpl[A, E](statement, rawParameters)(extractor)
-      .fetchSize(fetchSize).tags(tags: _*).queryTimeout(queryTimeout)
+      .fetchSize(fetchSize).tags(tags.toSeq: _*).queryTimeout(queryTimeout)
   }
 
   /**
@@ -569,11 +569,11 @@ abstract class SQL[A, E <: WithExtractor](
 
   def stripMargin(marginChar: Char): SQL[A, E] =
     withStatementAndParameters(statement.stripMargin(marginChar), rawParameters)
-      .fetchSize(fetchSize).tags(tags: _*).queryTimeout(queryTimeout)
+      .fetchSize(fetchSize).tags(tags.toSeq: _*).queryTimeout(queryTimeout)
 
   def stripMargin: SQL[A, E] =
     withStatementAndParameters(statement.stripMargin, rawParameters)
-      .fetchSize(fetchSize).tags(tags: _*).queryTimeout(queryTimeout)
+      .fetchSize(fetchSize).tags(tags.toSeq: _*).queryTimeout(queryTimeout)
 
 }
 
@@ -708,18 +708,18 @@ class SQLUpdate(val statement: String, val parameters: scala.collection.Seq[Any]
   val after: (PreparedStatement) => Unit) {
 
   def apply()(implicit session: DBSession): Int = {
-    val attributesSwitcher = new DBSessionAttributesSwitcher(SQL("").tags(tags: _*))
+    val attributesSwitcher = new DBSessionAttributesSwitcher(SQL("").tags(tags.toSeq: _*))
     session match {
       case AutoSession =>
-        DB.autoCommit(DBSessionWrapper(_, attributesSwitcher).updateWithFilters(before, after, statement, parameters: _*))
+        DB.autoCommit(DBSessionWrapper(_, attributesSwitcher).updateWithFilters(before, after, statement, parameters.toSeq: _*))
       case NamedAutoSession(name, _) =>
-        NamedDB(name, session.settings).autoCommit(DBSessionWrapper(_, attributesSwitcher).updateWithFilters(before, after, statement, parameters: _*))
+        NamedDB(name, session.settings).autoCommit(DBSessionWrapper(_, attributesSwitcher).updateWithFilters(before, after, statement, parameters.toSeq: _*))
       case ReadOnlyAutoSession =>
-        DB.readOnly(DBSessionWrapper(_, attributesSwitcher).updateWithFilters(before, after, statement, parameters: _*))
+        DB.readOnly(DBSessionWrapper(_, attributesSwitcher).updateWithFilters(before, after, statement, parameters.toSeq: _*))
       case ReadOnlyNamedAutoSession(name, _) =>
-        NamedDB(name, session.settings).readOnly(DBSessionWrapper(_, attributesSwitcher).updateWithFilters(before, after, statement, parameters: _*))
+        NamedDB(name, session.settings).readOnly(DBSessionWrapper(_, attributesSwitcher).updateWithFilters(before, after, statement, parameters.toSeq: _*))
       case _ =>
-        DBSessionWrapper(session, attributesSwitcher).updateWithFilters(before, after, statement, parameters: _*)
+        DBSessionWrapper(session, attributesSwitcher).updateWithFilters(before, after, statement, parameters.toSeq: _*)
     }
   }
 
@@ -744,18 +744,18 @@ class SQLLargeUpdate private[scalikejdbc] (statement: String, parameters: scala.
   after: PreparedStatement => Unit) {
 
   def apply()(implicit session: DBSession): Long = {
-    val attributesSwitcher = new DBSessionAttributesSwitcher(SQL("").tags(tags: _*))
+    val attributesSwitcher = new DBSessionAttributesSwitcher(SQL("").tags(tags.toSeq: _*))
     session match {
       case AutoSession =>
-        DB.autoCommit(DBSessionWrapper(_, attributesSwitcher).largeUpdateWithFilters(before, after, statement, parameters: _*))
+        DB.autoCommit(DBSessionWrapper(_, attributesSwitcher).largeUpdateWithFilters(before, after, statement, parameters.toSeq: _*))
       case NamedAutoSession(name, _) =>
-        NamedDB(name, session.settings).autoCommit(DBSessionWrapper(_, attributesSwitcher).largeUpdateWithFilters(before, after, statement, parameters: _*))
+        NamedDB(name, session.settings).autoCommit(DBSessionWrapper(_, attributesSwitcher).largeUpdateWithFilters(before, after, statement, parameters.toSeq: _*))
       case ReadOnlyAutoSession =>
-        DB.readOnly(DBSessionWrapper(_, attributesSwitcher).largeUpdateWithFilters(before, after, statement, parameters: _*))
+        DB.readOnly(DBSessionWrapper(_, attributesSwitcher).largeUpdateWithFilters(before, after, statement, parameters.toSeq: _*))
       case ReadOnlyNamedAutoSession(name, _) =>
-        NamedDB(name, session.settings).readOnly(DBSessionWrapper(_, attributesSwitcher).largeUpdateWithFilters(before, after, statement, parameters: _*))
+        NamedDB(name, session.settings).readOnly(DBSessionWrapper(_, attributesSwitcher).largeUpdateWithFilters(before, after, statement, parameters.toSeq: _*))
       case _ =>
-        DBSessionWrapper(session, attributesSwitcher).largeUpdateWithFilters(before, after, statement, parameters: _*)
+        DBSessionWrapper(session, attributesSwitcher).largeUpdateWithFilters(before, after, statement, parameters.toSeq: _*)
     }
   }
 }
@@ -769,8 +769,8 @@ class SQLLargeUpdate private[scalikejdbc] (statement: String, parameters: scala.
 class SQLUpdateWithGeneratedKey(val statement: String, val parameters: scala.collection.Seq[Any], val tags: scala.collection.Seq[String] = Nil)(val key: Any) {
 
   def apply()(implicit session: DBSession): Long = {
-    val attributesSwitcher = new DBSessionAttributesSwitcher(SQL("").tags(tags: _*))
-    val f: DBSession => Long = DBSessionWrapper(_, attributesSwitcher).updateAndReturnSpecifiedGeneratedKey(statement, parameters: _*)(key)
+    val attributesSwitcher = new DBSessionAttributesSwitcher(SQL("").tags(tags.toSeq: _*))
+    val f: DBSession => Long = DBSessionWrapper(_, attributesSwitcher).updateAndReturnSpecifiedGeneratedKey(statement, parameters.toSeq: _*)(key)
     // format: OFF
     session match {
       case AutoSession                       => DB.autoCommit(f)
@@ -823,7 +823,7 @@ trait SQLToResult[A, E <: WithExtractor, C[_]] extends SQL[A, E] with Extractor[
 trait SQLToTraversable[A, E <: WithExtractor] extends SQLToResult[A, E, Traversable] {
 
   def result[AA](f: WrappedResultSet => AA, session: DBSession): Traversable[AA] = {
-    session.traversable[AA](statement, rawParameters: _*)(f)
+    session.traversable[AA](statement, rawParameters.toSeq: _*)(f)
   }
 
 }
@@ -874,7 +874,7 @@ trait SQLToCollection[A, E <: WithExtractor] extends SQL[A, E] with Extractor[A]
   private[scalikejdbc] val rawParameters: scala.collection.Seq[Any]
   def apply[C[_]]()(implicit session: DBSession, context: ConnectionPoolContext = NoConnectionPoolContext, hasExtractor: ThisSQL =:= SQLWithExtractor, cbf: CanBuildFrom[Nothing, A, C[A]]): C[A] = {
     val attributesSwitcher = createDBSessionAttributesSwitcher()
-    val f: DBSession => C[A] = DBSessionWrapper(_, attributesSwitcher).collection[A, C](statement, rawParameters: _*)(extractor)
+    val f: DBSession => C[A] = DBSessionWrapper(_, attributesSwitcher).collection[A, C](statement, rawParameters.toSeq: _*)(extractor)
     // format: OFF
     session match {
       case AutoSession | ReadOnlyAutoSession => DB.readOnly(f)
@@ -922,7 +922,7 @@ object SQLToCollectionImpl {
 trait SQLToList[A, E <: WithExtractor] extends SQLToResult[A, E, List] {
 
   def result[AA](f: WrappedResultSet => AA, session: DBSession): List[AA] = {
-    session.list[AA](statement, rawParameters: _*)(f)
+    session.list[AA](statement, rawParameters.toSeq: _*)(f)
   }
 
 }
@@ -973,9 +973,9 @@ trait SQLToOption[A, E <: WithExtractor] extends SQLToResult[A, E, Option] {
 
   def result[AA](f: WrappedResultSet => AA, session: DBSession): Option[AA] = {
     if (isSingle) {
-      session.single[AA](statement, rawParameters: _*)(f)
+      session.single[AA](statement, rawParameters.toSeq: _*)(f)
     } else {
-      session.first[AA](statement, rawParameters: _*)(f)
+      session.first[AA](statement, rawParameters.toSeq: _*)(f)
     }
   }
 

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/SQLInterpolationString.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/SQLInterpolationString.scala
@@ -13,7 +13,7 @@ class SQLInterpolationString(private val s: StringContext) extends AnyVal {
 
   def sql[A](params: Any*): SQL[A, NoExtractor] = {
     val syntax = sqls(params: _*)
-    SQL[A](syntax.value).bind(syntax.rawParameters: _*)
+    SQL[A](syntax.value).bind(syntax.rawParameters.toSeq: _*)
   }
 
   def sqls(params: Any*): SQLSyntax = {


### PR DESCRIPTION
prepare Scala 2.13.0-M4

varargs parameter type changed since Scala 2.13.0-M4

```
Welcome to Scala 2.13.0-M4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_172).
Type in expressions for evaluation. Or try :help.

scala> def foo(xs: Int*): scala.collection.Seq[Int] = xs
foo: (xs: Int*)scala.collection.Seq[Int]

scala> def bar(xs: Int*): scala.collection.immutable.Seq[Int] = xs
bar: (xs: Int*)Seq[Int]

scala> val a: collection.Seq[Int] = Nil
a: scala.collection.Seq[Int] = List()

scala> foo(a: _*)
           ^
       error: type mismatch;
        found   : Seq[Int] (in scala.collection)
        required: Seq[Int] (in scala.collection.immutable)

scala> foo(a.toSeq: _*)
res1: scala.collection.Seq[Int] = List()
```

```
Welcome to Scala 2.12.6 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_172).
Type in expressions for evaluation. Or try :help.

scala> def foo(xs: Int*): scala.collection.Seq[Int] = xs
foo: (xs: Int*)Seq[Int]

scala> def bar(xs: Int*): scala.collection.immutable.Seq[Int] = xs
<console>:11: error: type mismatch;
 found   : Seq[Int] (in scala.collection)
 required: Seq[Int] (in scala.collection.immutable)
       def bar(xs: Int*): scala.collection.immutable.Seq[Int] = xs
                                                                ^

scala> val a: collection.Seq[Int] = Nil
a: Seq[Int] = List()

scala> foo(a: _*)
res0: Seq[Int] = List()

scala> foo(a.toSeq: _*)
res1: Seq[Int] = List()
```