### PR TITLE
Update Travis build settings and add our policy to support JDKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ scala:
   - 2.11.12
   - 2.12.7
 
+# The project supports OpenJDK 8+ / Oracle JDK 8,9,10
+# As of October 2018, Oracle JDK 8 is the most widely used JDK for Scala applications.
+# Thereby, we use Oracle JDK 8 as the default for now. We may change the default JDK for testing.
 jdk:
   - oraclejdk8
 
@@ -44,19 +47,38 @@ env:
 
 matrix:
   include:
+    # scripted test
     - scala: scripted-test
       env: SCALIKEJDBC_DATABASE="mysql"
     - scala: scripted-test
       env: SCALIKEJDBC_DATABASE="postgresql"
     - scala: scripted-test
       env: SCALIKEJDBC_DATABASE="h2"
+    # h2, hsqldb
     - scala: 2.12.7
       env: SCALIKEJDBC_DATABASE="h2"
     - scala: 2.12.7
       env: SCALIKEJDBC_DATABASE="hsqldb"
+    # Oracle JDK 8,9,10 / OpenJDK 8,9,10,11+
     - scala: 2.12.7
       env: SCALIKEJDBC_DATABASE="mysql"
-      jdk: oraclejdk11
+      jdk: oraclejdk9
+    - scala: 2.12.7
+      env: SCALIKEJDBC_DATABASE="mysql"
+      jdk: oraclejdk10
+    - scala: 2.12.7
+      env: SCALIKEJDBC_DATABASE="mysql"
+      jdk: openjdk8
+    - scala: 2.12.7
+      env: SCALIKEJDBC_DATABASE="mysql"
+      jdk: openjdk9
+    - scala: 2.12.7
+      env: SCALIKEJDBC_DATABASE="mysql"
+      jdk: openjdk10
+    - scala: 2.12.7
+      env: SCALIKEJDBC_DATABASE="mysql"
+      jdk: openjdk11
+   # Scala 2.13.0 Milestone Releases
     - scala: 2.13.0-M4
       env: SCALIKEJDBC_DATABASE="mysql"
     - scala: 2.13.0-M5

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,12 +69,13 @@ matrix:
     - scala: 2.12.7
       env: SCALIKEJDBC_DATABASE="mysql"
       jdk: openjdk8
-    - scala: 2.12.7
-      env: SCALIKEJDBC_DATABASE="mysql"
-      jdk: openjdk9
-    - scala: 2.12.7
-      env: SCALIKEJDBC_DATABASE="mysql"
-      jdk: openjdk10
+    # Disabled because the sbt initialization with OpenJDK9/10 are somehow unstable
+    #- scala: 2.12.7
+    #  env: SCALIKEJDBC_DATABASE="mysql"
+    #  jdk: openjdk9
+    #- scala: 2.12.7
+    #  env: SCALIKEJDBC_DATABASE="mysql"
+    #  jdk: openjdk10
     - scala: 2.12.7
       env: SCALIKEJDBC_DATABASE="mysql"
       jdk: openjdk11


### PR DESCRIPTION
Considering recent Oracle Corporation's licensing since JDK 11 and the current situation of Scala community, I would like to update Travis build settings and also define our policy to support JDKs. 

At this moment, we should keep using Oracle JDK 8 as the default JDK to use for quality assurance tests. The reason why I think so is that Oracle Java SE 8 (or including 9, 10 as well) is the most widely used to run Scala applications as of today. The most popular JDK will be another one in the future, but it's not time yet.

Regarding the JDKs to be supported in the future, I will be always open to supporting more JDKs in Travis builds. However, we should carefully consider adding more JDKs not to cause excessive increase of the total build time. Also, we should consider dropping older versions at the right time. For instance, dropping Oracle 9, 10 in 2019 is quite reasonable because they are not long-term supported JDKs.

Anyway, from now on, we should be more aware of JDK releases than ever before.