### PR TITLE
use xenial instead of trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: scala
 
+dist: xenial
+
+services:
+  - mysql
+
 scala:
   - 2.11.12
   - 2.12.8
 
 # The project supports OpenJDK 8+ / Oracle JDK 8,9,10
-# As of October 2018, Oracle JDK 8 is the most widely used JDK for Scala applications.
-# Thereby, we use Oracle JDK 8 as the default for now. We may change the default JDK for testing.
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 addons:
   postgresql: "9.4"
@@ -62,7 +65,7 @@ matrix:
     # Oracle JDK 8,9,10 / OpenJDK 8,9,10,11+
     - scala: 2.12.8
       env: SCALIKEJDBC_DATABASE="mysql"
-      jdk: oraclejdk9
+      jdk: openjdk9
     - scala: 2.12.8
       env: SCALIKEJDBC_DATABASE="mysql"
       jdk: openjdk8

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/jsr310/StatementExecutorSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/jsr310/StatementExecutorSpec.scala
@@ -21,8 +21,19 @@ class StatementExecutorSpec extends FunSpec with Matchers with Settings {
         }
 
         try {
-          sql"create table accounts (birthday date not null, alert_time time(6) not null, local_created_at timestamp(6) not null, created_at timestamp(6) not null, updated_at timestamp(6) not null, deleted_at timestamp(6) not null )"
-            .execute.apply()
+          if (driverClassName == "com.mysql.jdbc.Driver") {
+            sql"""create table accounts (
+               birthday         date         not null,
+               alert_time       time(6)      not null,
+               local_created_at timestamp(6) not null default CURRENT_TIMESTAMP(6) on update CURRENT_TIMESTAMP(6),
+               created_at       timestamp(6) not null default CURRENT_TIMESTAMP(6) on update CURRENT_TIMESTAMP(6),
+               updated_at       timestamp(6) not null default CURRENT_TIMESTAMP(6) on update CURRENT_TIMESTAMP(6),
+               deleted_at       timestamp(6) not null default CURRENT_TIMESTAMP(6) on update CURRENT_TIMESTAMP(6)
+            )""".execute.apply()
+          } else {
+            sql"create table accounts (birthday date not null, alert_time time(6) not null, local_created_at timestamp(6) not null, created_at timestamp(6) not null, updated_at timestamp(6) not null, deleted_at timestamp(6) not null )"
+              .execute.apply()
+          }
 
           val birthday = LocalDate.now
           val alertTime = if (Set("org.hsqldb.jdbc.JDBCDriver", "com.mysql.jdbc.Driver") contains driverClassName) {


### PR DESCRIPTION
- add explicit `services: mysql` settings. see https://blog.travis-ci.com/2018-11-08-xenial-release

> First, Services like MySQL or PostgreSQL are not started by default. To start any service

- use openjdk instead of oraclejdk. see https://github.com/travis-ci/travis-ci/issues/10290#issuecomment-432331802

> oraclejdk8 is not preinstalled on Xenial anymore, and cannot be retrieved from Oracle itself anymore. We'd suggest using either openjdk, or the currently supported Oracle JDK.

- fix StatementExecutorSpec. xenial default mysql version is 5.7.x (5.6.x in trusty)
  - https://docs.travis-ci.com/user/database-setup/
  - https://dev.mysql.com/doc/refman/5.7/en/timestamp-initialization.html