### PR TITLE
scalatestplus-testng: use real release, not milestone

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -312,7 +312,7 @@ lazy val scalikejdbcStreams = Project(
       "org.reactivestreams" %  "reactive-streams"          % _reactiveStreamsVersion % "compile",
       "org.slf4j"           %  "slf4j-api"                 % _slf4jApiVersion        % "compile",
       "ch.qos.logback"      %  "logback-classic"           % _logbackVersion         % "test",
-      "org.scalatestplus"   %% "scalatestplus-testng"      % "1.0.0-M2"              % "test",
+      "org.scalatestplus"   %% "testng-6-7"                % "3.1.0.0"               % "test",
       "org.reactivestreams" %  "reactive-streams-tck"      % _reactiveStreamsVersion % "test",
       "org.reactivestreams" %  "reactive-streams-examples" % _reactiveStreamsVersion % "test"
     ) ++ scalaTestDependenciesInTestScope.value ++ jdbcDriverDependenciesInTestScope


### PR DESCRIPTION
(this came up in the Scala community build)