### PR TITLE
remove oraclejdk10 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,9 +65,6 @@ matrix:
       jdk: oraclejdk9
     - scala: 2.12.7
       env: SCALIKEJDBC_DATABASE="mysql"
-      jdk: oraclejdk10
-    - scala: 2.12.7
-      env: SCALIKEJDBC_DATABASE="mysql"
       jdk: openjdk8
     # Disabled because the sbt initialization with OpenJDK9/10 are somehow unstable
     #- scala: 2.12.7


### PR DESCRIPTION
https://travis-ci.org/scalikejdbc/scalikejdbc/jobs/444241159#L407

```
oraclejdk10 is deprecated. See https://www.oracle.com/technetwork/java/javase/eol-135779.html for more details. Consider using openjdk10 instead.
```