### PR TITLE
fix PartialSubQueryResultSQLSyntaxProvider#column

### DIFF
--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
@@ -819,8 +819,9 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
     }
 
     def column(name: String): SQLSyntax = cachedColumns.getOrElseUpdate(name, {
-      underlying.namedColumns.find(_.value.equalsIgnoreCase(name)).map { nc =>
-        SQLSyntax(s"${aliasName}.${nc.value} as ${nc.value}${delimiterForResultName}${aliasName}")
+      underlying.columns.find(_.value.equalsIgnoreCase(name)).map { original =>
+        val underlyingResultName = underlying.column(original.value).value
+        SQLSyntax(s"${aliasName}.${underlyingResultName} as ${underlyingResultName}${delimiterForResultName}${aliasName}")
       }.getOrElse {
         throw notFoundInColumns(aliasName, name, underlying.columns.map(_.value).mkString(","))
       }


### PR DESCRIPTION
Before:

```
scala> import scalikejdbc._
scala> case class Member(id: Long, groupId: Long)
scala> object Member extends SQLSyntaxSupport[Member] { override val columnNames = Seq("id", "group_id") }
scala> val m = Member.syntax("m")
scala> val s = SubQuery.syntax("s").include(m)
scala> s(m).result.id // scalikejdbc.InvalidColumnNameException: Invalid column name. (name: s.id, registered names: id,group_id)
```
After:

```
scala> import scalikejdbc._
scala> case class Member(id: Long, groupId: Long)
scala> object Member extends SQLSyntaxSupport[Member] { override val columnNames = Seq("id", "group_id") }
scala> val m = Member.syntax("m")
scala> val s = SubQuery.syntax("s").include(m)
scala> s(m).result.id // SQLSyntax(value: s.i_on_m as i_on_m_on_s, parameters: List())
```