### PR TITLE
fix compile error with latest Scala 2.13.x

### DIFF
--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DB_SQLOperationSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DB_SQLOperationSpec.scala
@@ -44,7 +44,7 @@ class DB_SQLOperationSpec extends FlatSpec with Matchers with BeforeAndAfter wit
       TestUtils.initialize(tableName)
       implicit val session = DB.readOnlySession()
       try {
-        val result = SQL("select * from " + tableName + "") map (rs => Some(rs.string("name"))) toList () apply ()
+        val result = SQL("select * from " + tableName + "").map(rs => Some(rs.string("name"))).toList.apply()
         result.size should be > 0
       } finally {
         session.close()


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/1731/consoleFull

```
[scalikejdbc] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.16/project-builds/scalikejdbc-8135323278afbc970c78b8ed76a8f7c909585934/scalikejdbc-core/src/test/scala/scalikejdbc/DB_SQLOperationSpec.scala:47:97: no arguments allowed for nullary method toList: ()scalikejdbc.SQLToList[Some[String],scalikejdbc.HasExtractor]
[scalikejdbc] [error]         val result = SQL("select * from " + tableName + "") map (rs => Some(rs.string("name"))) toList () apply ()
[scalikejdbc] [error]
```