### PR TITLE
fix warning. use "reverseIterator.map" instead of "reverseMap"

### DIFF
--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala
@@ -467,7 +467,7 @@ trait QueryDSLFeature { self: SQLInterpolationFeature with SQLSyntaxSupportFeatu
 
     def map(mapper: SelectSQLBuilder[A] => SelectSQLBuilder[A]): SelectSQLBuilder[A] = mapper.apply(this)
 
-    private def lazyLoadedPart: SQLSyntax = sqls"select ${sqls.join(resultAllProviders.reverseMap(_.resultAll), sqls",")}"
+    private def lazyLoadedPart: SQLSyntax = sqls"select ${sqls.join(resultAllProviders.reverseIterator.map(_.resultAll).toSeq, sqls",")}"
 
     override def toSQLSyntax: SQLSyntax = if (lazyColumns) sqls"${lazyLoadedPart} ${sql}" else sqls"${sql}"
     override def toSQL: SQL[A, NoExtractor] = if (lazyColumns) sql"${lazyLoadedPart} ${sql}" else sql"${sql}"


### PR DESCRIPTION
- https://github.com/scala/scala/blob/v2.13.0-M4/src/library/scala/collection/Seq.scala#L427
- https://travis-ci.org/scalikejdbc/scalikejdbc/jobs/385447713#L589-L591

```
[warn] /home/travis/build/scalikejdbc/scalikejdbc/scalikejdbc-interpolation/src/main/scala/scalikejdbc/QueryDSLFeature.scala:470:88: method reverseMap in trait SeqOps is deprecated (since 2.13.0): Use .reverseIterator.map(f).to(...) instead of .reverseMap(f)
[warn]     private def lazyLoadedPart: SQLSyntax = sqls"select ${sqls.join(resultAllProviders.reverseMap(_.resultAll), sqls",")}"
[warn]                                                                                        ^
```