### PR TITLE
[#1064] Add instance of TxBoundary for cats.effect.IO and ioLocalTx

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ lazy val scalatestVersion = SettingKey[String]("scalatestVersion")
 lazy val specs2Version = SettingKey[String]("specs2Version")
 lazy val parserCombinatorsVersion = settingKey[String]("")
 lazy val mockitoVersion = "3.0.0"
+lazy val catsEffect = "1.3.0"
 lazy val collectionCompatVersion = settingKey[String]("")
 
 def gitHash: String = try {
@@ -165,6 +166,7 @@ lazy val scalikejdbcCore = Project(
       "org.slf4j"               %  "slf4j-api"       % _slf4jApiVersion  % "compile",
       "org.scala-lang.modules"  %% "scala-parser-combinators" % parserCombinatorsVersion.value % "compile",
       "org.scala-lang.modules"  %% "scala-collection-compat" % collectionCompatVersion.value,
+      "org.typelevel"           %% "cats-effect" % catsEffect withSources() withJavadoc(),
       // scope: provided
       "commons-dbcp"            %  "commons-dbcp"    % "1.4"             % "provided",
       "com.jolbox"              %  "bonecp"          % "0.8.0.RELEASE"   % "provided",

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DB.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DB.scala
@@ -1,6 +1,7 @@
 package scalikejdbc
 
 import java.sql.Connection
+import cats.effect.IO
 import scalikejdbc.metadata._
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -277,6 +278,24 @@ object DB extends LoanPattern {
     // Enable TxBoundary implicits
     import scalikejdbc.TxBoundary.Future._
     localTx(execution)(context, implicitly, settings)
+  }
+
+  /**
+   * Begins a local-tx block that returns a IO value easily with ConnectionPool.
+   *
+   * @param execution execution that returns a IO value
+   * @param context connection pool context
+   * @tparam A IO result type
+   * @return IO result value
+   */
+  def ioLocalTx[A](execution: DBSession => IO[A])(
+    implicit
+    context: CPContext = NoCPContext,
+    ec: ExecutionContext,
+    settings: SettingsProvider = SettingsProvider.default): IO[A] = {
+    // Enable TxBoundary implicits
+    import scalikejdbc.TxBoundary.IO.ioTxBoundary
+    localTx(execution)(context, ioTxBoundary[A], settings)
   }
 
   /**

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/IOTxBoundarySpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/IOTxBoundarySpec.scala
@@ -1,0 +1,21 @@
+package scalikejdbc
+
+import cats.effect.IO
+import org.mockito.Mockito.{ mock, when }
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ FlatSpec, Matchers }
+import scalikejdbc.TxBoundary.IO.ioTxBoundary
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class IOTxBoundarySpec extends FlatSpec with Matchers with ScalaFutures {
+
+  behavior of "closeConnection()"
+
+  it should "returns Failure when onClose() throws an exception" in {
+    val exception = new RuntimeException
+    val result = ioTxBoundary[Int].closeConnection(IO(1), () => throw exception)
+    result.attempt.unsafeRunSync() should be(Left(exception))
+  }
+}


### PR DESCRIPTION
Issue: https://github.com/scalikejdbc/scalikejdbc/issues/1064