### PR TITLE
fix warning in Scala 2.13.0-M5

### DIFF
--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/GeneratorConfig.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/GeneratorConfig.scala
@@ -64,7 +64,7 @@ object GeneratorConfig {
 
   val lowerCamelCase: String => String =
     GeneratorConfig.toCamelCase.andThen {
-      camelCase => camelCase.head.toLower + camelCase.tail
+      camelCase => s"${camelCase.head.toLower}${camelCase.tail}"
     }
 
   val columnNameToFieldNameBasic: String => String = {


### PR DESCRIPTION
- https://github.com/scala/scala/commit/1f1912d34789d4a8d50c411507ba2d7ece7b12f4
- https://travis-ci.org/scalikejdbc/scalikejdbc/jobs/427930615#L777

```
[warn]/home/travis/build/scalikejdbc/scalikejdbc/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/GeneratorConfig.scala:67:43: method + in class Char is deprecated (since 2.13.0): Adding a number and a String is deprecated. Convert the number to a String with `toString` first to call +
[warn]      camelCase => camelCase.head.toLower + camelCase.tail
[warn]                                          ^
```