### PR TITLE
Add Future support for readOnly

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DB.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DB.scala
@@ -168,9 +168,9 @@ object DB extends LoanPattern {
    * @tparam A return type
    * @return result value
    */
-  def readOnly[A](execution: DBSession => A)(implicit context: CPContext = NoCPContext, settings: SettingsProvider = SettingsProvider.default): A = {
+  def readOnly[A](execution: DBSession => A)(implicit context: CPContext = NoCPContext, settings: SettingsProvider = SettingsProvider.default, F: OnFinish[A]): A = {
     val cp = connectionPool(context)
-    using(cp.borrow()) { conn =>
+    F.using(cp.borrow()) { conn =>
       DB(conn, cp.connectionAttributes, settings).autoClose(false).readOnly(execution)
     }
   }
@@ -184,9 +184,9 @@ object DB extends LoanPattern {
    * @tparam A return type
    * @return result value
    */
-  def readOnlyWithConnection[A](execution: Connection => A)(implicit context: CPContext = NoCPContext, settings: SettingsProvider = SettingsProvider.default): A = {
+  def readOnlyWithConnection[A](execution: Connection => A)(implicit context: CPContext = NoCPContext, settings: SettingsProvider = SettingsProvider.default, F: OnFinish[A]): A = {
     val cp = connectionPool(context)
-    using(cp.borrow()) { conn =>
+    F.using(cp.borrow()) { conn =>
       DB(conn, cp.connectionAttributes, settings).autoClose(false).readOnlyWithConnection(execution)
     }
   }
@@ -210,9 +210,9 @@ object DB extends LoanPattern {
    * @tparam A return type
    * @return result value
    */
-  def autoCommit[A](execution: DBSession => A)(implicit context: CPContext = NoCPContext, settings: SettingsProvider = SettingsProvider.default): A = {
+  def autoCommit[A](execution: DBSession => A)(implicit context: CPContext = NoCPContext, settings: SettingsProvider = SettingsProvider.default, F: OnFinish[A]): A = {
     val cp = connectionPool(context)
-    using(cp.borrow()) { conn =>
+    F.using(cp.borrow()) { conn =>
       DB(conn, cp.connectionAttributes, settings).autoClose(false).autoCommit(execution)
     }
   }
@@ -226,9 +226,9 @@ object DB extends LoanPattern {
    * @tparam A return type
    * @return result value
    */
-  def autoCommitWithConnection[A](execution: Connection => A)(implicit context: CPContext = NoCPContext, settings: SettingsProvider = SettingsProvider.default): A = {
+  def autoCommitWithConnection[A](execution: Connection => A)(implicit context: CPContext = NoCPContext, settings: SettingsProvider = SettingsProvider.default, F: OnFinish[A]): A = {
     val cp = connectionPool(context)
-    using(cp.borrow()) { conn =>
+    F.using(cp.borrow()) { conn =>
       DB(conn, cp.connectionAttributes, settings).autoClose(false).autoCommitWithConnection(execution)
     }
   }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DBConnection.scala
@@ -206,8 +206,8 @@ trait DBConnection extends LogSupport with LoanPattern with AutoCloseable {
    * @tparam A  return type
    * @return result value
    */
-  def readOnly[A](execution: DBSession => A): A = {
-    if (autoCloseEnabled) using(conn)(_ => execution(readOnlySession()))
+  def readOnly[A](execution: DBSession => A)(implicit F: OnFinish[A]): A = {
+    if (autoCloseEnabled) F.using(conn)(_ => execution(readOnlySession()))
     else execution(readOnlySession())
   }
 
@@ -217,7 +217,7 @@ trait DBConnection extends LogSupport with LoanPattern with AutoCloseable {
    * @tparam A  return type
    * @return result value
    */
-  def readOnlyWithConnection[A](execution: Connection => A): A = {
+  def readOnlyWithConnection[A](execution: Connection => A)(implicit F: OnFinish[A]): A = {
     readOnly(s => execution(s.conn))
   }
 
@@ -237,8 +237,8 @@ trait DBConnection extends LogSupport with LoanPattern with AutoCloseable {
    * @tparam A  return type
    * @return result value
    */
-  def autoCommit[A](execution: DBSession => A): A = {
-    if (autoCloseEnabled) using(conn)(_ => execution(autoCommitSession()))
+  def autoCommit[A](execution: DBSession => A)(implicit F: OnFinish[A]): A = {
+    if (autoCloseEnabled) F.using(conn)(_ => execution(autoCommitSession()))
     else execution(autoCommitSession())
   }
 
@@ -248,7 +248,7 @@ trait DBConnection extends LogSupport with LoanPattern with AutoCloseable {
    * @tparam A  return type
    * @return result value
    */
-  def autoCommitWithConnection[A](execution: Connection => A): A = {
+  def autoCommitWithConnection[A](execution: Connection => A)(implicit F: OnFinish[A]): A = {
     autoCommit(s => execution(s.conn))
   }
 

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/OnFinish.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/OnFinish.scala
@@ -1,0 +1,23 @@
+package scalikejdbc
+
+import scalikejdbc.LoanPattern.Closable
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+trait OnFinish[A] {
+  def using[R <: Closable](resource: R)(f: R => A): A
+}
+
+object OnFinish extends LowPriorityImplicitsOnFinish {
+  object Future {
+    implicit def futureOnFinish[A](implicit ec: ExecutionContext): OnFinish[Future[A]] = new OnFinish[Future[A]] {
+      def using[R <: Closable](resource: R)(f: R => Future[A]): Future[A] = LoanPattern.futureUsing(resource)(f)
+    }
+  }
+}
+
+sealed trait LowPriorityImplicitsOnFinish {
+  implicit def onFuture[A]: OnFinish[A] = new OnFinish[A] {
+    def using[R <: Closable](resource: R)(f: R => A): A = LoanPattern.using(resource)(f)
+  }
+}


### PR DESCRIPTION
If execution returns Future, Connection will be closed before completion.