### PR TITLE
Add a handy way to create batch parameters with ParameterBinderFactory

### DIFF
--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -154,7 +154,7 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
 
         // batch insert with BatchParamsBuilder
         {
-          val products: Seq[Product] = Seq(Product(3, Some("Coffee"), Price(90)), Product(3, Some("Coffee"), Price(200)))
+          val products: Seq[Product] = Seq(Product(3, Some("Coffee"), Price(90)), Product(4, Some("Coffee"), Price(200)))
           val params = BatchParamsBuilder {
             products.map { product =>
               Seq(

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -152,6 +152,24 @@ class QueryInterfaceSpec extends FlatSpec with Matchers with DBSettings with SQL
 
         withSQL { delete.from(Product).where.in(pc.id, Seq(3, 4)) }.update.apply()
 
+        // batch insert with BatchParamsBuilder
+        {
+          val products: Seq[Product] = Seq(Product(3, Some("Coffee"), Price(90)), Product(3, Some("Coffee"), Price(200)))
+          val params = BatchParamsBuilder {
+            products.map { product =>
+              Seq(
+                pc.id -> product.id,
+                pc.name -> product.name,
+                pc.price -> product.price)
+            }
+          }
+          withSQL {
+            insert.into(Product).namedValues(params.columnsAndPlaceholders: _*)
+          }.batch(params.batchParams: _*).apply()
+
+          withSQL { delete.from(Product).where.in(pc.id, Seq(3, 4)) }.update.apply()
+        }
+
         val (o, p, a) = (Order.syntax("o"), Product.syntax("p"), Account.syntax("a"))
 
         // simple query


### PR DESCRIPTION
Currently, using `ParameterBinderFactory` with Batch API is a little cumbersome.

On [docs](http://scalikejdbc.org/documentation/operations.html#batch-api), none of the examples use `ParameterBinderFactory`
```scala
import scalikejdbc._

DB localTx { implicit session =>
  val batchParams: Seq[Seq[Any]] = (2001 to 3000).map(i => Seq(i, "name" + i))
  sql"insert into emp (id, name) values (?, ?)".batch(batchParams: _*).apply()
}

DB localTx { implicit session =>
  sql"insert into emp (id, name) values ({id}, {name})"
    .batchByName(Seq(Seq('id -> 1, 'name -> "Alice"), Seq('id -> 2, 'name -> "Bob")):_*)
    .apply()
}

val column = Emp.column
DB localTx { implicit session =>
  val batchParams: Seq[Seq[Any]] = (2001 to 3000).map(i => Seq(i, "name" + i))
  withSQL {
    insert.into(Emp).namedValues(column.id -> sqls.?, column.name -> sqls.?)
  }.batch(batchParams: _*).apply()
}
```

So this PR introduce a handy way to create batch parameters with `ParameterBinderFactory`.

```scala
val emps: Seq[Emp] = ...
val column = Emp.column
DB localTx { implicit session =>
  val builder = BatchParamsBuilder {
    emps.map { emp =>
      Seq(
        column.id   -> emp.id, 
        column.name -> emp.name,
      )
    }
  }
  withSQL {
    insert.into(Emp).namedValues(builder.columnsAndPlaceholders: _*)
  }.batch(builder.batchParams: _*).apply()
}
```