### PR TITLE
3.3 backport: Fix #977 Issue with open connection after exception in begin(tx) method

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
@@ -323,9 +323,9 @@ trait DBConnection extends LogSupport with LoanPattern with AutoCloseable {
    */
   def localTx[A](execution: DBSession => A)(implicit boundary: TxBoundary[A] = defaultTxBoundary[A]): A = {
     val doClose = if (autoCloseEnabled) () => conn.close() else () => ()
-    val tx = newTx
-    begin(tx)
-    val txResult = try {
+    val txResult: A = try {
+      val tx = newTx
+      begin(tx)
       rollbackIfThrowable[A] {
         val session = DBSession(
           conn = conn,

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DBConnectionSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DBConnectionSpec.scala
@@ -1,0 +1,54 @@
+package scalikejdbc
+
+import java.sql.Connection
+import org.mockito.Mockito.{ mock, verify, times, when }
+import org.scalatest.{ FlatSpec, Matchers }
+
+class DBConnectionSpec extends FlatSpec with Matchers {
+
+  behavior of "DBConnection"
+
+  "#begin" should "simply work with mocked java.sql.Connection objects" in {
+    val mockConn = mock(classOf[java.sql.Connection])
+    when(mockConn.setAutoCommit(false)).thenThrow(new IllegalStateException("Failed to start a transaction"))
+    val conn = new DBConnection {
+      override protected[this] val settingsProvider: SettingsProvider = SettingsProvider.default
+      override def conn: Connection = mockConn
+    }
+    try {
+      conn.begin()
+      fail()
+    } catch {
+      case _: IllegalStateException =>
+    }
+    verify(mockConn, times(1)).getAutoCommit()
+    verify(mockConn, times(1)).isReadOnly()
+    verify(mockConn, times(1)).isClosed()
+    verify(mockConn, times(1)).setReadOnly(false)
+  }
+
+  it should "close the resource when an exception is thrown in #begin" in {
+    val mockConn = mock(classOf[java.sql.Connection])
+    when(mockConn.setAutoCommit(false)).thenThrow(new IllegalStateException("Failed to start a transaction"))
+    val conn = new DBConnection {
+      override protected[this] val settingsProvider: SettingsProvider = SettingsProvider.default
+      override def conn: Connection = mockConn
+    }
+    try {
+      conn.localTx { implicit session =>
+        // supposed to do something here
+      }
+      fail()
+    } catch {
+      case _: IllegalStateException =>
+    }
+    verify(mockConn, times(1)).getAutoCommit()
+    verify(mockConn, times(1)).isReadOnly()
+    verify(mockConn, times(1)).isClosed()
+    verify(mockConn, times(1)).setReadOnly(false)
+
+    // issue #977 Issue with open connection after exception in begin(tx) method
+    verify(mockConn, times(1)).close()
+  }
+
+}


### PR DESCRIPTION
This PR brings the backport of PR #979 (which fixes #977) to 3.3 series.