### PR TITLE
Fix MySQL returning unexpected column metadata.

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
@@ -414,7 +414,7 @@ trait DBConnection extends LogSupport with LoanPattern with AutoCloseable {
   def getAllColumns(meta: DatabaseMetaData, schema: String, table: String): ResultSet = {
     meta.getDatabaseProductName match {
       case "MySQL" => {
-        val catalog = if(schema == null || schema.isEmpty) {
+        val catalog = if (schema == null || schema.isEmpty) {
           // If you pass null to catalog, MySQL returns all columns which named {table}
           // To avoid that, get using database from connection.
           meta.getConnection.getCatalog()

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
@@ -413,7 +413,16 @@ trait DBConnection extends LogSupport with LoanPattern with AutoCloseable {
    */
   def getAllColumns(meta: DatabaseMetaData, schema: String, table: String): ResultSet = {
     meta.getDatabaseProductName match {
-      case "MySQL" => meta.getColumns(schema, null, table, "%")
+      case "MySQL" => {
+        val catalog = if(schema == null || schema.isEmpty) {
+          // If you pass null to catalog, MySQL returns all columns which named {table}
+          // To avoid that, get using database from connection.
+          meta.getConnection.getCatalog()
+        } else {
+          schema
+        }
+        meta.getColumns(catalog, null, table, "%")
+      }
       case _ => meta.getColumns(null, schema, table, "%")
     }
   }


### PR DESCRIPTION
MySQL returns all column metadata of all same name tables when I use "DB.getTable("MyTable").get.columns".
Fix it by complementing connection info.

e.g.
There are two databases and tables "create table db1.Item(id integer, itemName text)" and "create table db2.item(itemId integer,name text)". In this situation, DB.getTable("item").get.columns returns 4 columns, but correct result is 2;; 