### PR TITLE
[#1064] Generalize localTx with a higher kind to support IO monads

### DIFF
--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DBSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DBSpec.scala
@@ -11,6 +11,7 @@ import scala.util.control.Exception._
 import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration._
 import org.scalatest.concurrent.ScalaFutures
+import scalikejdbc.iomonads.MyIO
 
 import ExecutionContext.Implicits.global
 
@@ -321,6 +322,86 @@ class DBSpec extends FlatSpec with Matchers with BeforeAndAfter with Settings wi
       }
       intercept[Exception] {
         Await.result(failure, 10.seconds)
+      }
+      val res = DB readOnly (s => s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name")))
+      res.get should not be (Some("foo"))
+    }
+  }
+
+  // --------------------
+  // localTx with an IO monad example
+
+  it should "execute single in localTx block with an IO monad" in {
+    val tableName = tableNamePrefix + "_singleInFLocalTx"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+
+      val myIOResult = DB.localTx[MyIO[Option[String]]] { s =>
+        MyIO(s.single("select id from " + tableName + " where id = ?", 1)(rs => rs.string("id")))
+      }
+      myIOResult.run() should equal(Some("1"))
+    }
+  }
+
+  it should "execute list in localTx block with an IO monad" in {
+    val tableName = tableNamePrefix + "_singleInFLocalTx"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      val myIOResult = DB.localTx[MyIO[List[Option[String]]]] { s =>
+        MyIO(s.list("select id from " + tableName + "")(rs => Some(rs.string("id"))))
+      }(boundary = MyIO.myIOTxBoundary)
+      myIOResult.run().size should equal(2)
+    }
+  }
+
+  it should "execute update in localTx block with an IO monad" in {
+    val tableName = tableNamePrefix + "_singleInFLocalTx"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      val myIOCount = DB.localTx[MyIO[Int]] { s =>
+        MyIO(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
+      }(boundary = MyIO.myIOTxBoundary)
+      val firstResult = myIOCount.run()
+      firstResult should equal(1)
+
+      val myIOName = MyIO(firstResult).flatMap { _ =>
+        DB.localTx[MyIO[Option[String]]](s => MyIO(s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name"))))(boundary=MyIO.myIOTxBoundary)
+      }
+      myIOName.run() should be(Some("foo"))
+
+    }
+  }
+
+  it should "not be able to rollback in localTx block with an IO monad" in {
+    val tableName = tableNamePrefix + "_singleInFLocalTx"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      futureUsing(DB(ConnectionPool.borrow())) { db =>
+        val myIOCount = DB localTx[MyIO[Int]] { s =>
+          MyIO(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
+        }
+        myIOCount.run() should equal(1)
+
+        db.rollbackIfActive()
+        val myIOName = DB localTx[MyIO[Option[String]]] { s =>
+          MyIO(s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name")))
+        }
+        myIOName.run() should equal(Some("foo"))
+        Future(myIOName.run())
+      }
+    }
+  }
+
+  it should "do rollback in localTx block with an IO monad" in {
+    val tableName = tableNamePrefix + "_rollback"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      val failure = DB localTx[MyIO[Int]] { implicit s =>
+        MyIO(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
+          .map(_ => s.update("update foo should be rolled back"))
+      }
+      intercept[Exception] {
+        failure.run()
       }
       val res = DB readOnly (s => s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name")))
       res.get should not be (Some("foo"))

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/IOTxBoundarySpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/IOTxBoundarySpec.scala
@@ -1,0 +1,17 @@
+package scalikejdbc
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ FlatSpec, Matchers }
+import scalikejdbc.iomonads.MyIO
+
+class MyIOTxBoundarySpec extends FlatSpec with Matchers with ScalaFutures {
+
+  behavior of "closeConnection()"
+
+  it should "returns Failure when onClose() throws an exception" in {
+    val exception = new RuntimeException
+    val myIOTxBoundary = implicitly[TxBoundary[MyIO[Int]]]
+    val result = myIOTxBoundary.closeConnection(MyIO(1), () => throw exception)
+    result.attempt.run should be(Left(exception))
+  }
+}

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/NamedDBSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/NamedDBSpec.scala
@@ -7,6 +7,8 @@ import util.control.Exception._
 import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration._
 import org.scalatest.concurrent.ScalaFutures
+import scalikejdbc.iomonads.MyIO
+
 import ExecutionContext.Implicits.global
 
 class NamedDBSpec extends FlatSpec with Matchers with BeforeAndAfter with Settings with LoanPattern with ScalaFutures {
@@ -338,6 +340,85 @@ class NamedDBSpec extends FlatSpec with Matchers with BeforeAndAfter with Settin
       }
       intercept[Exception] {
         Await.result(failure, 10.seconds)
+      }
+      val res = NamedDB(Symbol("named")) readOnly (s => s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name")))
+      res.get should not be (Some("foo"))
+    }
+  }
+
+  // --------------------
+  // localTx with an IO monad example
+
+  it should "execute single in localTx block with an IO monad" in {
+    val tableName = tableNamePrefix + "_singleInIOLocalTx"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      val myIOResult = NamedDB(Symbol("named")).localTx[MyIO[Option[String]]]{ s =>
+        MyIO(s.single("select id from " + tableName + " where id = ?", 1)(rs => rs.string("id")))
+      }(MyIO.myIOTxBoundary)
+      myIOResult.run() should equal(Some("1"))
+    }
+  }
+
+  it should "execute list in localTx block with an IO monad" in {
+    val tableName = tableNamePrefix + "_singleInIOLocalTx"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      val myIOResult = NamedDB(Symbol("named")).localTx[MyIO[List[Option[String]]]] { s =>
+        MyIO(s.list("select id from " + tableName + "")(rs => Some(rs.string("id"))))
+      }(boundary = MyIO.myIOTxBoundary)
+      myIOResult.run().size should equal(2)
+    }
+  }
+
+  it should "execute update in localTx block with an IO monad" in {
+    val tableName = tableNamePrefix + "_singleInIOLocalTx"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      val myIOCount = NamedDB(Symbol("named")).localTx[MyIO[Int]] { s =>
+        MyIO(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
+      }(boundary = MyIO.myIOTxBoundary)
+      val result1 = myIOCount.run()
+
+      result1 should equal(1)
+
+      val myIOName = MyIO(result1).flatMap { _ =>
+        DB.localTx[MyIO[Option[String]]](s => MyIO(s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name"))))(boundary = MyIO.myIOTxBoundary)
+      }
+      myIOName.run() should be(Some("foo"))
+    }
+  }
+
+  it should "not be able to rollback in localTx block with an IO monad" in {
+    val tableName = tableNamePrefix + "_singleInIOLocalTx"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      futureUsing(DB(ConnectionPool(Symbol("named")).borrow())) { db =>
+        val myIOCount = NamedDB(Symbol("named"))localTx[MyIO[Int]] { s =>
+          MyIO(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
+        }
+        myIOCount.run() should equal(1)
+
+        db.rollbackIfActive()
+        val myIOName = NamedDB(Symbol("named")).localTx[MyIO[Option[String]]] { s =>
+          MyIO(s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name")))
+        }
+        myIOName.run() should equal(Some("foo"))
+        Future(myIOName.run())
+      }
+    }
+  }
+
+  it should "do rollback in localTx block with an IO monad" in {
+    val tableName = tableNamePrefix + "_rollback"
+    ultimately(TestUtils.deleteTable(tableName)) {
+      TestUtils.initialize(tableName)
+      val failure = NamedDB(Symbol("named")).localTx[MyIO[Int]] { implicit s =>
+        MyIO(s.update("update " + tableName + " set name = ? where id = ?", "foo", 1))
+          .map(_ => s.update("update foo should be rolled back"))
+      }(MyIO.myIOTxBoundary)
+      intercept[Exception] {
+        failure.run()
       }
       val res = NamedDB(Symbol("named")) readOnly (s => s.single("select name from " + tableName + " where id = ?", 1)(rs => rs.string("name")))
       res.get should not be (Some("foo"))

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/iomonads/MyIO.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/iomonads/MyIO.scala
@@ -1,0 +1,52 @@
+package scalikejdbc.iomonads
+
+import scalikejdbc.{ Tx, TxBoundary }
+
+sealed abstract class MyIO[+A] {
+  import MyIO._
+
+  def flatMap[B](f: A => MyIO[B]): MyIO[B] = {
+    this match {
+      case Delay(thunk) => Delay(() => f(thunk()).run())
+    }
+  }
+
+  def map[B](f: A => B): MyIO[B] = flatMap(x => MyIO(f(x)))
+
+  def run(): A = {
+    this match {
+      case Delay(f) => f.apply()
+    }
+  }
+
+  def attempt: MyIO[Either[Throwable, A]] =
+    MyIO(try {
+      Right(run())
+    } catch {
+      case scala.util.control.NonFatal(t) => Left(t)
+    })
+
+}
+
+object MyIO {
+  def apply[A](a: => A): MyIO[A] = Delay(a _)
+
+  final case class Delay[+A](thunk: () => A) extends MyIO[A]
+
+  implicit def myIOTxBoundary[A]: TxBoundary[MyIO[A]] = new TxBoundary[MyIO[A]] {
+
+    def finishTx(result: MyIO[A], tx: Tx): MyIO[A] = {
+      result.attempt.flatMap {
+        case Right(_) => MyIO(tx.commit()).flatMap(_ => result)
+        case Left(_) => MyIO(tx.rollback()).flatMap(_ => result)
+      }
+    }
+
+    override def closeConnection(result: MyIO[A], doClose: () => Unit): MyIO[A] = {
+      for {
+        x <- result
+        _ <- MyIO(doClose).map(x => x.apply())
+      } yield x
+    }
+  }
+}


### PR DESCRIPTION
@seratch the PR I mentionned in https://github.com/scalikejdbc/scalikejdbc/issues/1064#issuecomment-565864809 