### PR TITLE
Switch the sonatype repository to sonatype staging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -354,7 +354,7 @@ def _publishTo(v: String) = {
 }
 val _resolvers = Seq(
   "typesafe repo" at "https://repo.typesafe.com/typesafe/releases",
-  "sonatype releases" at "https://oss.sonatype.org/content/repositories/releases",
+  "sonatype staging" at "https://oss.sonatype.org/content/repositories/staging",
   "sonatype snaphots" at "https://oss.sonatype.org/content/repositories/snapshots"
 )
 lazy val scalaTestDependenciesInTestScope = Def.setting {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 scalaVersion := "2.12.4"
 
 resolvers ++= Seq(
-  "sonatype releases" at "https://oss.sonatype.org/content/repositories/releases",
+  "sonatype staging" at "https://oss.sonatype.org/content/repositories/staging",
   "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 )
 


### PR DESCRIPTION
`oss.sonatype.org/content/repositories/releases` seems to be no longer available. If I understand it correctly, we are still able to fetch the latest jar files from `oss.sonatype.org/content/repositories/staging` instead.
```
$ curl -I https://oss.sonatype.org/content/repositories/releases/
HTTP/2 302 
server: awselb/2.0
date: Thu, 07 Mar 2019 07:08:09 GMT
content-type: text/html
content-length: 126
location: https://repo1.maven.org:443/content/repositories/releases/
```