### PR TITLE
Change the access modifier of ClassNameUtil and its class comment a bit

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ClassNameUtil.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ClassNameUtil.scala
@@ -1,9 +1,10 @@
 package scalikejdbc
 
-object ClassNameUtil {
+private[scalikejdbc] object ClassNameUtil {
+
   /**
-   * Returns clazz.getCanonicalName, or clazz.getName if clazz.getCanonicalName throws Error.
-   * @param clazz class
+   * Returns the canonical name of a given class. If getCanonicalName doesn't return expected value, this method returns the value came from getName instead.
+   * @param clazz a given class object
    */
   def getClassName(clazz: Class[_]): String = {
     val canonicalName: Option[String] = try {


### PR DESCRIPTION
This pull request changes the access modifier of `scalikejdbc.ClassNameUtil` which was introduced by #961 . Also, I changed its class comment a bit.