### PR TITLE
remove deprecated SQLInterpolation object

### DIFF
--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLInterpolation.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLInterpolation.scala
@@ -1,9 +1,5 @@
 package scalikejdbc
 
-@deprecated("'import SQLInterpolation._' is no longer required. Just 'import scalikejdbc._' works fine.", since = "2.0.0")
-object SQLInterpolation {
-}
-
 /**
  * SQLInterpolation full imports.
  */


### PR DESCRIPTION
deprecated 4 years ago
https://github.com/scalikejdbc/scalikejdbc/commit/8f6c03fa143263fafa0fcda783198c510beb463a#diff-3dc863a35d12eae70177ace5230278edR18
