### PR TITLE
fix warnings since Scala 2.13.3

### DIFF
--- a/scalikejdbc-config/src/test/scala/scalikejdbc/config/DBsSpec.scala
+++ b/scalikejdbc-config/src/test/scala/scalikejdbc/config/DBsSpec.scala
@@ -17,7 +17,7 @@ class DBsSpec extends AnyFunSpec with Matchers {
       it("should setup default connection with no argument") {
         DBs.setup()
         val res = DB readOnly { implicit session =>
-          SQL("SELECT 1 as one").map(rs => rs.int("one")).single.apply()
+          SQL("SELECT 1 as one").map(rs => rs.int("one")).single().apply()
         }
         res should be(Some(1))
         DBs.close()
@@ -25,7 +25,7 @@ class DBsSpec extends AnyFunSpec with Matchers {
       it("should setup a connection pool") {
         DBs.setup(Symbol("foo"))
         val res = NamedDB(Symbol("foo")) readOnly { implicit session =>
-          SQL("SELECT 1 as one").map(rs => rs.int("one")).single.apply()
+          SQL("SELECT 1 as one").map(rs => rs.int("one")).single().apply()
         }
         res should be(Some(1))
         DBs.close(Symbol("foo"))
@@ -33,7 +33,7 @@ class DBsSpec extends AnyFunSpec with Matchers {
       it("should setup env & top level config") {
         DBs.setup(Symbol("topLevelDefaults"))
         val res = NamedDB(Symbol("topLevelDefaults")) readOnly { implicit session =>
-          SQL("SELECT 1 as one").map(rs => rs.int("one")).single.apply()
+          SQL("SELECT 1 as one").map(rs => rs.int("one")).single().apply()
         }
         res should be(Some(1))
         DBs.close(Symbol("topLevelDefaults"))
@@ -51,11 +51,11 @@ class DBsSpec extends AnyFunSpec with Matchers {
       it("should read application.conf and setup all connection pool") {
         DBs.setupAll()
         val res = NamedDB(Symbol("foo")) readOnly { implicit session =>
-          SQL("SELECT 1 as one").map(rs => rs.int("one")).single.apply()
+          SQL("SELECT 1 as one").map(rs => rs.int("one")).single().apply()
         }
         res should be(Some(1))
         val res2 = NamedDB(Symbol("bar")) readOnly { implicit session =>
-          SQL("SELECT 1 as one").map(rs => rs.int("one")).single.apply()
+          SQL("SELECT 1 as one").map(rs => rs.int("one")).single().apply()
         }
         res2 should be(Some(1))
         DBs.closeAll()
@@ -63,7 +63,7 @@ class DBsSpec extends AnyFunSpec with Matchers {
       it("should read application.conf with env (dev)") {
         DBsWithEnv("dev").setupAll()
         val res = DB readOnly { implicit session =>
-          SQL("SELECT 1 as one").map(rs => rs.int("one")).single.apply()
+          SQL("SELECT 1 as one").map(rs => rs.int("one")).single().apply()
         }
         res should be(Some(1))
         DBs.closeAll()
@@ -71,7 +71,7 @@ class DBsSpec extends AnyFunSpec with Matchers {
       it("should read application.conf with env (dev2)") {
         DBsWithEnv("dev2").setupAll()
         val res = NamedDB(Symbol("hocon")) readOnly { implicit session =>
-          SQL("SELECT 1 as one").map(rs => rs.int("one")).single.apply()
+          SQL("SELECT 1 as one").map(rs => rs.int("one")).single().apply()
         }
         res should be(Some(1))
         DBs.closeAll()
@@ -86,11 +86,11 @@ class DBsSpec extends AnyFunSpec with Matchers {
           DBs.close()
           intercept[IllegalStateException] {
             DB readOnly { implicit session =>
-              SQL("SELECT 1 as one").map(rs => rs.int("one")).single.apply()
+              SQL("SELECT 1 as one").map(rs => rs.int("one")).single().apply()
             }
           }
           val res = NamedDB(Symbol("foo")) readOnly { implicit session =>
-            SQL("SELECT 1 as one").map(rs => rs.int("one")).single.apply()
+            SQL("SELECT 1 as one").map(rs => rs.int("one")).single().apply()
           }
           res should be(Some(1))
           DBs.close(Symbol("foo"))
@@ -102,7 +102,7 @@ class DBsSpec extends AnyFunSpec with Matchers {
         DBs.close(Symbol("foo"))
         intercept[IllegalStateException] {
           NamedDB(Symbol("foo")) readOnly { implicit session =>
-            SQL("SELECT 1 as one").map(rs => rs.int("one")).single.apply()
+            SQL("SELECT 1 as one").map(rs => rs.int("one")).single().apply()
           }
         }
       }
@@ -115,12 +115,12 @@ class DBsSpec extends AnyFunSpec with Matchers {
         DBs.closeAll()
         intercept[IllegalStateException] {
           NamedDB(Symbol("foo")) readOnly { implicit session =>
-            SQL("SELECT 1 as one").map(rs => rs.int("one")).single.apply()
+            SQL("SELECT 1 as one").map(rs => rs.int("one")).single().apply()
           }
         }
         intercept[IllegalStateException] {
           NamedDB(Symbol("bar")) readOnly { implicit session =>
-            SQL("SELECT 1 as one").map(rs => rs.int("one")).single.apply()
+            SQL("SELECT 1 as one").map(rs => rs.int("one")).single().apply()
           }
         }
       }

--- a/scalikejdbc-core/src/test/scala/BasicUsageSpec.scala
+++ b/scalikejdbc-core/src/test/scala/BasicUsageSpec.scala
@@ -171,31 +171,31 @@ class BasicUsageSpec extends AnyFlatSpec with Matchers with LoanPattern {
 
         val eopt: Option[Emp] = DB readOnly { implicit session =>
           SQL("select * from emp_BasicUsageSpec_SQL where id = ?").bind(1)
-            .map(rs => Emp(rs.int("id"), rs.string("name"))).single.apply()
+            .map(rs => Emp(rs.int("id"), rs.string("name"))).single().apply()
         }
         eopt.isDefined should be(true)
 
         val ehead: Option[Emp] = DB readOnly { implicit session =>
           SQL("select * from emp_BasicUsageSpec_SQL")
-            .map(rs => Emp(rs.int("id"), rs.string("name"))).first.apply()
+            .map(rs => Emp(rs.int("id"), rs.string("name"))).first().apply()
         }
         ehead.isDefined should be(true)
 
         val es: List[Emp] = DB readOnly { implicit session =>
           SQL("select * from emp_BasicUsageSpec_SQL")
-            .map(rs => Emp(rs.int("id"), rs.string("name"))).list.apply()
+            .map(rs => Emp(rs.int("id"), rs.string("name"))).list().apply()
         }
         es.size should equal(2)
 
         val tr: Iterable[Emp] = DB readOnly { implicit session =>
           SQL("select * from emp_BasicUsageSpec_SQL")
-            .map(rs => Emp(rs.int("id"), rs.string("name"))).iterable.apply()
+            .map(rs => Emp(rs.int("id"), rs.string("name"))).iterable().apply()
         }
 
         {
           implicit val session = DB(conn).readOnlySession()
           val e2s: List[Emp2] = SQL("select * from emp_BasicUsageSpec_SQL")
-            .map(rs => Emp2(rs.int("id"), Option(rs.string("name")))).list.apply()
+            .map(rs => Emp2(rs.int("id"), Option(rs.string("name")))).list().apply()
           e2s.size should equal(2)
           var sum: Long = 0L
           SQL("select id from emp_BasicUsageSpec_SQL").foreach { rs => sum += rs.long("id") }
@@ -217,19 +217,19 @@ class BasicUsageSpec extends AnyFlatSpec with Matchers with LoanPattern {
         DB autoCommit { implicit s =>
           try {
             val sql = SQL("select * from emp order by id limit 10").map(empMapper)
-            sql.list.apply() // trying limit keyword for this database
+            sql.list().apply() // trying limit keyword for this database
             sql // ok, this database supports limit keyword
           } catch {
             case e: Exception =>
               val sql = SQL("select * from emp order by id fetch first 10 rows only").map(empMapper)
-              sql.list.apply()
+              sql.list().apply()
               sql
           }
         }
       }
 
       // SQLTo* instances are also reusable
-      val get10EmpAllSQL: SQLToList[Emp, HasExtractor] = get10EmpSQL.list // or #toList
+      val get10EmpAllSQL: SQLToList[Emp, HasExtractor] = get10EmpSQL.list() // or #toList
 
       DB autoCommit { implicit s =>
 
@@ -237,17 +237,17 @@ class BasicUsageSpec extends AnyFlatSpec with Matchers with LoanPattern {
         val emps: List[Emp] = get10EmpAllSQL.apply()
         emps.size should be <= 10
 
-        val getFirstOf10Emp: SQLToOption[Emp, HasExtractor] = get10EmpSQL.first // or #headOption
+        val getFirstOf10Emp: SQLToOption[Emp, HasExtractor] = get10EmpSQL.first() // or #headOption
         val firstEmp: Option[Emp] = getFirstOf10Emp.apply()
         firstEmp.isDefined should be(true)
 
         // expects single result or nothing, when mutiple results are returned, Exception will be thrown.
-        val single: Option[Emp] = SQL("select * from emp where id = ?").bind(1).map(empMapper).single.apply() // or #toOption
+        val single: Option[Emp] = SQL("select * from emp where id = ?").bind(1).map(empMapper).single().apply() // or #toOption
         single.isDefined should be(true)
 
         // Execute DDL
         try {
-          SQL("drop table company").execute.apply()
+          SQL("drop table company").execute().apply()
         } catch { case e: Exception => }
         try {
           val result: Boolean = SQL("""
@@ -256,9 +256,9 @@ class BasicUsageSpec extends AnyFlatSpec with Matchers with LoanPattern {
               name varchar(30) not null,
               description varchar(1000),
               created_at timestamp
-            );""").execute.apply()
+            );""").execute().apply()
         } catch { case e: Exception => }
-        SQL("truncate table company").execute.apply()
+        SQL("truncate table company").execute().apply()
 
         // simply using statement with ?(place holder)
         SQL("""insert into company values (?, ?, ?, ?);""")
@@ -267,7 +267,7 @@ class BasicUsageSpec extends AnyFlatSpec with Matchers with LoanPattern {
             "Typesafe",
             """Typesafe makes it easy to build software based on the open source Scala programming language, Akka middleware, and Play web framework.
              From multicore to cloud computing, it's purpose built for scale.""",
-            LocalDateTime.now).update.apply()
+            LocalDateTime.now).update().apply()
 
         // Anorm like template
         SQL("""
@@ -280,7 +280,7 @@ class BasicUsageSpec extends AnyFlatSpec with Matchers with LoanPattern {
           Symbol("id") -> 2,
           Symbol("name") -> "Typesafe",
           Symbol("description") -> "xxx",
-          Symbol("createdAt") -> LocalDateTime.now).update.apply()
+          Symbol("createdAt") -> LocalDateTime.now).update().apply()
 
         // executable template
         SQL("""
@@ -293,7 +293,7 @@ class BasicUsageSpec extends AnyFlatSpec with Matchers with LoanPattern {
           Symbol("id") -> 3,
           Symbol("name") -> "Typesafe",
           Symbol("description") -> "xxx",
-          Symbol("createdAt") -> LocalDateTime.now).update.apply()
+          Symbol("createdAt") -> LocalDateTime.now).update().apply()
 
       }
     } finally { TestUtils.deleteTable("emp") }
@@ -307,13 +307,13 @@ class BasicUsageSpec extends AnyFlatSpec with Matchers with LoanPattern {
         GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings
 
         try {
-          SQL("drop table logging_sql_and_timing").execute.apply()
+          SQL("drop table logging_sql_and_timing").execute().apply()
         } catch { case e: Exception => }
-        SQL("create table logging_sql_and_timing (id int primary key, name varchar(13) not null)").execute.apply()
+        SQL("create table logging_sql_and_timing (id int primary key, name varchar(13) not null)").execute().apply()
 
         // bulk insert
         1 to 10000 foreach { i =>
-          SQL("insert into  logging_sql_and_timing values (?,?)").bind(i, "id_%010d".format(i)).update.apply()
+          SQL("insert into  logging_sql_and_timing values (?,?)").bind(i, "id_%010d".format(i)).update().apply()
         }
 
         GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings(
@@ -322,12 +322,12 @@ class BasicUsageSpec extends AnyFlatSpec with Matchers with LoanPattern {
           warningLogLevel = Symbol("INFO"),
           warningThresholdMillis = 10L)
         // this query will spend more than 10 millis
-        SQL("select  *  from logging_sql_and_timing").map(rs => rs.int("id")).list.apply()
+        SQL("select  *  from logging_sql_and_timing").map(rs => rs.int("id")).list().apply()
 
       } finally {
         GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings
         try {
-          SQL("drop table logging_sql_and_timing").execute.apply()
+          SQL("drop table logging_sql_and_timing").execute().apply()
         } catch { case e: Exception => }
       }
     }

--- a/scalikejdbc-core/src/test/scala/models/Member.scala
+++ b/scalikejdbc-core/src/test/scala/models/Member.scala
@@ -41,23 +41,23 @@ object Member extends JavaUtilDateConverterImplicits {
   }
 
   def find(id: Long)(implicit session: DBSession = AutoSession): Option[Member] = {
-    SQL("""SELECT * FROM MEMBER WHERE ID = /*'id*/1""").bindByName(Symbol("id") -> id).map(*).single.apply()
+    SQL("""SELECT * FROM MEMBER WHERE ID = /*'id*/1""").bindByName(Symbol("id") -> id).map(*).single().apply()
   }
 
   def findAll()(implicit session: DBSession = AutoSession): List[Member] = {
-    SQL("""SELECT * FROM MEMBER""").map(*).list.apply()
+    SQL("""SELECT * FROM MEMBER""").map(*).list().apply()
   }
 
   def countAll()(implicit session: DBSession = AutoSession): Long = {
-    SQL("""SELECT COUNT(1) FROM MEMBER""").map(rs => rs.long(1)).single.apply().get
+    SQL("""SELECT COUNT(1) FROM MEMBER""").map(rs => rs.long(1)).single().apply().get
   }
 
   def findBy(where: String, params: (Symbol, Any)*)(implicit session: DBSession = AutoSession): List[Member] = {
-    SQL("""SELECT * FROM MEMBER WHERE """ + where).bindByName(params: _*).map(*).list.apply()
+    SQL("""SELECT * FROM MEMBER WHERE """ + where).bindByName(params: _*).map(*).list().apply()
   }
 
   def countBy(where: String, params: (Symbol, Any)*)(implicit session: DBSession = AutoSession): Long = {
-    SQL("""SELECT count(1) FROM MEMBER WHERE """ + where).bindByName(params: _*).map(rs => rs.long(1)).single.apply().get
+    SQL("""SELECT count(1) FROM MEMBER WHERE """ + where).bindByName(params: _*).map(rs => rs.long(1)).single().apply().get
   }
 
   def create(
@@ -86,7 +86,7 @@ object Member extends JavaUtilDateConverterImplicits {
         Symbol("name") -> name,
         Symbol("description") -> description,
         Symbol("birthday") -> birthday,
-        Symbol("createdAt") -> createdAt).update.apply()
+        Symbol("createdAt") -> createdAt).update().apply()
 
     Member(
       id = id,
@@ -114,13 +114,13 @@ object Member extends JavaUtilDateConverterImplicits {
         Symbol("name") -> m.name,
         Symbol("description") -> m.description,
         Symbol("birthday") -> m.birthday,
-        Symbol("createdAt") -> m.createdAt).update.apply()
+        Symbol("createdAt") -> m.createdAt).update().apply()
     m
   }
 
   def delete(m: Member)(implicit session: DBSession = AutoSession): Unit = {
     SQL("""DELETE FROM MEMBER WHERE ID = /*'id*/1""")
-      .bindByName(Symbol("id") -> m.id).update.apply()
+      .bindByName(Symbol("id") -> m.id).update().apply()
   }
 
 }
@@ -162,23 +162,23 @@ object NamedMember {
   }
 
   def find(id: Long)(implicit session: DBSession = NamedAutoSession(Symbol("named"))): Option[NamedMember] = {
-    SQL("""SELECT * FROM NAMED_MEMBER WHERE ID = /*'id*/1""").bindByName(Symbol("id") -> id).map(*).single.apply()
+    SQL("""SELECT * FROM NAMED_MEMBER WHERE ID = /*'id*/1""").bindByName(Symbol("id") -> id).map(*).single().apply()
   }
 
   def findAll()(implicit session: DBSession = NamedAutoSession(Symbol("named"))): List[NamedMember] = {
-    SQL("""SELECT * FROM NAMED_MEMBER""").map(*).list.apply()
+    SQL("""SELECT * FROM NAMED_MEMBER""").map(*).list().apply()
   }
 
   def countAll()(implicit session: DBSession = NamedAutoSession(Symbol("named"))): Long = {
-    SQL("""SELECT COUNT(1) FROM NAMED_MEMBER""").map(rs => rs.long(1)).single.apply().get
+    SQL("""SELECT COUNT(1) FROM NAMED_MEMBER""").map(rs => rs.long(1)).single().apply().get
   }
 
   def findBy(where: String, params: (Symbol, Any)*)(implicit session: DBSession = NamedAutoSession(Symbol("named"))): List[NamedMember] = {
-    SQL("""SELECT * FROM NAMED_MEMBER WHERE """ + where).bindByName(params: _*).map(*).list.apply()
+    SQL("""SELECT * FROM NAMED_MEMBER WHERE """ + where).bindByName(params: _*).map(*).list().apply()
   }
 
   def countBy(where: String, params: (Symbol, Any)*)(implicit session: DBSession = NamedAutoSession(Symbol("named"))): Long = {
-    SQL("""SELECT count(1) FROM NAMED_MEMBER WHERE """ + where).bindByName(params: _*).map(rs => rs.long(1)).single.apply().get
+    SQL("""SELECT count(1) FROM NAMED_MEMBER WHERE """ + where).bindByName(params: _*).map(rs => rs.long(1)).single().apply().get
   }
 
   def create(
@@ -207,7 +207,7 @@ object NamedMember {
         Symbol("name") -> name,
         Symbol("description") -> description,
         Symbol("birthday") -> birthday,
-        Symbol("createdAt") -> createdAt).update.apply()
+        Symbol("createdAt") -> createdAt).update().apply()
 
     NamedMember(
       id = id,
@@ -235,13 +235,13 @@ object NamedMember {
         Symbol("name") -> m.name,
         Symbol("description") -> m.description,
         Symbol("birthday") -> m.birthday,
-        Symbol("createdAt") -> m.createdAt).update.apply()
+        Symbol("createdAt") -> m.createdAt).update().apply()
     m
   }
 
   def delete(m: NamedMember)(implicit session: DBSession = NamedAutoSession(Symbol("named"))): Unit = {
     SQL("""DELETE FROM NAMED_MEMBER WHERE ID = /*'id*/1""")
-      .bindByName(Symbol("id") -> m.id).update.apply()
+      .bindByName(Symbol("id") -> m.id).update().apply()
   }
 
 }
@@ -253,20 +253,20 @@ object MemberSQLTemplate {
   def find(): Option[Member] = {
     DB readOnly { implicit session =>
       SQL("""SELECT * FROM MEMBER WHERE ID = /*'id*/123""")
-        .map(*).single.apply()
+        .map(*).single().apply()
     }
   }
 
   def findAll(): List[Member] = {
     DB readOnly { implicit session =>
-      SQL("""SELECT * FROM MEMBER""").map(*).list.apply()
+      SQL("""SELECT * FROM MEMBER""").map(*).list().apply()
     }
   }
 
   def countAll(): Long = {
     DB readOnly { implicit session =>
       SQL("""SELECT COUNT(1) FROM MEMBER""")
-        .map(rs => rs.long(1)).single.apply().get
+        .map(rs => rs.long(1)).single().apply().get
     }
   }
 
@@ -286,7 +286,7 @@ object MemberSQLTemplate {
           /*'birthday*/'1980-04-06',
           /*'createdAt*/'2012-05-06 12:34:56'
         )
-          """).update.apply()
+          """).update().apply()
     }
     Member.find(123).get
   }
@@ -304,7 +304,7 @@ object MemberSQLTemplate {
           CREATED_AT = /*'createdAt*/'2012-05-04 12:23:34'
         WHERE
           ID = /*'id*/123
-          """).update.apply()
+          """).update().apply()
     }
     Member.find(123).get
   }
@@ -312,7 +312,7 @@ object MemberSQLTemplate {
   def delete(): Unit = {
     DB localTx { implicit session =>
       SQL("""DELETE FROM MEMBER WHERE ID = /*'id*/123""")
-        .update.apply()
+        .update().apply()
     }
   }
 

--- a/scalikejdbc-core/src/test/scala/models/MemberOnMemorySpec.scala
+++ b/scalikejdbc-core/src/test/scala/models/MemberOnMemorySpec.scala
@@ -19,7 +19,7 @@ class MemberOnMemorySpec extends AnyFlatSpec with Matchers {
     NamedDB(Symbol("MemberSpec")) autoCommit {
       implicit session =>
         try {
-          SQL("drop table member").execute.apply()
+          SQL("drop table member").execute().apply()
         } catch {
           case e: Exception =>
         }
@@ -31,7 +31,7 @@ class MemberOnMemorySpec extends AnyFlatSpec with Matchers {
               birthday date,
               created_at timestamp not null
             )
-             """).execute.apply()
+             """).execute().apply()
     }
 
     NamedDB(Symbol("MemberSpec")) localTx {

--- a/scalikejdbc-core/src/test/scala/models/MemberSpec.scala
+++ b/scalikejdbc-core/src/test/scala/models/MemberSpec.scala
@@ -14,7 +14,7 @@ class MemberSpec extends AnyFlatSpec with Matchers with Settings {
 
     DB autoCommit { implicit session =>
       try {
-        SQL("drop table MEMBER").execute.apply()
+        SQL("drop table MEMBER").execute().apply()
       } catch {
         case e: Exception =>
       }
@@ -27,7 +27,7 @@ class MemberSpec extends AnyFlatSpec with Matchers with Settings {
               birthday date,
               created_at timestamp not null
             )
-            """).execute.apply()
+            """).execute().apply()
       } catch {
         case e: Exception =>
       }
@@ -79,7 +79,7 @@ class MemberSpec extends AnyFlatSpec with Matchers with Settings {
 
     NamedDB(Symbol("named")) autoCommit { implicit session =>
       try {
-        SQL("drop table NAMED_MEMBER").execute.apply()
+        SQL("drop table NAMED_MEMBER").execute().apply()
       } catch {
         case e: Exception =>
       }
@@ -91,7 +91,7 @@ class MemberSpec extends AnyFlatSpec with Matchers with Settings {
               birthday date,
               created_at timestamp not null
             )
-          """).execute.apply()
+          """).execute().apply()
     }
 
     // use model

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/ActiveSessionSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/ActiveSessionSpec.scala
@@ -32,7 +32,7 @@ class ActiveSessionSpec extends AnyFlatSpec with Matchers {
     val conn: Connection = mock(classOf[Connection])
 
     val tx = mock(classOf[Tx])
-    when(tx.isActive).thenReturn(true)
+    when(tx.isActive()).thenReturn(true)
     val txOpt: Option[Tx] = Some(tx)
 
     val isReadOnly: Boolean = false

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/ConnectionPoolSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/ConnectionPoolSpec.scala
@@ -71,9 +71,9 @@ class ConnectionPoolSpec extends AnyFlatSpec with Matchers {
     ConnectionPool.add(Symbol("sample"), url, user, password)
     try {
       NamedDB(Symbol("sample")) autoCommit { implicit s =>
-        try SQL("create table data_source_test(id bigint not null)").execute.apply()
+        try SQL("create table data_source_test(id bigint not null)").execute().apply()
         catch { case e: Exception => e.printStackTrace }
-        SQL("insert into data_source_test values (123)").update.apply()
+        SQL("insert into data_source_test values (123)").update().apply()
       }
       val ds = new org.apache.commons.dbcp.BasicDataSource
       ds.setUrl(url)
@@ -82,13 +82,13 @@ class ConnectionPoolSpec extends AnyFlatSpec with Matchers {
       ConnectionPool.add(Symbol("ds"), new DataSourceConnectionPool(ds))
 
       NamedDB(Symbol("ds")) readOnly { implicit s =>
-        val count = SQL("select count(1) from data_source_test").map(_.long(1)).single.apply().get
+        val count = SQL("select count(1) from data_source_test").map(_.long(1)).single().apply().get
         count should equal(1L)
       }
 
     } finally {
       NamedDB(Symbol("sample")) autoCommit { implicit s =>
-        try SQL("drop table data_source_test").execute.apply()
+        try SQL("drop table data_source_test").execute().apply()
         catch { case e: Exception => e.printStackTrace }
       }
     }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/ConnectionPoolsSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/ConnectionPoolsSpec.scala
@@ -28,19 +28,19 @@ class ConnectionPoolsSpec extends AnyFlatSpec with Matchers {
 
     val tableName = "connection_pool_" + System.currentTimeMillis
     NamedDB(Symbol("dbcp")).autoCommit { implicit s =>
-      SQL(s"create table ${tableName} (id int, name varchar(256))").execute.apply()
-      SQL(s"insert into ${tableName} (id, name) values (1, 'commons-dbcp')").update.apply()
-      SQL(s"insert into ${tableName} (id, name) values (2, 'hikaricp')").update.apply()
-      SQL(s"insert into ${tableName} (id, name) values (3, 'bonecp')").update.apply()
+      SQL(s"create table ${tableName} (id int, name varchar(256))").execute().apply()
+      SQL(s"insert into ${tableName} (id, name) values (1, 'commons-dbcp')").update().apply()
+      SQL(s"insert into ${tableName} (id, name) values (2, 'hikaricp')").update().apply()
+      SQL(s"insert into ${tableName} (id, name) values (3, 'bonecp')").update().apply()
     }
 
     NamedDB(Symbol("dbcp")).readOnly { implicit s =>
-      val count = SQL(s"select count(1) from ${tableName}").map(_.long(1)).single.apply()
+      val count = SQL(s"select count(1) from ${tableName}").map(_.long(1)).single().apply()
       count should equal(Some(3))
     }
 
     NamedDB(Symbol("bonecp")).readOnly { implicit s =>
-      val count = SQL(s"select count(1) from ${tableName}").map(_.long(1)).single.apply()
+      val count = SQL(s"select count(1) from ${tableName}").map(_.long(1)).single().apply()
       count should equal(Some(3))
     }
 
@@ -56,7 +56,7 @@ class ConnectionPoolsSpec extends AnyFlatSpec with Matchers {
     ConnectionPool.add(Symbol("hikaricp"), new DataSourceConnectionPool(dataSource))
 
     NamedDB(Symbol("hikaricp")).readOnly { implicit s =>
-      val count = SQL(s"select count(1) from ${tableName}").map(_.long(1)).single.apply()
+      val count = SQL(s"select count(1) from ${tableName}").map(_.long(1)).single().apply()
       count should equal(Some(3))
     }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DBSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DBSpec.scala
@@ -630,7 +630,7 @@ class DBSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with Settings
     }) {
       TestUtils.initialize(tableName)
       DB localTx { implicit s =>
-        SQL("insert into " + tableName + " values (?,?)").bind(3, "so what?").update.apply()
+        SQL("insert into " + tableName + " values (?,?)").bind(3, "so what?").update().apply()
       }
       GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
         enabled = true,
@@ -638,11 +638,11 @@ class DBSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with Settings
       DB readOnly { implicit s =>
         val res1 = SQL("select * from " + tableName + " where name =  /* why? */ 'so what?' and id = ? /* really? */ -- line?")
           .bind(3)
-          .map(rs => rs.string("name")).list.apply()
+          .map(rs => rs.string("name")).list().apply()
         res1.size should equal(1)
         val res2 = SQL("select * from " + tableName + " where name = /* why? */ 'so what?' and id = /*'id*/123 /* really? */ -- line?")
           .bindByName(Symbol("id") -> 3)
-          .map(rs => rs.string("name")).list.apply()
+          .map(rs => rs.string("name")).list().apply()
         res2.size should equal(1)
       }
     }
@@ -728,12 +728,12 @@ class DBSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with Settings
       val tableName = s"issue245_${System.currentTimeMillis}"
       try {
         DB autoCommit { implicit s =>
-          SQL(s"create table `${tableName}` (some_setting tinyint(1) NOT NULL DEFAULT '1')").execute.apply()
+          SQL(s"create table `${tableName}` (some_setting tinyint(1) NOT NULL DEFAULT '1')").execute().apply()
         }
         val table = DB.getTable(tableName)
         table.isDefined should equal(true)
       } finally {
-        try DB autoCommit { implicit s => SQL(s"drop table ${tableName}").execute.apply() }
+        try DB autoCommit { implicit s => SQL(s"drop table ${tableName}").execute().apply() }
         catch { case e: Exception => }
       }
     }
@@ -800,7 +800,7 @@ class DBSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with Settings
 
       {
         val result: collection.Seq[String] = DB readOnly { implicit session =>
-          SQL("select * from " + tableName + "").fetchSize(222).map(rs => rs.string("name")).list.apply()
+          SQL("select * from " + tableName + "").fetchSize(222).map(rs => rs.string("name")).list().apply()
         }
         result.size should be > 0
       }
@@ -854,7 +854,7 @@ class DBSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with Settings
 
       {
         val result: collection.Seq[String] = DB readOnly { implicit session =>
-          SQL("select * from " + tableName + "").queryTimeout(222).map(rs => rs.string("name")).list.apply()
+          SQL("select * from " + tableName + "").queryTimeout(222).map(rs => rs.string("name")).list().apply()
         }
         result.size should be > 0
       }
@@ -863,7 +863,7 @@ class DBSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with Settings
         // set invalid value
         intercept[java.sql.SQLException] {
           DB readOnly { implicit session =>
-            SQL("select * from " + tableName + "").queryTimeout(-1).map(rs => rs.string("name")).list.apply()
+            SQL("select * from " + tableName + "").queryTimeout(-1).map(rs => rs.string("name")).list().apply()
           }
         }
       }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DB_AnormSQLOperationSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DB_AnormSQLOperationSpec.scala
@@ -76,7 +76,7 @@ class DB_AnormSQLOperationSpec extends AnyFlatSpec with Matchers with BeforeAndA
           implicit session =>
             SQL("select name from " + tableName + " where id = {id}")
               .bindByName(Symbol("id") -> 1)
-              .map(rs => rs.string("name")).single.apply()
+              .map(rs => rs.string("name")).single().apply()
         }).get
         name should equal("foo")
       }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DB_ExecutableSQLOperationSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DB_ExecutableSQLOperationSpec.scala
@@ -75,7 +75,7 @@ class DB_ExecutableSQLOperationSpec extends AnyFlatSpec with Matchers with Befor
           implicit session =>
             SQL("select name from " + tableName + " where id = /* 'id */123")
               .bindByName(Symbol("id") -> 1)
-              .map(rs => rs.string("name")).single.apply()
+              .map(rs => rs.string("name")).single().apply()
         }).get
         name should equal("foo")
       }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DB_MetaDataSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DB_MetaDataSpec.scala
@@ -531,7 +531,7 @@ class DB_MetaDataSpec extends AnyFlatSpec with Matchers with Settings with LogSu
   private def execute(sqls: String*)(implicit session: DBSession): Unit = {
     for (sql <- sqls) {
       try {
-        SQL(sql).execute.apply()
+        SQL(sql).execute().apply()
         return
       } catch {
         case e: Exception =>

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DB_SQLOperationSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DB_SQLOperationSpec.scala
@@ -33,7 +33,7 @@ class DB_SQLOperationSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
             logLevel = Symbol("info"))
           val result = SQL("select * from " + tableName + " where name = 'name1' and id = /*'id*/123;")
             .bindByName(Symbol("id") -> 1)
-            .map(rs => Some(rs.string("name"))).toList.apply()
+            .map(rs => Some(rs.string("name"))).toList().apply()
           result.size should equal(1)
           GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(enabled = false)
       }
@@ -46,7 +46,7 @@ class DB_SQLOperationSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
       TestUtils.initialize(tableName)
       implicit val session = DB.readOnlySession()
       try {
-        val result = SQL("select * from " + tableName + "").map(rs => Some(rs.string("name"))).toList.apply()
+        val result = SQL("select * from " + tableName + "").map(rs => Some(rs.string("name"))).toList().apply()
         result.size should be > 0
       } finally {
         session.close()
@@ -206,7 +206,7 @@ class DB_SQLOperationSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
 
       // should be committed
       val name = DB readOnly { implicit s =>
-        SQL("select name from " + tableName + " where id = ?").bind(1).map(_.string("name")).single.apply().get
+        SQL("select name from " + tableName + " where id = ?").bind(1).map(_.string("name")).single().apply().get
       }
       name should equal("foo")
     }
@@ -292,7 +292,7 @@ class DB_SQLOperationSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
 
       // should not be committed
       val name = DB readOnly { implicit s =>
-        SQL("select name from " + tableName + " where id = ?").bind(1).map(_.string("name")).single.apply().get
+        SQL("select name from " + tableName + " where id = ?").bind(1).map(_.string("name")).single().apply().get
       }
       name should equal("name1")
     }
@@ -534,7 +534,7 @@ class DB_SQLOperationSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
       using(ConnectionPool.borrow()) { conn =>
         val name = DB(conn) autoCommit {
           implicit session =>
-            SQL("select name from " + tableName + " where id = ?").bind(1).map(rs => rs.string("name")).single.apply()
+            SQL("select name from " + tableName + " where id = ?").bind(1).map(rs => rs.string("name")).single().apply()
         }
         name.get should equal("name1")
       }
@@ -548,14 +548,14 @@ class DB_SQLOperationSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
     try {
       DB autoCommit { implicit session =>
         try {
-          SQL("drop table issue30;").execute.apply()
+          SQL("drop table issue30;").execute().apply()
         } catch { case e: Exception => }
         SQL("""
         create table issue30 (
           id bigint not null,
           data1 varchar(255) not null,
           data2 varchar(255) not null
-        );""").execute.apply()
+        );""").execute().apply()
         SQL("""insert into issue30 (id, data1, data2) values(?, ?, ?)""").batch(
           (101 to 121) map { i => Seq(i, "a", "b") }: _*).apply()
         SQL("""insert into issue30 (id, data1, data2) values(?, ?, ?)""").batch(
@@ -564,7 +564,7 @@ class DB_SQLOperationSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
     } finally {
       try {
         DB autoCommit { implicit s =>
-          SQL("drop table issue30;").execute.apply()
+          SQL("drop table issue30;").execute().apply()
         }
       } catch { case e: Exception => }
       GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings()
@@ -576,8 +576,8 @@ class DB_SQLOperationSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
     ultimately(TestUtils.deleteTable(tableName)) {
       TestUtils.initialize(tableName)
       val result = DB localTx { implicit s =>
-        SQL("insert into " + tableName + " values (?, ?)").bind(4, Option(null)).update.apply()
-        SQL("select id, name from " + tableName + " where id = ?").bind(4).map(rs => rs.toMap).single.apply()
+        SQL("insert into " + tableName + " values (?, ?)").bind(4, Option(null)).update().apply()
+        SQL("select id, name from " + tableName + " where id = ?").bind(4).map(rs => rs.toMap()).single().apply()
       }
       result.isDefined should equal(true)
       if (result.get.get("ID").isDefined) {
@@ -596,8 +596,8 @@ class DB_SQLOperationSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
     ultimately(TestUtils.deleteTable(tableName)) {
       TestUtils.initialize(tableName)
       val result = DB localTx { implicit s =>
-        SQL("insert into " + tableName + " values (?, ?)").bind(4, Option(null)).update.apply()
-        SQL("select id, name from " + tableName + " where id = ?").bind(4).map(rs => rs.toSymbolMap).single.apply()
+        SQL("insert into " + tableName + " values (?, ?)").bind(4, Option(null)).update().apply()
+        SQL("select id, name from " + tableName + " where id = ?").bind(4).map(rs => rs.toSymbolMap()).single().apply()
       }
       result.isDefined should equal(true)
       if (result.get.get(Symbol("ID")).isDefined) {

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/GlobalSettingsSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/GlobalSettingsSpec.scala
@@ -13,24 +13,24 @@ class GlobalSettingsSpec extends AnyFlatSpec with Matchers with Settings with Lo
     DB autoCommit { implicit session =>
       try {
         try {
-          SQL("drop table settings_example").execute.apply()
+          SQL("drop table settings_example").execute().apply()
         } catch { case e: Exception => }
         SQL("create table settings_example (id int primary key, name varchar(13) not null)")
-          .execute.apply()
+          .execute().apply()
         1 to 20000 foreach { i =>
           GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings()
-          SQL("insert into settings_example values (?,?)").bind(i, "id_%010d".format(i)).update.apply()
+          SQL("insert into settings_example values (?,?)").bind(i, "id_%010d".format(i)).update().apply()
         }
         GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings(
           enabled = true,
           warningEnabled = true,
           warningLogLevel = Symbol("INFO"),
           warningThresholdMillis = 10L)
-        SQL("select  * from settings_example").map(rs => rs.int("id")).list.apply()
+        SQL("select  * from settings_example").map(rs => rs.int("id")).list().apply()
       } finally {
         GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings()
         try {
-          SQL("drop table settings_example").execute.apply()
+          SQL("drop table settings_example").execute().apply()
         } catch { case e: Exception => }
       }
     }
@@ -40,22 +40,22 @@ class GlobalSettingsSpec extends AnyFlatSpec with Matchers with Settings with Lo
     DB autoCommit { implicit session =>
       try {
         try {
-          SQL("drop table issue22").execute.apply()
+          SQL("drop table issue22").execute().apply()
         } catch { case e: Exception => }
-        SQL("create table issue22 (id int primary key, created_at timestamp)").execute.apply()
+        SQL("create table issue22 (id int primary key, created_at timestamp)").execute().apply()
         GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings(
           enabled = true,
           warningEnabled = true,
           warningLogLevel = Symbol("INFO"),
           warningThresholdMillis = 0L)
-        SQL("insert into issue22 values (?,?)").bind(1, LocalDateTime.now).update.apply()
-        SQL("insert into issue22 values (?,?)").bind(2, new java.util.Date).update.apply()
-        SQL("insert into issue22 values (?,?)").bind(11, Option(LocalDateTime.now)).update.apply()
-        SQL("insert into issue22 values (?,?)").bind(12, Option(new java.util.Date)).update.apply()
+        SQL("insert into issue22 values (?,?)").bind(1, LocalDateTime.now).update().apply()
+        SQL("insert into issue22 values (?,?)").bind(2, new java.util.Date).update().apply()
+        SQL("insert into issue22 values (?,?)").bind(11, Option(LocalDateTime.now)).update().apply()
+        SQL("insert into issue22 values (?,?)").bind(12, Option(new java.util.Date)).update().apply()
       } finally {
         GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings()
         try {
-          SQL("drop table issue22").execute.apply()
+          SQL("drop table issue22").execute().apply()
         } catch { case e: Exception => }
       }
     }
@@ -70,14 +70,14 @@ class GlobalSettingsSpec extends AnyFlatSpec with Matchers with Settings with Lo
     DB autoCommit { implicit session =>
       try {
         try {
-          SQL("drop table issue118").execute.apply()
+          SQL("drop table issue118").execute().apply()
         } catch { case e: Exception => }
-        SQL("create table issue118 (id int primary key, created_at timestamp)").execute.apply()
-        SQL("insert into issue118 values (?,?)").bind(1, LocalDateTime.now).update.apply()
+        SQL("create table issue118 (id int primary key, created_at timestamp)").execute().apply()
+        SQL("insert into issue118 values (?,?)").bind(1, LocalDateTime.now).update().apply()
       } finally {
         GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings()
         try {
-          SQL("drop table issue118").execute.apply()
+          SQL("drop table issue118").execute().apply()
         } catch { case e: Exception => }
       }
     }
@@ -87,14 +87,14 @@ class GlobalSettingsSpec extends AnyFlatSpec with Matchers with Settings with Lo
     try {
       GlobalSettings.loggingSQLErrors = false
       DB autoCommit { implicit s =>
-        SQL("drop table should_not_be_logged").execute.apply()
+        SQL("drop table should_not_be_logged").execute().apply()
       }
     } catch { case e: Exception => } finally {
       GlobalSettings.loggingSQLErrors = true
     }
     try {
       DB autoCommit { implicit s =>
-        SQL("drop table should_be_logged").execute.apply()
+        SQL("drop table should_be_logged").execute().apply()
       }
     } catch { case e: Exception => }
   }
@@ -103,16 +103,16 @@ class GlobalSettingsSpec extends AnyFlatSpec with Matchers with Settings with Lo
     DB autoCommit { implicit session =>
       try {
         try {
-          SQL("drop table query_completion_listener").execute.apply()
+          SQL("drop table query_completion_listener").execute().apply()
         } catch { case e: Exception => }
-        SQL("create table query_completion_listener (id int primary key, created_at timestamp)").execute.apply()
-        SQL("insert into query_completion_listener values (?,?)").bind(1, LocalDateTime.now).update.apply()
+        SQL("create table query_completion_listener (id int primary key, created_at timestamp)").execute().apply()
+        SQL("insert into query_completion_listener values (?,?)").bind(1, LocalDateTime.now).update().apply()
 
         var result: String = ""
         GlobalSettings.queryCompletionListener = (sql: String, params: collection.Seq[Any], millis: Long) => {
           result = sql + params + millis
         }
-        SQL("select * from query_completion_listener").map(_.toMap).list.apply()
+        SQL("select * from query_completion_listener").map(_.toMap()).list().apply()
         result.size should be > (0)
 
         var errorResult: String = ""
@@ -120,7 +120,7 @@ class GlobalSettingsSpec extends AnyFlatSpec with Matchers with Settings with Lo
           errorResult = sql + params + e.getMessage
         }
         try {
-          SQL("select * from query_failure_listener").map(_.toMap).list.apply()
+          SQL("select * from query_failure_listener").map(_.toMap()).list().apply()
         } catch { case e: Exception => }
         errorResult.size should be > (0)
 
@@ -128,7 +128,7 @@ class GlobalSettingsSpec extends AnyFlatSpec with Matchers with Settings with Lo
         GlobalSettings.queryCompletionListener = (sql: String, params: collection.Seq[Any], millis: Long) => ()
         GlobalSettings.queryFailureListener = (sql: String, params: collection.Seq[Any], e: Throwable) => ()
         try {
-          SQL("drop table query_completion_listener").execute.apply()
+          SQL("drop table query_completion_listener").execute().apply()
         } catch { case e: Exception => }
       }
     }
@@ -138,7 +138,7 @@ class GlobalSettingsSpec extends AnyFlatSpec with Matchers with Settings with Lo
     DB autoCommit { implicit session =>
       try {
         try {
-          SQL("drop table tagged_query_completion_listener").tags("foo", "bar").execute.apply()
+          SQL("drop table tagged_query_completion_listener").tags("foo", "bar").execute().apply()
         } catch { case e: Exception => }
 
         var result: Int = -1
@@ -151,20 +151,20 @@ class GlobalSettingsSpec extends AnyFlatSpec with Matchers with Settings with Lo
         result = -1
         GlobalSettings.taggedQueryCompletionListener.synchronized {
           SQL("create table tagged_query_completion_listener (id int primary key, created_at timestamp)")
-            .tags("1", "2", "3", "4").execute.apply()
+            .tags("1", "2", "3", "4").execute().apply()
           result should equal(4)
         }
 
         result = -1
         GlobalSettings.taggedQueryCompletionListener.synchronized {
           SQL("insert into tagged_query_completion_listener values (?,?)")
-            .tags("1", "2", "3").bind(1, LocalDateTime.now).update.apply()
+            .tags("1", "2", "3").bind(1, LocalDateTime.now).update().apply()
           result should equal(3)
         }
 
         result = -1
         GlobalSettings.taggedQueryCompletionListener.synchronized {
-          SQL("select * from tagged_query_completion_listener").tags("foo", "bar").map(_.toMap).list.apply()
+          SQL("select * from tagged_query_completion_listener").tags("foo", "bar").map(_.toMap()).list().apply()
           result should equal(2)
         }
 
@@ -176,7 +176,7 @@ class GlobalSettingsSpec extends AnyFlatSpec with Matchers with Settings with Lo
         }
         GlobalSettings.taggedQueryFailureListener.synchronized {
           try {
-            SQL("select * from tagged_query_failure_listener").tags("foo", "bar", "baz").map(_.toMap).list.apply()
+            SQL("select * from tagged_query_failure_listener").tags("foo", "bar", "baz").map(_.toMap()).list().apply()
           } catch { case e: Exception => }
           errorResult should equal(3)
         }
@@ -185,12 +185,12 @@ class GlobalSettingsSpec extends AnyFlatSpec with Matchers with Settings with Lo
         result = -1
         session.tags("foo")
         GlobalSettings.taggedQueryCompletionListener.synchronized {
-          SQL("select * from tagged_query_completion_listener").tags("bar", "baz").map(_.toMap).list.apply()
+          SQL("select * from tagged_query_completion_listener").tags("bar", "baz").map(_.toMap()).list().apply()
           result should equal(3)
         }
         result = -1
         GlobalSettings.taggedQueryCompletionListener.synchronized {
-          SQL("select * from tagged_query_completion_listener").map(_.toMap).list.apply()
+          SQL("select * from tagged_query_completion_listener").map(_.toMap()).list().apply()
           result should equal(1)
         }
 
@@ -198,7 +198,7 @@ class GlobalSettingsSpec extends AnyFlatSpec with Matchers with Settings with Lo
         GlobalSettings.taggedQueryCompletionListener = (sql: String, params: collection.Seq[Any], millis: Long, tags: collection.Seq[String]) => ()
         GlobalSettings.taggedQueryFailureListener = (sql: String, params: collection.Seq[Any], e: Throwable, tags: collection.Seq[String]) => ()
         try {
-          SQL("drop table tagged_query_completion_listener").execute.apply()
+          SQL("drop table tagged_query_completion_listener").execute().apply()
         } catch { case e: Exception => }
       }
     }
@@ -207,25 +207,25 @@ class GlobalSettingsSpec extends AnyFlatSpec with Matchers with Settings with Lo
   it should "have stacktrace logging configuration" in {
     DB autoCommit { implicit session =>
       try {
-        try SQL("drop table logging_stacktrace").execute.apply()
+        try SQL("drop table logging_stacktrace").execute().apply()
         catch { case e: Exception => }
 
-        SQL("create table logging_stacktrace (id int primary key, name varchar(13) not null)").execute.apply()
+        SQL("create table logging_stacktrace (id int primary key, name varchar(13) not null)").execute().apply()
 
         1 to 20000 foreach { i =>
           GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings()
-          SQL("insert into logging_stacktrace values (?,?)").bind(i, "id_%010d".format(i)).update.apply()
+          SQL("insert into logging_stacktrace values (?,?)").bind(i, "id_%010d".format(i)).update().apply()
         }
         GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings(
           enabled = true,
           logLevel = Symbol("WARN"),
           printUnprocessedStackTrace = true,
           stackTraceDepth = 500)
-        SQL("select  * from logging_stacktrace").map(rs => rs.int("id")).list.apply()
+        SQL("select  * from logging_stacktrace").map(rs => rs.int("id")).list().apply()
 
       } finally {
         GlobalSettings.loggingSQLAndTime = new LoggingSQLAndTimeSettings()
-        try SQL("drop table logging_stacktrace").execute.apply()
+        try SQL("drop table logging_stacktrace").execute().apply()
         catch { case e: Exception => }
       }
     }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/IOTxBoundarySpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/IOTxBoundarySpec.scala
@@ -13,6 +13,6 @@ class MyIOTxBoundarySpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val exception = new RuntimeException
     val myIOTxBoundary = implicitly[TxBoundary[MyIO[Int]]]
     val result = myIOTxBoundary.closeConnection(MyIO(1), () => throw exception)
-    result.attempt.run should be(Left(exception))
+    result.attempt.run() should be(Left(exception))
   }
 }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/OneToManies6SQLSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/OneToManies6SQLSpec.scala
@@ -17,50 +17,50 @@ class OneToManies6SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
       DB autoCommit {
         implicit s =>
 
-          SQL(s"create table groups_${suffix} (id int not null, owner_id int not null)").execute.apply()
-          SQL(s"create table owners_${suffix} (id int not null)").execute.apply()
-          SQL(s"create table events_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table news_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table members_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table sponsors_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table entity6_${suffix} (id int not null, group_id int not null)").execute.apply()
+          SQL(s"create table groups_${suffix} (id int not null, owner_id int not null)").execute().apply()
+          SQL(s"create table owners_${suffix} (id int not null)").execute().apply()
+          SQL(s"create table events_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table news_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table members_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table sponsors_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table entity6_${suffix} (id int not null, group_id int not null)").execute().apply()
 
-          SQL(s"insert into groups_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into groups_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into groups_${suffix} values (3, 1)").update.apply()
-          SQL(s"insert into groups_${suffix} values (4, 2)").update.apply()
+          SQL(s"insert into groups_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into groups_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into groups_${suffix} values (3, 1)").update().apply()
+          SQL(s"insert into groups_${suffix} values (4, 2)").update().apply()
 
-          SQL(s"insert into owners_${suffix} values (1)").update.apply()
-          SQL(s"insert into owners_${suffix} values (2)").update.apply()
+          SQL(s"insert into owners_${suffix} values (1)").update().apply()
+          SQL(s"insert into owners_${suffix} values (2)").update().apply()
 
-          SQL(s"insert into events_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into events_${suffix} values (2, 1)").update.apply()
-          SQL(s"insert into events_${suffix} values (3, 1)").update.apply()
+          SQL(s"insert into events_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into events_${suffix} values (2, 1)").update().apply()
+          SQL(s"insert into events_${suffix} values (3, 1)").update().apply()
 
-          SQL(s"insert into news_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (2, 1)").update.apply()
-          SQL(s"insert into news_${suffix} values (3, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (4, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (5, 3)").update.apply()
-          SQL(s"insert into news_${suffix} values (6, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (7, 1)").update.apply()
-          SQL(s"insert into news_${suffix} values (8, 1)").update.apply()
+          SQL(s"insert into news_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (2, 1)").update().apply()
+          SQL(s"insert into news_${suffix} values (3, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (4, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (5, 3)").update().apply()
+          SQL(s"insert into news_${suffix} values (6, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (7, 1)").update().apply()
+          SQL(s"insert into news_${suffix} values (8, 1)").update().apply()
 
-          SQL(s"insert into members_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into members_${suffix} values (2, 1)").update.apply()
-          SQL(s"insert into members_${suffix} values (3, 1)").update.apply()
-          SQL(s"insert into members_${suffix} values (4, 2)").update.apply()
-          SQL(s"insert into members_${suffix} values (5, 1)").update.apply()
+          SQL(s"insert into members_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into members_${suffix} values (2, 1)").update().apply()
+          SQL(s"insert into members_${suffix} values (3, 1)").update().apply()
+          SQL(s"insert into members_${suffix} values (4, 2)").update().apply()
+          SQL(s"insert into members_${suffix} values (5, 1)").update().apply()
 
-          SQL(s"insert into sponsors_${suffix} values (1, 1)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (3, 3)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (4, 2)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (5, 3)").update.apply()
+          SQL(s"insert into sponsors_${suffix} values (1, 1)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (3, 3)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (4, 2)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (5, 3)").update().apply()
 
-          SQL(s"insert into entity6_${suffix} values (1, 1)").update.apply()
-          SQL(s"insert into entity6_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into entity6_${suffix} values (3, 1)").update.apply()
+          SQL(s"insert into entity6_${suffix} values (1, 1)").update().apply()
+          SQL(s"insert into entity6_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into entity6_${suffix} values (3, 1)").update().apply()
 
           case class GroupEntity(id: Int, ownerId: Int)
           case class Group(
@@ -110,7 +110,7 @@ class OneToManies6SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
               .map { (g, os, es, ns, ms, ss, e6) =>
                 Group(id = g.id, ownerId = g.ownerId, owner = os.head,
                   events = es, news = ns, members = ms, sponsors = ss, entity6 = e6)
-              }.list.apply()
+              }.list().apply()
 
             groups.size should equal(4)
             groups(0).id should equal(1)
@@ -213,7 +213,7 @@ class OneToManies6SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
               .map { (g, os, es, ns, ms, ss, e6) =>
                 Group(id = g.id, ownerId = g.ownerId, owner = os.head,
                   events = es, news = ns, members = ms, sponsors = ss, entity6 = e6)
-              }.single.apply().get
+              }.single().apply().get
 
             group.id should equal(1)
 
@@ -231,12 +231,12 @@ class OneToManies6SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
     } finally {
       DB autoCommit {
         implicit s =>
-          SQL(s"drop table groups_${suffix}").execute.apply()
-          SQL(s"drop table owners_${suffix}").execute.apply()
-          SQL(s"drop table events_${suffix}").execute.apply()
-          SQL(s"drop table members_${suffix}").execute.apply()
-          SQL(s"drop table sponsors_${suffix}").execute.apply()
-          SQL(s"drop table entity6_${suffix}").execute.apply()
+          SQL(s"drop table groups_${suffix}").execute().apply()
+          SQL(s"drop table owners_${suffix}").execute().apply()
+          SQL(s"drop table events_${suffix}").execute().apply()
+          SQL(s"drop table members_${suffix}").execute().apply()
+          SQL(s"drop table sponsors_${suffix}").execute().apply()
+          SQL(s"drop table entity6_${suffix}").execute().apply()
       }
     }
   }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/OneToManies7SQLSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/OneToManies7SQLSpec.scala
@@ -15,55 +15,55 @@ class OneToManies7SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
       DB autoCommit {
         implicit s =>
 
-          SQL(s"create table groups_${suffix} (id int not null, owner_id int not null)").execute.apply()
-          SQL(s"create table owners_${suffix} (id int not null)").execute.apply()
-          SQL(s"create table events_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table news_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table members_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table sponsors_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table entity6_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table entity7_${suffix} (id int not null, group_id int not null)").execute.apply()
+          SQL(s"create table groups_${suffix} (id int not null, owner_id int not null)").execute().apply()
+          SQL(s"create table owners_${suffix} (id int not null)").execute().apply()
+          SQL(s"create table events_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table news_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table members_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table sponsors_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table entity6_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table entity7_${suffix} (id int not null, group_id int not null)").execute().apply()
 
-          SQL(s"insert into groups_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into groups_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into groups_${suffix} values (3, 1)").update.apply()
-          SQL(s"insert into groups_${suffix} values (4, 2)").update.apply()
+          SQL(s"insert into groups_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into groups_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into groups_${suffix} values (3, 1)").update().apply()
+          SQL(s"insert into groups_${suffix} values (4, 2)").update().apply()
 
-          SQL(s"insert into owners_${suffix} values (1)").update.apply()
-          SQL(s"insert into owners_${suffix} values (2)").update.apply()
+          SQL(s"insert into owners_${suffix} values (1)").update().apply()
+          SQL(s"insert into owners_${suffix} values (2)").update().apply()
 
-          SQL(s"insert into events_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into events_${suffix} values (2, 1)").update.apply()
-          SQL(s"insert into events_${suffix} values (3, 1)").update.apply()
+          SQL(s"insert into events_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into events_${suffix} values (2, 1)").update().apply()
+          SQL(s"insert into events_${suffix} values (3, 1)").update().apply()
 
-          SQL(s"insert into news_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (2, 1)").update.apply()
-          SQL(s"insert into news_${suffix} values (3, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (4, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (5, 3)").update.apply()
-          SQL(s"insert into news_${suffix} values (6, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (7, 1)").update.apply()
-          SQL(s"insert into news_${suffix} values (8, 1)").update.apply()
+          SQL(s"insert into news_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (2, 1)").update().apply()
+          SQL(s"insert into news_${suffix} values (3, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (4, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (5, 3)").update().apply()
+          SQL(s"insert into news_${suffix} values (6, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (7, 1)").update().apply()
+          SQL(s"insert into news_${suffix} values (8, 1)").update().apply()
 
-          SQL(s"insert into members_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into members_${suffix} values (2, 1)").update.apply()
-          SQL(s"insert into members_${suffix} values (3, 1)").update.apply()
-          SQL(s"insert into members_${suffix} values (4, 2)").update.apply()
-          SQL(s"insert into members_${suffix} values (5, 1)").update.apply()
+          SQL(s"insert into members_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into members_${suffix} values (2, 1)").update().apply()
+          SQL(s"insert into members_${suffix} values (3, 1)").update().apply()
+          SQL(s"insert into members_${suffix} values (4, 2)").update().apply()
+          SQL(s"insert into members_${suffix} values (5, 1)").update().apply()
 
-          SQL(s"insert into sponsors_${suffix} values (1, 1)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (3, 3)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (4, 2)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (5, 3)").update.apply()
+          SQL(s"insert into sponsors_${suffix} values (1, 1)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (3, 3)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (4, 2)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (5, 3)").update().apply()
 
-          SQL(s"insert into entity6_${suffix} values (1, 1)").update.apply()
-          SQL(s"insert into entity6_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into entity6_${suffix} values (3, 1)").update.apply()
+          SQL(s"insert into entity6_${suffix} values (1, 1)").update().apply()
+          SQL(s"insert into entity6_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into entity6_${suffix} values (3, 1)").update().apply()
 
-          SQL(s"insert into entity7_${suffix} values (1, 1)").update.apply()
-          SQL(s"insert into entity7_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into entity7_${suffix} values (3, 1)").update.apply()
+          SQL(s"insert into entity7_${suffix} values (1, 1)").update().apply()
+          SQL(s"insert into entity7_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into entity7_${suffix} values (3, 1)").update().apply()
 
           case class GroupEntity(id: Int, ownerId: Int)
           case class Group(
@@ -117,7 +117,7 @@ class OneToManies7SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
               .map { (g, os, es, ns, ms, ss, e6, e7) =>
                 Group(id = g.id, ownerId = g.ownerId, owner = os.head,
                   events = es, news = ns, members = ms, sponsors = ss, entity6 = e6, entity7 = e7)
-              }.list.apply()
+              }.list().apply()
 
             groups.size should equal(4)
             groups(0).id should equal(1)
@@ -226,7 +226,7 @@ class OneToManies7SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
               .map { (g, os, es, ns, ms, ss, e6, e7) =>
                 Group(id = g.id, ownerId = g.ownerId, owner = os.head,
                   events = es, news = ns, members = ms, sponsors = ss, entity6 = e6, entity7 = e7)
-              }.single.apply().get
+              }.single().apply().get
 
             group.id should equal(1)
 
@@ -245,13 +245,13 @@ class OneToManies7SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
     } finally {
       DB autoCommit {
         implicit s =>
-          SQL(s"drop table groups_${suffix}").execute.apply()
-          SQL(s"drop table owners_${suffix}").execute.apply()
-          SQL(s"drop table events_${suffix}").execute.apply()
-          SQL(s"drop table members_${suffix}").execute.apply()
-          SQL(s"drop table sponsors_${suffix}").execute.apply()
-          SQL(s"drop table entity6_${suffix}").execute.apply()
-          SQL(s"drop table entity7_${suffix}").execute.apply()
+          SQL(s"drop table groups_${suffix}").execute().apply()
+          SQL(s"drop table owners_${suffix}").execute().apply()
+          SQL(s"drop table events_${suffix}").execute().apply()
+          SQL(s"drop table members_${suffix}").execute().apply()
+          SQL(s"drop table sponsors_${suffix}").execute().apply()
+          SQL(s"drop table entity6_${suffix}").execute().apply()
+          SQL(s"drop table entity7_${suffix}").execute().apply()
       }
     }
   }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/OneToManies8SQLSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/OneToManies8SQLSpec.scala
@@ -15,60 +15,60 @@ class OneToManies8SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
       DB autoCommit {
         implicit s =>
 
-          SQL(s"create table groups_${suffix} (id int not null, owner_id int not null)").execute.apply()
-          SQL(s"create table owners_${suffix} (id int not null)").execute.apply()
-          SQL(s"create table events_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table news_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table members_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table sponsors_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table entity6_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table entity7_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table entity8_${suffix} (id int not null, group_id int not null)").execute.apply()
+          SQL(s"create table groups_${suffix} (id int not null, owner_id int not null)").execute().apply()
+          SQL(s"create table owners_${suffix} (id int not null)").execute().apply()
+          SQL(s"create table events_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table news_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table members_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table sponsors_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table entity6_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table entity7_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table entity8_${suffix} (id int not null, group_id int not null)").execute().apply()
 
-          SQL(s"insert into groups_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into groups_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into groups_${suffix} values (3, 1)").update.apply()
-          SQL(s"insert into groups_${suffix} values (4, 2)").update.apply()
+          SQL(s"insert into groups_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into groups_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into groups_${suffix} values (3, 1)").update().apply()
+          SQL(s"insert into groups_${suffix} values (4, 2)").update().apply()
 
-          SQL(s"insert into owners_${suffix} values (1)").update.apply()
-          SQL(s"insert into owners_${suffix} values (2)").update.apply()
+          SQL(s"insert into owners_${suffix} values (1)").update().apply()
+          SQL(s"insert into owners_${suffix} values (2)").update().apply()
 
-          SQL(s"insert into events_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into events_${suffix} values (2, 1)").update.apply()
-          SQL(s"insert into events_${suffix} values (3, 1)").update.apply()
+          SQL(s"insert into events_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into events_${suffix} values (2, 1)").update().apply()
+          SQL(s"insert into events_${suffix} values (3, 1)").update().apply()
 
-          SQL(s"insert into news_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (2, 1)").update.apply()
-          SQL(s"insert into news_${suffix} values (3, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (4, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (5, 3)").update.apply()
-          SQL(s"insert into news_${suffix} values (6, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (7, 1)").update.apply()
-          SQL(s"insert into news_${suffix} values (8, 1)").update.apply()
+          SQL(s"insert into news_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (2, 1)").update().apply()
+          SQL(s"insert into news_${suffix} values (3, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (4, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (5, 3)").update().apply()
+          SQL(s"insert into news_${suffix} values (6, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (7, 1)").update().apply()
+          SQL(s"insert into news_${suffix} values (8, 1)").update().apply()
 
-          SQL(s"insert into members_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into members_${suffix} values (2, 1)").update.apply()
-          SQL(s"insert into members_${suffix} values (3, 1)").update.apply()
-          SQL(s"insert into members_${suffix} values (4, 2)").update.apply()
-          SQL(s"insert into members_${suffix} values (5, 1)").update.apply()
+          SQL(s"insert into members_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into members_${suffix} values (2, 1)").update().apply()
+          SQL(s"insert into members_${suffix} values (3, 1)").update().apply()
+          SQL(s"insert into members_${suffix} values (4, 2)").update().apply()
+          SQL(s"insert into members_${suffix} values (5, 1)").update().apply()
 
-          SQL(s"insert into sponsors_${suffix} values (1, 1)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (3, 3)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (4, 2)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (5, 3)").update.apply()
+          SQL(s"insert into sponsors_${suffix} values (1, 1)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (3, 3)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (4, 2)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (5, 3)").update().apply()
 
-          SQL(s"insert into entity6_${suffix} values (1, 1)").update.apply()
-          SQL(s"insert into entity6_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into entity6_${suffix} values (3, 1)").update.apply()
+          SQL(s"insert into entity6_${suffix} values (1, 1)").update().apply()
+          SQL(s"insert into entity6_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into entity6_${suffix} values (3, 1)").update().apply()
 
-          SQL(s"insert into entity7_${suffix} values (1, 1)").update.apply()
-          SQL(s"insert into entity7_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into entity7_${suffix} values (3, 1)").update.apply()
+          SQL(s"insert into entity7_${suffix} values (1, 1)").update().apply()
+          SQL(s"insert into entity7_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into entity7_${suffix} values (3, 1)").update().apply()
 
-          SQL(s"insert into entity8_${suffix} values (1, 1)").update.apply()
-          SQL(s"insert into entity8_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into entity8_${suffix} values (3, 1)").update.apply()
+          SQL(s"insert into entity8_${suffix} values (1, 1)").update().apply()
+          SQL(s"insert into entity8_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into entity8_${suffix} values (3, 1)").update().apply()
 
           case class GroupEntity(id: Int, ownerId: Int)
           case class Group(
@@ -126,7 +126,7 @@ class OneToManies8SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
               .map { (g, os, es, ns, ms, ss, e6, e7, e8) =>
                 Group(id = g.id, ownerId = g.ownerId, owner = os.head,
                   events = es, news = ns, members = ms, sponsors = ss, entity6 = e6, entity7 = e7, entity8 = e8)
-              }.list.apply()
+              }.list().apply()
 
             groups.size should equal(4)
             groups(0).id should equal(1)
@@ -241,7 +241,7 @@ class OneToManies8SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
               .map { (g, os, es, ns, ms, ss, e6, e7, e8) =>
                 Group(id = g.id, ownerId = g.ownerId, owner = os.head,
                   events = es, news = ns, members = ms, sponsors = ss, entity6 = e6, entity7 = e7, entity8 = e8)
-              }.single.apply().get
+              }.single().apply().get
 
             group.id should equal(1)
 
@@ -261,14 +261,14 @@ class OneToManies8SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
     } finally {
       DB autoCommit {
         implicit s =>
-          SQL(s"drop table groups_${suffix}").execute.apply()
-          SQL(s"drop table owners_${suffix}").execute.apply()
-          SQL(s"drop table events_${suffix}").execute.apply()
-          SQL(s"drop table members_${suffix}").execute.apply()
-          SQL(s"drop table sponsors_${suffix}").execute.apply()
-          SQL(s"drop table entity6_${suffix}").execute.apply()
-          SQL(s"drop table entity7_${suffix}").execute.apply()
-          SQL(s"drop table entity8_${suffix}").execute.apply()
+          SQL(s"drop table groups_${suffix}").execute().apply()
+          SQL(s"drop table owners_${suffix}").execute().apply()
+          SQL(s"drop table events_${suffix}").execute().apply()
+          SQL(s"drop table members_${suffix}").execute().apply()
+          SQL(s"drop table sponsors_${suffix}").execute().apply()
+          SQL(s"drop table entity6_${suffix}").execute().apply()
+          SQL(s"drop table entity7_${suffix}").execute().apply()
+          SQL(s"drop table entity8_${suffix}").execute().apply()
       }
     }
   }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/OneToManies9SQLSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/OneToManies9SQLSpec.scala
@@ -15,65 +15,65 @@ class OneToManies9SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
       DB autoCommit {
         implicit s =>
 
-          SQL(s"create table groups_${suffix} (id int not null, owner_id int not null)").execute.apply()
-          SQL(s"create table owners_${suffix} (id int not null)").execute.apply()
-          SQL(s"create table events_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table news_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table members_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table sponsors_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table entity6_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table entity7_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table entity8_${suffix} (id int not null, group_id int not null)").execute.apply()
-          SQL(s"create table entity9_${suffix} (id int not null, group_id int not null)").execute.apply()
+          SQL(s"create table groups_${suffix} (id int not null, owner_id int not null)").execute().apply()
+          SQL(s"create table owners_${suffix} (id int not null)").execute().apply()
+          SQL(s"create table events_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table news_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table members_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table sponsors_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table entity6_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table entity7_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table entity8_${suffix} (id int not null, group_id int not null)").execute().apply()
+          SQL(s"create table entity9_${suffix} (id int not null, group_id int not null)").execute().apply()
 
-          SQL(s"insert into groups_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into groups_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into groups_${suffix} values (3, 1)").update.apply()
-          SQL(s"insert into groups_${suffix} values (4, 2)").update.apply()
+          SQL(s"insert into groups_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into groups_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into groups_${suffix} values (3, 1)").update().apply()
+          SQL(s"insert into groups_${suffix} values (4, 2)").update().apply()
 
-          SQL(s"insert into owners_${suffix} values (1)").update.apply()
-          SQL(s"insert into owners_${suffix} values (2)").update.apply()
+          SQL(s"insert into owners_${suffix} values (1)").update().apply()
+          SQL(s"insert into owners_${suffix} values (2)").update().apply()
 
-          SQL(s"insert into events_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into events_${suffix} values (2, 1)").update.apply()
-          SQL(s"insert into events_${suffix} values (3, 1)").update.apply()
+          SQL(s"insert into events_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into events_${suffix} values (2, 1)").update().apply()
+          SQL(s"insert into events_${suffix} values (3, 1)").update().apply()
 
-          SQL(s"insert into news_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (2, 1)").update.apply()
-          SQL(s"insert into news_${suffix} values (3, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (4, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (5, 3)").update.apply()
-          SQL(s"insert into news_${suffix} values (6, 2)").update.apply()
-          SQL(s"insert into news_${suffix} values (7, 1)").update.apply()
-          SQL(s"insert into news_${suffix} values (8, 1)").update.apply()
+          SQL(s"insert into news_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (2, 1)").update().apply()
+          SQL(s"insert into news_${suffix} values (3, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (4, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (5, 3)").update().apply()
+          SQL(s"insert into news_${suffix} values (6, 2)").update().apply()
+          SQL(s"insert into news_${suffix} values (7, 1)").update().apply()
+          SQL(s"insert into news_${suffix} values (8, 1)").update().apply()
 
-          SQL(s"insert into members_${suffix} values (1, 2)").update.apply()
-          SQL(s"insert into members_${suffix} values (2, 1)").update.apply()
-          SQL(s"insert into members_${suffix} values (3, 1)").update.apply()
-          SQL(s"insert into members_${suffix} values (4, 2)").update.apply()
-          SQL(s"insert into members_${suffix} values (5, 1)").update.apply()
+          SQL(s"insert into members_${suffix} values (1, 2)").update().apply()
+          SQL(s"insert into members_${suffix} values (2, 1)").update().apply()
+          SQL(s"insert into members_${suffix} values (3, 1)").update().apply()
+          SQL(s"insert into members_${suffix} values (4, 2)").update().apply()
+          SQL(s"insert into members_${suffix} values (5, 1)").update().apply()
 
-          SQL(s"insert into sponsors_${suffix} values (1, 1)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (3, 3)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (4, 2)").update.apply()
-          SQL(s"insert into sponsors_${suffix} values (5, 3)").update.apply()
+          SQL(s"insert into sponsors_${suffix} values (1, 1)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (3, 3)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (4, 2)").update().apply()
+          SQL(s"insert into sponsors_${suffix} values (5, 3)").update().apply()
 
-          SQL(s"insert into entity6_${suffix} values (1, 1)").update.apply()
-          SQL(s"insert into entity6_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into entity6_${suffix} values (3, 1)").update.apply()
+          SQL(s"insert into entity6_${suffix} values (1, 1)").update().apply()
+          SQL(s"insert into entity6_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into entity6_${suffix} values (3, 1)").update().apply()
 
-          SQL(s"insert into entity7_${suffix} values (1, 1)").update.apply()
-          SQL(s"insert into entity7_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into entity7_${suffix} values (3, 1)").update.apply()
+          SQL(s"insert into entity7_${suffix} values (1, 1)").update().apply()
+          SQL(s"insert into entity7_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into entity7_${suffix} values (3, 1)").update().apply()
 
-          SQL(s"insert into entity8_${suffix} values (1, 1)").update.apply()
-          SQL(s"insert into entity8_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into entity8_${suffix} values (3, 1)").update.apply()
+          SQL(s"insert into entity8_${suffix} values (1, 1)").update().apply()
+          SQL(s"insert into entity8_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into entity8_${suffix} values (3, 1)").update().apply()
 
-          SQL(s"insert into entity9_${suffix} values (1, 1)").update.apply()
-          SQL(s"insert into entity9_${suffix} values (2, 2)").update.apply()
-          SQL(s"insert into entity9_${suffix} values (3, 1)").update.apply()
+          SQL(s"insert into entity9_${suffix} values (1, 1)").update().apply()
+          SQL(s"insert into entity9_${suffix} values (2, 2)").update().apply()
+          SQL(s"insert into entity9_${suffix} values (3, 1)").update().apply()
 
           case class GroupEntity(id: Int, ownerId: Int)
           case class Group(
@@ -136,7 +136,7 @@ class OneToManies9SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
                 Group(id = g.id, ownerId = g.ownerId, owner = os.head,
                   events = es, news = ns, members = ms, sponsors = ss,
                   entity6 = e6, entity7 = e7, entity8 = e8, entity9 = e9)
-              }.list.apply()
+              }.list().apply()
 
             groups.size should equal(4)
             groups(0).id should equal(1)
@@ -259,7 +259,7 @@ class OneToManies9SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
                 Group(id = g.id, ownerId = g.ownerId, owner = os.head,
                   events = es, news = ns, members = ms, sponsors = ss,
                   entity6 = e6, entity7 = e7, entity8 = e8, entity9 = e9)
-              }.single.apply().get
+              }.single().apply().get
 
             group.id should equal(1)
 
@@ -280,15 +280,15 @@ class OneToManies9SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter 
     } finally {
       DB autoCommit {
         implicit s =>
-          SQL(s"drop table groups_${suffix}").execute.apply()
-          SQL(s"drop table owners_${suffix}").execute.apply()
-          SQL(s"drop table events_${suffix}").execute.apply()
-          SQL(s"drop table members_${suffix}").execute.apply()
-          SQL(s"drop table sponsors_${suffix}").execute.apply()
-          SQL(s"drop table entity6_${suffix}").execute.apply()
-          SQL(s"drop table entity7_${suffix}").execute.apply()
-          SQL(s"drop table entity8_${suffix}").execute.apply()
-          SQL(s"drop table entity9_${suffix}").execute.apply()
+          SQL(s"drop table groups_${suffix}").execute().apply()
+          SQL(s"drop table owners_${suffix}").execute().apply()
+          SQL(s"drop table events_${suffix}").execute().apply()
+          SQL(s"drop table members_${suffix}").execute().apply()
+          SQL(s"drop table sponsors_${suffix}").execute().apply()
+          SQL(s"drop table entity6_${suffix}").execute().apply()
+          SQL(s"drop table entity7_${suffix}").execute().apply()
+          SQL(s"drop table entity8_${suffix}").execute().apply()
+          SQL(s"drop table entity9_${suffix}").execute().apply()
       }
     }
   }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/RelationalSQLSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/RelationalSQLSpec.scala
@@ -17,18 +17,18 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
       DB autoCommit {
         implicit s =>
 
-          SQL("create table users_" + suffix + " (id int not null, group_id int)").execute.apply()
-          SQL("create table groups_" + suffix + " (id int not null, name varchar(30))").execute.apply()
-          SQL("insert into users_" + suffix + " values (1,1)").update.apply()
-          SQL("insert into users_" + suffix + " values (2,1)").update.apply()
-          SQL("insert into users_" + suffix + " values (3,1)").update.apply()
-          SQL("insert into users_" + suffix + " values (4,1)").update.apply()
-          SQL("insert into users_" + suffix + " values (5,2)").update.apply()
-          SQL("insert into users_" + suffix + " values (6,2)").update.apply()
-          SQL("insert into users_" + suffix + " values (7,null)").update.apply()
-          SQL("insert into groups_" + suffix + " values (1, 'A')").update.apply()
-          SQL("insert into groups_" + suffix + " values (2, 'B')").update.apply()
-          SQL("insert into groups_" + suffix + " values (3, 'C')").update.apply()
+          SQL("create table users_" + suffix + " (id int not null, group_id int)").execute().apply()
+          SQL("create table groups_" + suffix + " (id int not null, name varchar(30))").execute().apply()
+          SQL("insert into users_" + suffix + " values (1,1)").update().apply()
+          SQL("insert into users_" + suffix + " values (2,1)").update().apply()
+          SQL("insert into users_" + suffix + " values (3,1)").update().apply()
+          SQL("insert into users_" + suffix + " values (4,1)").update().apply()
+          SQL("insert into users_" + suffix + " values (5,2)").update().apply()
+          SQL("insert into users_" + suffix + " values (6,2)").update().apply()
+          SQL("insert into users_" + suffix + " values (7,null)").update().apply()
+          SQL("insert into groups_" + suffix + " values (1, 'A')").update().apply()
+          SQL("insert into groups_" + suffix + " values (2, 'B')").update().apply()
+          SQL("insert into groups_" + suffix + " values (3, 'C')").update().apply()
 
           case class User(id: Int, groupId: Int, group: Option[Group] = None)
           case class Group(id: Int, name: String)
@@ -41,7 +41,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
             val users: List[User] = sql.one(rs => User(rs.int("u_id"), rs.int("u_group_id"), None))
               .toOne(rs => Group(rs.int("g_id"), rs.string("g_name")))
               .map((u: User, g: Group) => u.copy(group = Some(g)))
-              .list.apply()
+              .list().apply()
 
             users.size should equal(6)
             users.foreach {
@@ -62,7 +62,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
               .one(rs => User(rs.int("u_id"), rs.int("u_group_id"), None))
               .toOne(rs => Group(rs.int("g_id"), rs.string("g_name")))
               .map((u: User, g: Group) => u.copy(group = Some(g)))
-              .iterable.apply()
+              .iterable().apply()
 
             users.size should equal(6)
             users.foreach {
@@ -77,7 +77,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
               .one(rs => User(rs.int("u_id"), rs.int("u_group_id"), None))
               .toOne(rs => Group(rs.int("g_id"), rs.string("g_name")))
               .map((u: User, g: Group) => u.copy(group = Some(g)))
-              .single.apply()
+              .single().apply()
 
             user.get.id should equal(1)
           }
@@ -90,7 +90,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
                 .one(rs => User(rs.int("u_id"), rs.int("u_group_id"), None))
                 .toOne(rs => Group(rs.int("g_id"), rs.string("g_name")))
                 .map((u: User, g: Group) => u.copy(group = Some(g)))
-                .single.apply()
+                .single().apply()
             }
           }
 
@@ -101,7 +101,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
               .one(rs => User(rs.intOpt("u_id").getOrElse(0), rs.intOpt("u_group_id").getOrElse(0), None))
               .toOptionalOne(rs => rs.intOpt("g_id").map(id => Group(id, rs.string("g_name"))))
               .map((u: User, g: Option[Group]) => u.copy(group = g))
-              .list.apply()
+              .list().apply()
 
             users.size should equal(1)
             users.foreach {
@@ -140,28 +140,28 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
       DB autoCommit {
         implicit s =>
 
-          SQL("create table users_" + suffix + " (id int not null)").execute.apply()
-          SQL("create table groups_" + suffix + " (id int not null, name varchar(30))").execute.apply()
-          SQL("create table group_members_" + suffix + " (user_id int not null, group_id int not null)").execute.apply()
-          SQL("insert into users_" + suffix + " values (1)").update.apply()
-          SQL("insert into users_" + suffix + " values (2)").update.apply()
-          SQL("insert into users_" + suffix + " values (3)").update.apply()
-          SQL("insert into users_" + suffix + " values (4)").update.apply()
-          SQL("insert into users_" + suffix + " values (5)").update.apply()
-          SQL("insert into users_" + suffix + " values (6)").update.apply()
-          SQL("insert into groups_" + suffix + " values (1, 'A')").update.apply()
-          SQL("insert into groups_" + suffix + " values (2, 'B')").update.apply()
-          SQL("insert into groups_" + suffix + " values (3, 'C')").update.apply()
-          SQL("insert into group_members_" + suffix + " values (1,1)").update.apply()
-          SQL("insert into group_members_" + suffix + " values (2,1)").update.apply()
-          SQL("insert into group_members_" + suffix + " values (3,1)").update.apply()
-          SQL("insert into group_members_" + suffix + " values (4,1)").update.apply()
-          SQL("insert into group_members_" + suffix + " values (5,1)").update.apply()
-          SQL("insert into group_members_" + suffix + " values (6,1)").update.apply()
-          SQL("insert into group_members_" + suffix + " values (1,2)").update.apply()
-          SQL("insert into group_members_" + suffix + " values (2,2)").update.apply()
-          SQL("insert into group_members_" + suffix + " values (3,2)").update.apply()
-          SQL("insert into group_members_" + suffix + " values (4,2)").update.apply()
+          SQL("create table users_" + suffix + " (id int not null)").execute().apply()
+          SQL("create table groups_" + suffix + " (id int not null, name varchar(30))").execute().apply()
+          SQL("create table group_members_" + suffix + " (user_id int not null, group_id int not null)").execute().apply()
+          SQL("insert into users_" + suffix + " values (1)").update().apply()
+          SQL("insert into users_" + suffix + " values (2)").update().apply()
+          SQL("insert into users_" + suffix + " values (3)").update().apply()
+          SQL("insert into users_" + suffix + " values (4)").update().apply()
+          SQL("insert into users_" + suffix + " values (5)").update().apply()
+          SQL("insert into users_" + suffix + " values (6)").update().apply()
+          SQL("insert into groups_" + suffix + " values (1, 'A')").update().apply()
+          SQL("insert into groups_" + suffix + " values (2, 'B')").update().apply()
+          SQL("insert into groups_" + suffix + " values (3, 'C')").update().apply()
+          SQL("insert into group_members_" + suffix + " values (1,1)").update().apply()
+          SQL("insert into group_members_" + suffix + " values (2,1)").update().apply()
+          SQL("insert into group_members_" + suffix + " values (3,1)").update().apply()
+          SQL("insert into group_members_" + suffix + " values (4,1)").update().apply()
+          SQL("insert into group_members_" + suffix + " values (5,1)").update().apply()
+          SQL("insert into group_members_" + suffix + " values (6,1)").update().apply()
+          SQL("insert into group_members_" + suffix + " values (1,2)").update().apply()
+          SQL("insert into group_members_" + suffix + " values (2,2)").update().apply()
+          SQL("insert into group_members_" + suffix + " values (3,2)").update().apply()
+          SQL("insert into group_members_" + suffix + " values (4,2)").update().apply()
 
           case class User(id: Int)
           case class Group(id: Int, name: String, members: collection.Seq[User] = Nil)
@@ -175,7 +175,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
               .one(rs => Group(rs.int("g_id"), rs.string("g_name")))
               .toMany(rs => Some(User(rs.int("u_id"))))
               .map((g: Group, ms: collection.Seq[User]) => g.copy(members = ms))
-              .list.apply()
+              .list().apply()
 
             groups.size should equal(2)
             groups(0).members.size should equal(6)
@@ -227,7 +227,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
               .one(rs => Group(rs.int("g_id"), rs.string("g_name")))
               .toMany(rs => Some(User(rs.int("u_id"))))
               .map((g: Group, ms: collection.Seq[User]) => g.copy(members = ms))
-              .iterable.apply()
+              .iterable().apply()
 
             groups.size should equal(2)
           }
@@ -241,7 +241,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
               .one(rs => Group(rs.int("g_id"), rs.string("g_name")))
               .toMany(rs => Some(User(rs.int("u_id"))))
               .map((g: Group, ms: collection.Seq[User]) => g.copy(members = ms))
-              .single.apply()
+              .single().apply()
 
             group.get.id should equal(1)
           }
@@ -256,7 +256,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
                 .one(rs => Group(rs.int("g_id"), rs.string("g_name")))
                 .toMany(rs => Some(User(rs.int("u_id"))))
                 .map((g: Group, ms: collection.Seq[User]) => g.copy(members = ms))
-                .single.apply()
+                .single().apply()
             }
           }
       }
@@ -276,26 +276,26 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
       DB autoCommit {
         implicit s =>
 
-          SQL("create table groups_" + suffix + " (id int not null)").execute.apply()
-          SQL("create table members_" + suffix + " (id int not null, group_id int not null)").execute.apply()
-          SQL("create table sponsors_" + suffix + " (id int not null, group_id int not null)").execute.apply()
+          SQL("create table groups_" + suffix + " (id int not null)").execute().apply()
+          SQL("create table members_" + suffix + " (id int not null, group_id int not null)").execute().apply()
+          SQL("create table sponsors_" + suffix + " (id int not null, group_id int not null)").execute().apply()
 
-          SQL("insert into groups_" + suffix + " values (1)").update.apply()
-          SQL("insert into groups_" + suffix + " values (2)").update.apply()
-          SQL("insert into groups_" + suffix + " values (3)").update.apply()
-          SQL("insert into groups_" + suffix + " values (4)").update.apply()
+          SQL("insert into groups_" + suffix + " values (1)").update().apply()
+          SQL("insert into groups_" + suffix + " values (2)").update().apply()
+          SQL("insert into groups_" + suffix + " values (3)").update().apply()
+          SQL("insert into groups_" + suffix + " values (4)").update().apply()
 
-          SQL("insert into members_" + suffix + " values (1, 2)").update.apply()
-          SQL("insert into members_" + suffix + " values (2, 1)").update.apply()
-          SQL("insert into members_" + suffix + " values (3, 1)").update.apply()
-          SQL("insert into members_" + suffix + " values (4, 2)").update.apply()
-          SQL("insert into members_" + suffix + " values (5, 1)").update.apply()
+          SQL("insert into members_" + suffix + " values (1, 2)").update().apply()
+          SQL("insert into members_" + suffix + " values (2, 1)").update().apply()
+          SQL("insert into members_" + suffix + " values (3, 1)").update().apply()
+          SQL("insert into members_" + suffix + " values (4, 2)").update().apply()
+          SQL("insert into members_" + suffix + " values (5, 1)").update().apply()
 
-          SQL("insert into sponsors_" + suffix + " values (1, 1)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (2, 2)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (3, 3)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (4, 2)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (5, 3)").update.apply()
+          SQL("insert into sponsors_" + suffix + " values (1, 1)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (2, 2)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (3, 3)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (4, 2)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (5, 3)").update().apply()
 
           case class Group(id: Int, members: collection.Seq[Member] = Nil, sponsors: collection.Seq[Sponsor] = Nil)
           case class Member(id: Int, groupId: Int)
@@ -312,7 +312,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
                 rs => rs.intOpt("m_id").map(id => Member(id, rs.int("g_id"))),
                 rs => rs.intOpt("s_id").map(id => Sponsor(id, rs.int("g_id"))))
               .map((g: Group, ms: collection.Seq[Member], ss: collection.Seq[Sponsor]) => g.copy(members = ms, sponsors = ss))
-              .list.apply()
+              .list().apply()
 
             groups.size should equal(4)
             groups(0).id should equal(1)
@@ -362,7 +362,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
                 rs => rs.intOpt("m_id").map(id => Member(id, rs.int("g_id"))),
                 rs => rs.intOpt("s_id").map(id => Sponsor(id, rs.int("g_id"))))
               .map((g: Group, ms: collection.Seq[Member], ss: collection.Seq[Sponsor]) => g.copy(members = ms, sponsors = ss))
-              .single.apply().get
+              .single().apply().get
 
             group.id should equal(1)
 
@@ -391,30 +391,30 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
       DB autoCommit {
         implicit s =>
 
-          SQL("create table groups_" + suffix + " (id int not null, owner_id int not null)").execute.apply()
-          SQL("create table owners_" + suffix + " (id int not null)").execute.apply()
-          SQL("create table members_" + suffix + " (id int not null, group_id int not null)").execute.apply()
-          SQL("create table sponsors_" + suffix + " (id int not null, group_id int not null)").execute.apply()
+          SQL("create table groups_" + suffix + " (id int not null, owner_id int not null)").execute().apply()
+          SQL("create table owners_" + suffix + " (id int not null)").execute().apply()
+          SQL("create table members_" + suffix + " (id int not null, group_id int not null)").execute().apply()
+          SQL("create table sponsors_" + suffix + " (id int not null, group_id int not null)").execute().apply()
 
-          SQL("insert into groups_" + suffix + " values (1, 2)").update.apply()
-          SQL("insert into groups_" + suffix + " values (2, 2)").update.apply()
-          SQL("insert into groups_" + suffix + " values (3, 1)").update.apply()
-          SQL("insert into groups_" + suffix + " values (4, 2)").update.apply()
+          SQL("insert into groups_" + suffix + " values (1, 2)").update().apply()
+          SQL("insert into groups_" + suffix + " values (2, 2)").update().apply()
+          SQL("insert into groups_" + suffix + " values (3, 1)").update().apply()
+          SQL("insert into groups_" + suffix + " values (4, 2)").update().apply()
 
-          SQL("insert into owners_" + suffix + " values (1)").update.apply()
-          SQL("insert into owners_" + suffix + " values (2)").update.apply()
+          SQL("insert into owners_" + suffix + " values (1)").update().apply()
+          SQL("insert into owners_" + suffix + " values (2)").update().apply()
 
-          SQL("insert into members_" + suffix + " values (1, 2)").update.apply()
-          SQL("insert into members_" + suffix + " values (2, 1)").update.apply()
-          SQL("insert into members_" + suffix + " values (3, 1)").update.apply()
-          SQL("insert into members_" + suffix + " values (4, 2)").update.apply()
-          SQL("insert into members_" + suffix + " values (5, 1)").update.apply()
+          SQL("insert into members_" + suffix + " values (1, 2)").update().apply()
+          SQL("insert into members_" + suffix + " values (2, 1)").update().apply()
+          SQL("insert into members_" + suffix + " values (3, 1)").update().apply()
+          SQL("insert into members_" + suffix + " values (4, 2)").update().apply()
+          SQL("insert into members_" + suffix + " values (5, 1)").update().apply()
 
-          SQL("insert into sponsors_" + suffix + " values (1, 1)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (2, 2)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (3, 3)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (4, 2)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (5, 3)").update.apply()
+          SQL("insert into sponsors_" + suffix + " values (1, 1)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (2, 2)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (3, 3)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (4, 2)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (5, 3)").update().apply()
 
           case class GroupEntity(id: Int, ownerId: Int)
           case class Group(id: Int, ownerId: Int, owner: Owner, members: collection.Seq[Member] = Nil, sponsors: collection.Seq[Sponsor] = Nil)
@@ -436,7 +436,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
                 rs => rs.intOpt("s_id").map(id => Sponsor(id, rs.int("g_id"))))
               .map { (g, os, ms, ss) =>
                 Group(id = g.id, ownerId = g.ownerId, owner = os.head, members = ms, sponsors = ss)
-              }.list.apply()
+              }.list().apply()
 
             groups.size should equal(4)
             groups(0).id should equal(1)
@@ -498,7 +498,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
                 rs => rs.intOpt("s_id").map(id => Sponsor(id, rs.int("g_id"))))
               .map { (g, os, ms, ss) =>
                 Group(id = g.id, ownerId = os.head.id, owner = os.head, members = ms, sponsors = ss)
-              }.single.apply().get
+              }.single().apply().get
 
             group.id should equal(1)
 
@@ -530,35 +530,35 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
       DB autoCommit {
         implicit s =>
 
-          SQL("create table groups_" + suffix + " (id int not null, owner_id int not null)").execute.apply()
-          SQL("create table owners_" + suffix + " (id int not null)").execute.apply()
-          SQL("create table events_" + suffix + " (id int not null, group_id int not null)").execute.apply()
-          SQL("create table members_" + suffix + " (id int not null, group_id int not null)").execute.apply()
-          SQL("create table sponsors_" + suffix + " (id int not null, group_id int not null)").execute.apply()
+          SQL("create table groups_" + suffix + " (id int not null, owner_id int not null)").execute().apply()
+          SQL("create table owners_" + suffix + " (id int not null)").execute().apply()
+          SQL("create table events_" + suffix + " (id int not null, group_id int not null)").execute().apply()
+          SQL("create table members_" + suffix + " (id int not null, group_id int not null)").execute().apply()
+          SQL("create table sponsors_" + suffix + " (id int not null, group_id int not null)").execute().apply()
 
-          SQL("insert into groups_" + suffix + " values (1, 2)").update.apply()
-          SQL("insert into groups_" + suffix + " values (2, 2)").update.apply()
-          SQL("insert into groups_" + suffix + " values (3, 1)").update.apply()
-          SQL("insert into groups_" + suffix + " values (4, 2)").update.apply()
+          SQL("insert into groups_" + suffix + " values (1, 2)").update().apply()
+          SQL("insert into groups_" + suffix + " values (2, 2)").update().apply()
+          SQL("insert into groups_" + suffix + " values (3, 1)").update().apply()
+          SQL("insert into groups_" + suffix + " values (4, 2)").update().apply()
 
-          SQL("insert into owners_" + suffix + " values (1)").update.apply()
-          SQL("insert into owners_" + suffix + " values (2)").update.apply()
+          SQL("insert into owners_" + suffix + " values (1)").update().apply()
+          SQL("insert into owners_" + suffix + " values (2)").update().apply()
 
-          SQL("insert into events_" + suffix + " values (1, 2)").update.apply()
-          SQL("insert into events_" + suffix + " values (2, 1)").update.apply()
-          SQL("insert into events_" + suffix + " values (3, 1)").update.apply()
+          SQL("insert into events_" + suffix + " values (1, 2)").update().apply()
+          SQL("insert into events_" + suffix + " values (2, 1)").update().apply()
+          SQL("insert into events_" + suffix + " values (3, 1)").update().apply()
 
-          SQL("insert into members_" + suffix + " values (1, 2)").update.apply()
-          SQL("insert into members_" + suffix + " values (2, 1)").update.apply()
-          SQL("insert into members_" + suffix + " values (3, 1)").update.apply()
-          SQL("insert into members_" + suffix + " values (4, 2)").update.apply()
-          SQL("insert into members_" + suffix + " values (5, 1)").update.apply()
+          SQL("insert into members_" + suffix + " values (1, 2)").update().apply()
+          SQL("insert into members_" + suffix + " values (2, 1)").update().apply()
+          SQL("insert into members_" + suffix + " values (3, 1)").update().apply()
+          SQL("insert into members_" + suffix + " values (4, 2)").update().apply()
+          SQL("insert into members_" + suffix + " values (5, 1)").update().apply()
 
-          SQL("insert into sponsors_" + suffix + " values (1, 1)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (2, 2)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (3, 3)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (4, 2)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (5, 3)").update.apply()
+          SQL("insert into sponsors_" + suffix + " values (1, 1)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (2, 2)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (3, 3)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (4, 2)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (5, 3)").update().apply()
 
           case class GroupEntity(id: Int, ownerId: Int)
           case class Group(id: Int, ownerId: Int, owner: Owner,
@@ -585,7 +585,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
                 rs => rs.intOpt("s_id").map(id => Sponsor(id, rs.int("g_id"))))
               .map { (g, os, es, ms, ss) =>
                 Group(id = g.id, ownerId = g.ownerId, owner = os.head, events = es, members = ms, sponsors = ss)
-              }.list.apply()
+              }.list().apply()
 
             groups.size should equal(4)
             groups(0).id should equal(1)
@@ -659,7 +659,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
                 rs => rs.intOpt("s_id").map(id => Sponsor(id, rs.int("g_id"))))
               .map { (g, os, es, ms, ss) =>
                 Group(id = g.id, ownerId = g.ownerId, owner = os.head, events = es, members = ms, sponsors = ss)
-              }.single.apply().get
+              }.single().apply().get
 
             group.id should equal(1)
 
@@ -696,45 +696,45 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
       DB autoCommit {
         implicit s =>
 
-          SQL("create table groups_" + suffix + " (id int not null, owner_id int not null)").execute.apply()
-          SQL("create table owners_" + suffix + " (id int not null)").execute.apply()
-          SQL("create table events_" + suffix + " (id int not null, group_id int not null)").execute.apply()
-          SQL("create table news_" + suffix + " (id int not null, group_id int not null)").execute.apply()
-          SQL("create table members_" + suffix + " (id int not null, group_id int not null)").execute.apply()
-          SQL("create table sponsors_" + suffix + " (id int not null, group_id int not null)").execute.apply()
+          SQL("create table groups_" + suffix + " (id int not null, owner_id int not null)").execute().apply()
+          SQL("create table owners_" + suffix + " (id int not null)").execute().apply()
+          SQL("create table events_" + suffix + " (id int not null, group_id int not null)").execute().apply()
+          SQL("create table news_" + suffix + " (id int not null, group_id int not null)").execute().apply()
+          SQL("create table members_" + suffix + " (id int not null, group_id int not null)").execute().apply()
+          SQL("create table sponsors_" + suffix + " (id int not null, group_id int not null)").execute().apply()
 
-          SQL("insert into groups_" + suffix + " values (1, 2)").update.apply()
-          SQL("insert into groups_" + suffix + " values (2, 2)").update.apply()
-          SQL("insert into groups_" + suffix + " values (3, 1)").update.apply()
-          SQL("insert into groups_" + suffix + " values (4, 2)").update.apply()
+          SQL("insert into groups_" + suffix + " values (1, 2)").update().apply()
+          SQL("insert into groups_" + suffix + " values (2, 2)").update().apply()
+          SQL("insert into groups_" + suffix + " values (3, 1)").update().apply()
+          SQL("insert into groups_" + suffix + " values (4, 2)").update().apply()
 
-          SQL("insert into owners_" + suffix + " values (1)").update.apply()
-          SQL("insert into owners_" + suffix + " values (2)").update.apply()
+          SQL("insert into owners_" + suffix + " values (1)").update().apply()
+          SQL("insert into owners_" + suffix + " values (2)").update().apply()
 
-          SQL("insert into events_" + suffix + " values (1, 2)").update.apply()
-          SQL("insert into events_" + suffix + " values (2, 1)").update.apply()
-          SQL("insert into events_" + suffix + " values (3, 1)").update.apply()
+          SQL("insert into events_" + suffix + " values (1, 2)").update().apply()
+          SQL("insert into events_" + suffix + " values (2, 1)").update().apply()
+          SQL("insert into events_" + suffix + " values (3, 1)").update().apply()
 
-          SQL("insert into news_" + suffix + " values (1, 2)").update.apply()
-          SQL("insert into news_" + suffix + " values (2, 1)").update.apply()
-          SQL("insert into news_" + suffix + " values (3, 2)").update.apply()
-          SQL("insert into news_" + suffix + " values (4, 2)").update.apply()
-          SQL("insert into news_" + suffix + " values (5, 3)").update.apply()
-          SQL("insert into news_" + suffix + " values (6, 2)").update.apply()
-          SQL("insert into news_" + suffix + " values (7, 1)").update.apply()
-          SQL("insert into news_" + suffix + " values (8, 1)").update.apply()
+          SQL("insert into news_" + suffix + " values (1, 2)").update().apply()
+          SQL("insert into news_" + suffix + " values (2, 1)").update().apply()
+          SQL("insert into news_" + suffix + " values (3, 2)").update().apply()
+          SQL("insert into news_" + suffix + " values (4, 2)").update().apply()
+          SQL("insert into news_" + suffix + " values (5, 3)").update().apply()
+          SQL("insert into news_" + suffix + " values (6, 2)").update().apply()
+          SQL("insert into news_" + suffix + " values (7, 1)").update().apply()
+          SQL("insert into news_" + suffix + " values (8, 1)").update().apply()
 
-          SQL("insert into members_" + suffix + " values (1, 2)").update.apply()
-          SQL("insert into members_" + suffix + " values (2, 1)").update.apply()
-          SQL("insert into members_" + suffix + " values (3, 1)").update.apply()
-          SQL("insert into members_" + suffix + " values (4, 2)").update.apply()
-          SQL("insert into members_" + suffix + " values (5, 1)").update.apply()
+          SQL("insert into members_" + suffix + " values (1, 2)").update().apply()
+          SQL("insert into members_" + suffix + " values (2, 1)").update().apply()
+          SQL("insert into members_" + suffix + " values (3, 1)").update().apply()
+          SQL("insert into members_" + suffix + " values (4, 2)").update().apply()
+          SQL("insert into members_" + suffix + " values (5, 1)").update().apply()
 
-          SQL("insert into sponsors_" + suffix + " values (1, 1)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (2, 2)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (3, 3)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (4, 2)").update.apply()
-          SQL("insert into sponsors_" + suffix + " values (5, 3)").update.apply()
+          SQL("insert into sponsors_" + suffix + " values (1, 1)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (2, 2)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (3, 3)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (4, 2)").update().apply()
+          SQL("insert into sponsors_" + suffix + " values (5, 3)").update().apply()
       }
 
       implicit val session = ReadOnlyAutoSession
@@ -775,7 +775,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
             rs => rs.intOpt("s_id").map(id => Sponsor(id, rs.int("g_id"))))
           .map { (g, os, es, ns, ms, ss) =>
             Group(id = g.id, ownerId = g.ownerId, owner = os.head, events = es, news = ns, members = ms, sponsors = ss)
-          }.list.apply()
+          }.list().apply()
 
         groups.size should equal(4)
         groups(0).id should equal(1)
@@ -863,7 +863,7 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
             rs => rs.intOpt("s_id").map(id => Sponsor(id, rs.int("g_id"))))
           .map { (g, os, es, ns, ms, ss) =>
             Group(id = g.id, ownerId = g.ownerId, owner = os.head, events = es, news = ns, members = ms, sponsors = ss)
-          }.single.apply().get
+          }.single().apply().get
 
         group.id should equal(1)
 
@@ -879,11 +879,11 @@ class RelationalSQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter wi
     } finally {
       DB autoCommit {
         implicit s =>
-          SQL("drop table groups_" + suffix).execute.apply()
-          SQL("drop table owners_" + suffix).execute.apply()
-          SQL("drop table events_" + suffix).execute.apply()
-          SQL("drop table members_" + suffix).execute.apply()
-          SQL("drop table sponsors_" + suffix).execute.apply()
+          SQL("drop table groups_" + suffix).execute().apply()
+          SQL("drop table owners_" + suffix).execute().apply()
+          SQL("drop table events_" + suffix).execute().apply()
+          SQL("drop table members_" + suffix).execute().apply()
+          SQL("drop table sponsors_" + suffix).execute().apply()
       }
     }
   }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/ResultSetIteratorSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/ResultSetIteratorSpec.scala
@@ -26,10 +26,10 @@ class ResultSetIteratorSpec extends AnyFlatSpec with Matchers with Settings {
         assert(i.hasNext === false)
         assert(i.size === 0)
         intercept[NoSuchElementException] {
-          i.next
+          i.next()
         }
         intercept[NoSuchElementException] {
-          i.next
+          i.next()
         }
       }
 
@@ -53,10 +53,10 @@ class ResultSetIteratorSpec extends AnyFlatSpec with Matchers with Settings {
           assert(i.hasNext === false)
           assert(i.hasNext === false)
           intercept[NoSuchElementException] {
-            i.next
+            i.next()
           }
           intercept[NoSuchElementException] {
-            i.next
+            i.next()
           }
         }
       }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/SQLSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/SQLSpec.scala
@@ -32,7 +32,7 @@ class SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with Setting
         SQL("insert into " + tableName + " values (?, ?)").bind(4, Option(null)).execute().apply()
 
         val noName = SQL("select id,name from " + tableName + " where id = ?").bind(4)
-          .map(rs => (rs.int("id"), rs.string("name"))).toOption
+          .map(rs => (rs.int("id"), rs.string("name"))).toOption()
           .apply()
 
         noName.get._1 should equal(4)
@@ -110,7 +110,7 @@ class SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with Setting
       using(DB(ConnectionPool.borrow())) { db =>
         implicit val session = db.autoCommitSession()
 
-        val count = SQL("update " + tableName + " set name = ? where id = ?").bind("foo", 1).executeUpdate.apply()
+        val count = SQL("update " + tableName + " set name = ? where id = ?").bind("foo", 1).executeUpdate().apply()
         count should equal(1)
 
         val before = (s: PreparedStatement) => println("before")
@@ -134,7 +134,7 @@ class SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with Setting
       TestUtils.initialize(tableName)
       using(DB(ConnectionPool.borrow())) { db =>
         implicit val session = db.autoCommitSession()
-        val count = SQL("update " + tableName + " set name = ? where id = ?").bind("foo", 1).update.apply()
+        val count = SQL("update " + tableName + " set name = ? where id = ?").bind("foo", 1).update().apply()
         count should equal(1)
 
         val before = (s: PreparedStatement) => println("before")
@@ -252,20 +252,20 @@ class SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with Setting
       TestUtils.initialize(tableName)
       GlobalSettings.nameBindingSQLValidator = NameBindingSQLValidatorSettings(globalsettings.NoCheckForIgnoredParams)
       DB readOnly { implicit s =>
-        SQL("select 1 from " + tableName).bindByName(Symbol("foo") -> "bar").map(_.toMap).list.apply()
+        SQL("select 1 from " + tableName).bindByName(Symbol("foo") -> "bar").map(_.toMap()).list().apply()
       }
       GlobalSettings.nameBindingSQLValidator = NameBindingSQLValidatorSettings(globalsettings.InfoLoggingForIgnoredParams)
       DB readOnly { implicit s =>
-        SQL("select 1 from " + tableName).bindByName(Symbol("foo") -> "bar").map(_.toMap).list.apply()
+        SQL("select 1 from " + tableName).bindByName(Symbol("foo") -> "bar").map(_.toMap()).list().apply()
       }
       GlobalSettings.nameBindingSQLValidator = NameBindingSQLValidatorSettings(globalsettings.WarnLoggingForIgnoredParams)
       DB readOnly { implicit s =>
-        SQL("select 1 from " + tableName).bindByName(Symbol("foo") -> "bar").map(_.toMap).list.apply()
+        SQL("select 1 from " + tableName).bindByName(Symbol("foo") -> "bar").map(_.toMap()).list().apply()
       }
       GlobalSettings.nameBindingSQLValidator = NameBindingSQLValidatorSettings(globalsettings.ExceptionForIgnoredParams)
       intercept[IllegalStateException] {
         DB readOnly { implicit s =>
-          SQL("select 1 from " + tableName).bindByName(Symbol("foo") -> "bar").map(_.toMap).list.apply()
+          SQL("select 1 from " + tableName).bindByName(Symbol("foo") -> "bar").map(_.toMap()).list().apply()
         }
       }
     }
@@ -278,7 +278,7 @@ class SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with Setting
       TestUtils.initialize(tableName)
 
       val results: List[Map[String, Any]] = DB readOnly { implicit s =>
-        SQL("select 1 from " + tableName).toMap.list.apply()
+        SQL("select 1 from " + tableName).toMap().list().apply()
       }
       results.size should be > (0)
     }
@@ -303,13 +303,13 @@ class SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with Setting
 
       implicit val session = ReadOnlyAutoSession
 
-      SQL("select id from " + tableName + "").map(_.long(1)).list.apply()
+      SQL("select id from " + tableName + "").map(_.long(1)).list().apply()
 
       intercept[SQLException] {
-        SQL("delete from " + tableName + "").update.apply()
+        SQL("delete from " + tableName + "").update().apply()
       }
       intercept[SQLException] {
-        SQL("update " + tableName + " set name = 'Anonymous'").update.apply()
+        SQL("update " + tableName + " set name = 'Anonymous'").update().apply()
       }
       intercept[SQLException] {
         SQL("update " + tableName + " set name = ?").batch(Seq("Anonymous")).apply()
@@ -323,13 +323,13 @@ class SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with Setting
       TestUtils.initialize(tableName)
       implicit val session = ReadOnlyNamedAutoSession(Symbol("named"))
 
-      SQL("select id from " + tableName + "").map(_.long(1)).list.apply()
+      SQL("select id from " + tableName + "").map(_.long(1)).list().apply()
 
       intercept[SQLException] {
-        SQL("delete from " + tableName + "").update.apply()
+        SQL("delete from " + tableName + "").update().apply()
       }
       intercept[SQLException] {
-        SQL("update " + tableName + " set name = 'Anonymous'").update.apply()
+        SQL("update " + tableName + " set name = 'Anonymous'").update().apply()
       }
       intercept[SQLException] {
         SQL("update " + tableName + " set name = ?").batch(Seq("Anonymous")).apply()
@@ -345,14 +345,14 @@ class SQLSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with Setting
       ultimately(TestUtils.deleteTable("sqlspec_genkey")) {
         try {
           try {
-            SQL("create table sqlspec_genkey (id integer generated always as identity(start with 0), name varchar(10))").execute.apply()
+            SQL("create table sqlspec_genkey (id integer generated always as identity(start with 0), name varchar(10))").execute().apply()
           } catch {
             case e: Exception =>
               try {
-                SQL("create table sqlspec_genkey (id integer auto_increment, name varchar(10), primary key(id))").execute.apply()
+                SQL("create table sqlspec_genkey (id integer auto_increment, name varchar(10), primary key(id))").execute().apply()
               } catch {
                 case e: Exception =>
-                  SQL("create table sqlspec_genkey (id serial not null, name varchar(10), primary key(id))").execute.apply()
+                  SQL("create table sqlspec_genkey (id serial not null, name varchar(10), primary key(id))").execute().apply()
               }
           }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/StringSQLRunnerSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/StringSQLRunnerSpec.scala
@@ -21,11 +21,11 @@ class StringSQLRunnerSpec extends AnyFlatSpec with Matchers with Settings {
       import scalikejdbc.StringSQLRunner._
 
       // run insert SQL
-      ("insert into " + tableName + " values (3, 'Ben')").run
-      ("insert into " + tableName + " values (4, 'Chris')").execute
+      ("insert into " + tableName + " values (3, 'Ben')").run()
+      ("insert into " + tableName + " values (4, 'Chris')").execute()
 
       // run select SQL
-      val result = ("select id,name from " + tableName + " where id = 3").run
+      val result = ("select id,name from " + tableName + " where id = 3").run()
       if (result.head.get("ID").isDefined) {
         result.head.get("ID").get should equal(3)
         result.head.get("NAME").get should equal("Ben")

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/cpcontext/ConnectionPoolContextSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/cpcontext/ConnectionPoolContextSpec.scala
@@ -22,18 +22,18 @@ class ConnectionPoolContextSpec extends AnyFlatSpec with Matchers with Settings 
       insertData(tableName, 4)(ConnectionPool.DEFAULT_NAME)
 
       val result1 = DB readOnly { implicit s =>
-        SQL("select * from " + tableName).map(rs => rs.string("name")).list.apply()
+        SQL("select * from " + tableName).map(rs => rs.string("name")).list().apply()
       }
       result1.size should equal(4)
 
       val result11 = NamedDB(ConnectionPool.DEFAULT_NAME)(NoConnectionPoolContext) readOnly { implicit s =>
-        SQL("select * from " + tableName).map(rs => rs.string("name")).list.apply()
+        SQL("select * from " + tableName).map(rs => rs.string("name")).list().apply()
       }
       result11.size should equal(4)
       result1.zip(result11).foreach { case (a, b) => a should equal(b) }
 
       val result2 = NamedDB(ConnectionPool.DEFAULT_NAME)(NoConnectionPoolContext) readOnly { implicit s =>
-        SQL("select * from " + tableName).map(rs => rs.string("name")).list.apply()
+        SQL("select * from " + tableName).map(rs => rs.string("name")).list().apply()
       }
       result2.size should equal(4)
       result1.zip(result2).foreach { case (a, b) => a should equal(b) }
@@ -55,18 +55,18 @@ class ConnectionPoolContextSpec extends AnyFlatSpec with Matchers with Settings 
       insertData(tableName, 6)(ConnectionPool.DEFAULT_NAME)
 
       val result1 = DB readOnly { implicit s =>
-        SQL("select * from " + tableName).map(rs => rs.string("name")).list.apply()
+        SQL("select * from " + tableName).map(rs => rs.string("name")).list().apply()
       }
       result1.size should equal(6)
 
       val result11 = NamedDB(ConnectionPool.DEFAULT_NAME) readOnly { implicit s =>
-        SQL("select * from " + tableName).map(rs => rs.string("name")).list.apply()
+        SQL("select * from " + tableName).map(rs => rs.string("name")).list().apply()
       }
       result11.size should equal(6)
       result1.zip(result11).foreach { case (a, b) => a should equal(b) }
 
       val result2 = NamedDB(Symbol("ConnectionPoolContextSpec")) readOnly { implicit s =>
-        SQL("select * from " + tableName).map(rs => rs.string("name")).list.apply()
+        SQL("select * from " + tableName).map(rs => rs.string("name")).list().apply()
       }
       result2.size should equal(6)
       result1.zip(result2).foreach { case (a, b) => a should equal(b) }
@@ -87,16 +87,16 @@ object ConnectionPoolContextSpecUtils {
   def createTable(tableName: String)(name: Any) = {
     NamedDB(name)(NoConnectionPoolContext) autoCommit { implicit s =>
       try {
-        SQL("drop table " + tableName).execute.apply()
+        SQL("drop table " + tableName).execute().apply()
       } catch { case e: Throwable => }
-      SQL("create table " + tableName + " (id integer primary key, name varchar(30))").execute.apply()
+      SQL("create table " + tableName + " (id integer primary key, name varchar(30))").execute().apply()
     }
   }
 
   def insertData(tableName: String, num: Int)(name: Any) = {
     NamedDB(name)(NoConnectionPoolContext) localTx { implicit s =>
       (1 to num).foreach { n =>
-        SQL("insert into " + tableName + " (id, name) values (?, ?)").bind(n, "name" + n).update.apply()
+        SQL("insert into " + tableName + " (id, name) values (?, ?)").bind(n, "name" + n).update().apply()
       }
     }
   }
@@ -104,7 +104,7 @@ object ConnectionPoolContextSpecUtils {
   def dropTable(tableName: String)(name: Any) = {
     try {
       NamedDB(name)(NoConnectionPoolContext) autoCommit { implicit s =>
-        SQL("drop table " + tableName).execute.apply()
+        SQL("drop table " + tableName).execute().apply()
       }
     } catch { case e: Throwable => }
   }
@@ -133,18 +133,18 @@ class ConnectionPoolContextMixinSpec extends AnyFlatSpec with Matchers with Sett
       insertData(tableName, 6)(ConnectionPool.DEFAULT_NAME)
 
       val result1 = DB readOnly { implicit s =>
-        SQL("select * from " + tableName).map(rs => rs.string("name")).list.apply()
+        SQL("select * from " + tableName).map(rs => rs.string("name")).list().apply()
       }
       result1.size should equal(6)
 
       val result11 = NamedDB(ConnectionPool.DEFAULT_NAME) readOnly { implicit s =>
-        SQL("select * from " + tableName).map(rs => rs.string("name")).list.apply()
+        SQL("select * from " + tableName).map(rs => rs.string("name")).list().apply()
       }
       result11.size should equal(6)
       result1.zip(result11).foreach { case (a, b) => a should equal(b) }
 
       val result2 = NamedDB(Symbol("ConnectionPoolContextSpec")) readOnly { implicit s =>
-        SQL("select * from " + tableName).map(rs => rs.string("name")).list.apply()
+        SQL("select * from " + tableName).map(rs => rs.string("name")).list().apply()
       }
       result2.size should equal(6)
       result1.zip(result2).foreach { case (a, b) => a should equal(b) }
@@ -168,10 +168,10 @@ trait InMemoryDB {
     Symbol("CPContextWithAutoSessionSpec") -> CommonsConnectionPoolFactory.apply("jdbc:h2:mem:CPContextWithAutoSessionSpec", "", ""))
   NamedDB(Symbol("CPContextWithAutoSessionSpec")) localTx { implicit session =>
     SQL("create table users (id bigint primary key, name varchar(256), created_at timestamp not null);")
-      .execute.apply()
+      .execute().apply()
     (1 to 1000) foreach { i =>
       SQL("insert into users values (?,?,?)")
-        .bind(i, "user%05d".format(i), LocalDateTime.now).update.apply()
+        .bind(i, "user%05d".format(i), LocalDateTime.now).update().apply()
     }
   }
 }
@@ -181,12 +181,12 @@ object Sample {
   def countAll()(implicit
     session: DBSession = NamedAutoSession(Symbol("CPContextWithAutoSessionSpec")),
     context: ConnectionPoolContext = NoConnectionPoolContext): Long = {
-    SQL("select count(1) c from users").map(rs => rs.long("c")).single.apply.get
+    SQL("select count(1) c from users").map(rs => rs.long("c")).single().apply().get
   }
 
   def countAll2()(implicit context: ConnectionPoolContext = NoConnectionPoolContext): Long = {
     NamedDB(Symbol("CPContextWithAutoSessionSpec")) readOnly { implicit s =>
-      SQL("select count(1) c from users").map(rs => rs.long("c")).single.apply.get
+      SQL("select count(1) c from users").map(rs => rs.long("c")).single().apply().get
     }
   }
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/jsr310/StatementExecutorSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/jsr310/StatementExecutorSpec.scala
@@ -31,10 +31,10 @@ class StatementExecutorSpec extends AnyFunSpec with Matchers with Settings {
                created_at       timestamp(6) not null default CURRENT_TIMESTAMP(6) on update CURRENT_TIMESTAMP(6),
                updated_at       timestamp(6) not null default CURRENT_TIMESTAMP(6) on update CURRENT_TIMESTAMP(6),
                deleted_at       timestamp(6) not null default CURRENT_TIMESTAMP(6) on update CURRENT_TIMESTAMP(6)
-            )""".execute.apply()
+            )""".execute().apply()
           } else {
             sql"create table accounts (birthday date not null, alert_time time(6) not null, local_created_at timestamp(6) not null, created_at timestamp(6) not null, updated_at timestamp(6) not null, deleted_at timestamp(6) not null )"
-              .execute.apply()
+              .execute().apply()
           }
 
           val birthday = LocalDate.now
@@ -48,11 +48,11 @@ class StatementExecutorSpec extends AnyFunSpec with Matchers with Settings {
           val updatedAt = Instant.now.plusNanos(333000)
           val deletedAt = OffsetDateTime.now.plusNanos(444000)
           val query = sql"insert into accounts (birthday, alert_time, local_created_at, created_at, updated_at, deleted_at) values (${birthday}, ${alertTime}, ${localCreatedAt}, ${createdAt}, ${updatedAt}, ${deletedAt})"
-          query.execute.apply()
+          query.execute().apply()
 
           val account = sql"select birthday, alert_time, local_created_at, created_at, updated_at, deleted_at from accounts limit 1".map { rs =>
             (rs.get[LocalDate]("birthday"), rs.get[LocalTime]("alert_time"), rs.get[LocalDateTime]("local_created_at"), rs.get[ZonedDateTime]("created_at"), rs.get[Instant]("updated_at"), rs.get[OffsetDateTime]("deleted_at"))
-          }.headOption.apply()
+          }.headOption().apply()
 
           account.isDefined should equal(true)
           account.get._1 should equal(birthday)

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/ColumnSQLSyntaxProviderSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/ColumnSQLSyntaxProviderSpec.scala
@@ -18,12 +18,12 @@ trait SyntaxProviderTestSupport extends TestSuiteMixin with SQLInterpolation { s
   abstract override protected def withFixture(test: NoArgTest): Outcome = {
     DB.autoCommit { implicit session =>
       this.session = session
-      sql"create table ${Account.table} (id int not null, name varchar(256))".execute.apply()
+      sql"create table ${Account.table} (id int not null, name varchar(256))".execute().apply()
       try {
         super.withFixture(test)
       } finally {
         try {
-          sql"drop table ${Account.table}".execute.apply()
+          sql"drop table ${Account.table}".execute().apply()
         } catch {
           case NonFatal(e) =>
         }

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/InformationSchemaSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/InformationSchemaSpec.scala
@@ -19,15 +19,15 @@ class InformationSchemaSpec extends AnyFlatSpec with Matchers with SQLInterpolat
   it should "work" in {
     val roles: collection.Seq[Role] = DB autoCommit { implicit s =>
       try {
-        sql"drop table roles if exists".execute.apply()
+        sql"drop table roles if exists".execute().apply()
       } catch { case e: Exception => }
       try {
-        sql"create table roles (id int not null, name varchar(256) not null)".execute.apply()
-        sql"insert into roles (id, name) values (1, 'Alice')".update.apply()
+        sql"create table roles (id int not null, name varchar(256) not null)".execute().apply()
+        sql"insert into roles (id, name) values (1, 'Alice')".update().apply()
       } catch { case e: Exception => }
 
       val r = Roles.syntax("r")
-      withSQL { select.from(Roles as r) }.map(Roles(r)).list.apply()
+      withSQL { select.from(Roles as r) }.map(Roles(r)).list().apply()
     }
     roles.size should equal(1)
   }

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/PostgreSQL_JSON_Objects_Spec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/PostgreSQL_JSON_Objects_Spec.scala
@@ -18,17 +18,17 @@ class PostgreSQL_JSON_Objects_Spec extends AnyFlatSpec with Matchers with DBSett
   }
 
   it should "perform DDLs/DMLs" in {
-    if (isTestWithPostgreSQL) {
+    if (isTestWithPostgreSQL()) {
       implicit val session = AutoSession
       val tableName = sqls"json_data_table"
       // preparation
       try {
-        sql"drop table $tableName".execute.apply()
+        sql"drop table $tableName".execute().apply()
       } catch {
         case NonFatal(_) =>
       }
-      sql"create table $tableName (c1 json, c2 jsonb, c3 json not null, c4 jsonb not null)".execute.apply()
-      sql"create index ${tableName}_idx1 on $tableName using gin (c4)".execute.apply()
+      sql"create table $tableName (c1 json, c2 jsonb, c3 json not null, c4 jsonb not null)".execute().apply()
+      sql"create index ${tableName}_idx1 on $tableName using gin (c4)".execute().apply()
 
       {
         // You can pass JSON string data as a normal parameter to prepared statement.
@@ -40,7 +40,7 @@ class PostgreSQL_JSON_Objects_Spec extends AnyFlatSpec with Matchers with DBSett
             |  "birthYear": 1995
             |}
             |""".stripMargin
-        sql"insert into $tableName (c3, c4) values ($json::json, $json::jsonb)".update.apply()
+        sql"insert into $tableName (c3, c4) values ($json::json, $json::jsonb)".update().apply()
       }
       {
         // Embedding JSON as a SQLSyntax, it requires enclosing the JSON part with single quotes
@@ -54,10 +54,10 @@ class PostgreSQL_JSON_Objects_Spec extends AnyFlatSpec with Matchers with DBSett
             |'
             |""".stripMargin
         // Having ::json, ::jsonb is not mandatory for this case.
-        sql"insert into $tableName (c3, c4) values ($json, $json)".update.apply()
-        sql"insert into $tableName (c3, c4) values ($json::json, $json::jsonb)".update.apply()
+        sql"insert into $tableName (c3, c4) values ($json, $json)".update().apply()
+        sql"insert into $tableName (c3, c4) values ($json::json, $json::jsonb)".update().apply()
       }
-      val results: Seq[Map[String, Any]] = sql"select c1, c2, c3, c4 from $tableName".toMap.list.apply()
+      val results: Seq[Map[String, Any]] = sql"select c1, c2, c3, c4 from $tableName".toMap().list().apply()
       logger.debug(results.toString)
       results.size should be > 0
     } else {
@@ -67,17 +67,17 @@ class PostgreSQL_JSON_Objects_Spec extends AnyFlatSpec with Matchers with DBSett
 
   it should "perform json operators" in {
     // https://www.postgresql.org/docs/9.5/functions-json.html
-    if (isTestWithPostgreSQL) {
+    if (isTestWithPostgreSQL()) {
       val tableName = sqls"json_operators_table"
 
       DB.autoCommit { implicit s =>
         // preparation
         try {
-          sql"drop table $tableName".execute.apply()
+          sql"drop table $tableName".execute().apply()
         } catch {
           case NonFatal(_) =>
         }
-        sql"create table $tableName (id serial, config jsonb not null)".execute.apply()
+        sql"create table $tableName (id serial, config jsonb not null)".execute().apply()
 
         val config1 =
           """
@@ -98,38 +98,38 @@ class PostgreSQL_JSON_Objects_Spec extends AnyFlatSpec with Matchers with DBSett
             |  "applications": ["frontend", "backend-api", "database"]
             |}
             |""".stripMargin
-        sql"insert into $tableName (config) values ($config1::jsonb)".update.apply()
-        sql"insert into $tableName (config) values ($config2::jsonb)".update.apply()
+        sql"insert into $tableName (config) values ($config1::jsonb)".update().apply()
+        sql"insert into $tableName (config) values ($config2::jsonb)".update().apply()
       }
 
       DB.readOnly { implicit s =>
         val apps: Seq[Option[String]] = sql"select config::jsonb->'applications' apps from $tableName order by id"
           .map(_.get[Option[String]]("apps"))
-          .list
+          .list()
           .apply()
         apps should equal(Seq(None, Some("""["frontend", "backend-api", "database"]""")))
 
         val credentials: Seq[Option[String]] = sql"select config::jsonb#>'{credentials,api-2}' c from $tableName order by id"
           .map(_.get[Option[String]]("c"))
-          .list
+          .list()
           .apply()
         credentials should equal(Seq(Some("\"abcdef\""), None))
 
         val credentials2: Seq[Option[String]] = sql"select config::jsonb#>>'{credentials,api-2}' c from $tableName order by id"
           .map(_.get[Option[String]]("c"))
-          .list
+          .list()
           .apply()
         credentials2 should equal(Seq(Some("abcdef"), None))
 
         val hosts: Seq[String] = sql"select config::jsonb->'host' host from $tableName order by id"
           .map(_.get[String]("host"))
-          .list
+          .list()
           .apply()
         hosts should equal(Seq("\"localhost\"", "\"somewhere-beautiful.com\""))
 
         val hostsAsText: Seq[String] = sql"select config::jsonb->>'host' host from $tableName order by id"
           .map(_.get[String]("host"))
-          .list
+          .list()
           .apply()
         hostsAsText should equal(Seq("localhost", "somewhere-beautiful.com"))
       }

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/QueryInterfaceSpec.scala
@@ -68,20 +68,20 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
     if (!isMySQL) {
       try {
         DB autoCommit { implicit s =>
-          try sql"drop table ${SchemaExample.table}".execute.apply()
+          try sql"drop table ${SchemaExample.table}".execute().apply()
           catch { case e: Exception => }
-          sql"create table ${SchemaExample.table} (id int not null)".execute.apply()
-          withSQL { insert.into(SchemaExample).values(1) }.update.apply()
+          sql"create table ${SchemaExample.table} (id int not null)".execute().apply()
+          withSQL { insert.into(SchemaExample).values(1) }.update().apply()
           val se = SchemaExample.syntax("se")
           select(sqls.count).from(SchemaExample as se).toSQL.statement should equal(
             "select count(1) from public.qi_schema_example se")
 
-          val count = withSQL { select(sqls.count).from(SchemaExample as se) }.map(_.long(1)).single.apply().get
+          val count = withSQL { select(sqls.count).from(SchemaExample as se) }.map(_.long(1)).single().apply().get
           count should equal(1L)
         }
       } finally {
         DB autoCommit { implicit s =>
-          sql"drop table ${SchemaExample.table}".execute.apply()
+          sql"drop table ${SchemaExample.table}".execute().apply()
         }
       }
     }
@@ -90,21 +90,21 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
   it should "be available with Query Interface" in {
     try {
       DB autoCommit { implicit s =>
-        try sql"drop table ${Order.table}".execute.apply()
+        try sql"drop table ${Order.table}".execute().apply()
         catch { case e: Exception => }
-        sql"create table ${Order.table} (id int not null, product_id int not null, account_id int, created_at timestamp not null)".execute.apply()
+        sql"create table ${Order.table} (id int not null, product_id int not null, account_id int, created_at timestamp not null)".execute().apply()
 
-        try sql"drop table ${Product.table}".execute.apply()
+        try sql"drop table ${Product.table}".execute().apply()
         catch { case e: Exception => }
-        sql"create table ${Product.table} (id int not null, name varchar(256), price int not null)".execute.apply()
+        sql"create table ${Product.table} (id int not null, name varchar(256), price int not null)".execute().apply()
 
-        try sql"drop table ${LegacyProduct.table}".execute.apply()
+        try sql"drop table ${LegacyProduct.table}".execute().apply()
         catch { case e: Exception => }
-        sql"create table ${LegacyProduct.table} (id int, name varchar(256), price int not null)".execute.apply()
+        sql"create table ${LegacyProduct.table} (id int, name varchar(256), price int not null)".execute().apply()
 
-        try sql"drop table ${Account.table}".execute.apply()
+        try sql"drop table ${Account.table}".execute().apply()
         catch { case e: Exception => }
-        sql"create table ${Account.table} (id int not null, name varchar(256))".execute.apply()
+        sql"create table ${Account.table} (id int not null, name varchar(256))".execute().apply()
       }
 
       DB localTx { implicit s =>
@@ -142,7 +142,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
           val p = Product.syntax("p")
           val products = withSQL {
             select.from(Product as p).orderBy(p.id)
-          }.map(Product(p)).list.apply()
+          }.map(Product(p)).list().apply()
           assert(products === List(Product(1, Some("Cookie"), Price(120)), Product(2, Some("Tea"), Price(80))))
         }
 
@@ -152,7 +152,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
         }
         batchInsertQuery.batch(Seq(3, "Coffee", 90), Seq(4, "Chocolate", 200)).apply()
 
-        withSQL { delete.from(Product).where.in(pc.id, Seq(3, 4)) }.update.apply()
+        withSQL { delete.from(Product).where.in(pc.id, Seq(3, 4)) }.update().apply()
 
         // batch insert with BatchParamsBuilder
         {
@@ -169,20 +169,20 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             insert.into(Product).namedValues(params.columnsAndPlaceholders: _*)
           }.batch(params.batchParams: _*).apply()
 
-          withSQL { delete.from(Product).where.in(pc.id, Seq(3, 4)) }.update.apply()
+          withSQL { delete.from(Product).where.in(pc.id, Seq(3, 4)) }.update().apply()
         }
 
         val (o, p, a) = (Order.syntax("o"), Product.syntax("p"), Account.syntax("a"))
 
         // simple query
-        val alice: Account = withSQL(select.from(Account as a).where.eq(a.name, "Alice")).map(Account(a)).single.apply().get
+        val alice: Account = withSQL(select.from(Account as a).where.eq(a.name, "Alice")).map(Account(a)).single().apply().get
         val ordersByAlice = withSQL {
           select.from(Order as o).where.eq(o.accountId, alice.id)
-        }.map(Order(o)).list.apply()
+        }.map(Order(o)).list().apply()
 
         ordersByAlice.size should equal(4)
 
-        val allAccounts = withSQL { select.from(Account as a).orderBy(a.id) }.map(Account(a)).list.apply()
+        val allAccounts = withSQL { select.from(Account as a).orderBy(a.id) }.map(Account(a)).list().apply()
         allAccounts.size should equal(4)
 
         // join query
@@ -195,7 +195,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             .orderBy(o.id).desc
             .limit(4)
             .offset(0)
-        }.map(Order(o, p, a)).list.apply()
+        }.map(Order(o, p, a)).list().apply()
 
         cookieOrders.size should equal(4)
         cookieOrders(0).product.isEmpty should be(false)
@@ -208,10 +208,10 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
           select
             .from(Order as o)
             .crossJoin(Product as p)
-        }.map(Order(o, p)).list.apply()
+        }.map(Order(o, p)).list().apply()
 
-        val productNum = withSQL(select.from(Product as p)).map(Product(p)).list.apply().size
-        val orderNum = withSQL(select.from(Order as o)).map(Order(o)).list.apply().size
+        val productNum = withSQL(select.from(Product as p)).map(Product(p)).list().apply().size
+        val orderNum = withSQL(select.from(Order as o)).map(Order(o)).list().apply().size
         ordersAndProducts.size should equal(productNum * orderNum)
         ordersAndProducts.head.id should equal(11)
         ordersAndProducts.head.productId should equal(1)
@@ -226,7 +226,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             .where.eq(o.id, 13)
         }.map {
           rs => if (accountRequired) Order(o, p, a)(rs) else Order(o, p)(rs)
-        }.single.apply()
+        }.single().apply()
 
         findCookieOrder(true).get.account.isEmpty should be(false)
         findCookieOrder(false).get.account.isEmpty should be(true)
@@ -239,7 +239,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             .where(sqls.toAndConditionOpt(
               accountName.map(sqls.eq(a.name, _))))
         }.map { rs => Order(o, p)(rs)
-        }.list.apply()
+        }.list().apply()
 
         findByOptionalAccountName(Some("Alice")).size should be(4)
         findByOptionalAccountName(Option.empty).size should be(11)
@@ -252,7 +252,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
                 productId.map(id => sqls.eq(o.productId, id)),
                 accountId.map(id => sqls.eq(o.accountId, id))))
               .orderBy(o.id)
-          }.map(_.int(1)).list.apply()
+          }.map(_.int(1)).list().apply()
           ids should equal(Seq(11, 12, 13, 14, 15))
         }
         {
@@ -263,7 +263,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
                 productId.map(id => sqls.eq(o.productId, id)),
                 accountId.map(id => sqls.eq(o.accountId, id))))
               .orderBy(o.id)
-          }.map(_.int(1)).list.apply()
+          }.map(_.int(1)).list().apply()
           ids should equal(Seq(12))
         }
 
@@ -277,7 +277,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
                 id1.map(id => sqls.eq(o.productId, id)),
                 id2.map(id => sqls.eq(o.productId, id))))
               .orderBy(o.id)
-          }.map(_.int(1)).list.apply()
+          }.map(_.int(1)).list().apply()
           ids should equal(Seq(11, 12, 13, 14, 15))
         }
         {
@@ -290,7 +290,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
                 id1.map(id => sqls.eq(o.productId, id)),
                 id2.map(id => sqls.eq(o.productId, id))))
               .orderBy(o.id)
-          }.map(_.int(1)).list.apply()
+          }.map(_.int(1)).list().apply()
           ids should equal(Seq(11, 12, 13, 14, 15, 21, 22, 23, 24, 25))
         }
 
@@ -299,7 +299,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
         val productId: Option[Int] = withSQL {
           select(sqls"${sp(p).id} id")
             .from(select.from(Product as p).where.eq(p.price, Price(80)).as(sp))
-        }.map(rs => rs.int("id")).single.apply()
+        }.map(rs => rs.int("id")).single().apply()
 
         productId should equal(Option(2))
 
@@ -312,7 +312,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             .groupBy(x(o).accountId)
             .having(gt(sum(x(p).price), 300))
             .orderBy(sqls"amount")
-        }.map(rs => (rs.int("id"), rs.int("amount"))).list.apply()
+        }.map(rs => (rs.int("id"), rs.int("amount"))).list().apply()
 
         preferredClients.size should equal(2)
         preferredClients should equal(List((2, 360), (1, 440)))
@@ -325,7 +325,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
               _.eq(o.productId, 1).and.isNotNull(o.accountId)
             }.or.isNull(o.accountId)
             .orderBy(o.id)
-        }.map(_.int(o.resultName.id)).list.apply()
+        }.map(_.int(o.resultName.id)).list().apply()
 
         bracketTestResults should equal(List(11, 12, 13, 14, 15, 26))
 
@@ -336,7 +336,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             .where.roundBracket(
               sqls.eq(o.productId, 1).and.isNotNull(o.accountId)).or.isNull(o.accountId)
             .orderBy(o.id)
-        }.map(_.int(o.resultName.id)).list.apply()
+        }.map(_.int(o.resultName.id)).list().apply()
 
         bracketTestResults2 should equal(List(11, 12, 13, 14, 15, 26))
 
@@ -351,7 +351,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
                 Some(sqls.isNotNull(o.accountId))).map(s => sql.append(s)).getOrElse(sql))
               .or.isNull(o.accountId)
               .orderBy(o.id).append(sqls"desc")
-          }.map(_.int(o.resultName.id)).list.apply()
+          }.map(_.int(o.resultName.id)).list().apply()
 
           withConditionsTestResults should equal(List(26, 15, 14, 13, 12, 11))
         }
@@ -364,7 +364,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
               .where(sqls.toOrConditionOpt(
                 productId.map(i => sqls.eq(o.productId, i)),
                 Some(sqls.isNull(o.accountId)))).orderBy(o.id)
-          }.map(_.int(o.resultName.id)).list.apply()
+          }.map(_.int(o.resultName.id)).list().apply()
 
           withConditionsTestResults should equal(List(11, 12, 13, 14, 15, 26))
         }
@@ -375,7 +375,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Order as o)
               .where.in(o.id, Seq(1, 2, 14, 15, 16, 20, 21, 22))
               .orderBy(o.id)
-          }.map(Order(o)).list.apply()
+          }.map(Order(o)).list().apply()
           inClauseResults.map(_.id) should equal(List(14, 15, 21, 22))
         }
         {
@@ -383,7 +383,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Order as o)
               .where.in(o.id, Seq[Int]())
               .orderBy(o.id)
-          }.map(Order(o)).list.apply()
+          }.map(Order(o)).list().apply()
           inClauseResults.map(_.id) should equal(Nil)
         }
         {
@@ -391,7 +391,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Order as o)
               .where.notIn(o.id, Seq(14, 15, 22, 23, 24, 25, 26))
               .orderBy(o.id)
-          }.map(Order(o)).list.apply()
+          }.map(Order(o)).list().apply()
           notInClauseResults.map(_.id) should equal(List(11, 12, 13, 21))
         }
         {
@@ -399,7 +399,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Order as o)
               .where.notIn(o.id, Seq[Int]())
               .orderBy(o.id)
-          }.map(Order(o)).list.apply()
+          }.map(Order(o)).list().apply()
           notInClauseResults.map(_.id) should equal(List(11, 12, 13, 14, 15, 21, 22, 23, 24, 25, 26))
         }
         {
@@ -407,7 +407,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Order as o)
               .where.not.in(o.id, Seq[Int]())
               .orderBy(o.id)
-          }.map(Order(o)).list.apply()
+          }.map(Order(o)).list().apply()
           notInClauseResults.map(_.id) should equal(List(11, 12, 13, 14, 15, 21, 22, 23, 24, 25, 26))
         }
         {
@@ -415,7 +415,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Order as o)
               .where.in(o.id, select(o.id).from(Order as o).where.between(o.id, 14, 16))
               .orderBy(o.id)
-          }.map(Order(o)).list.apply()
+          }.map(Order(o)).list().apply()
           inClauseResults.map(_.id) should equal(List(14, 15))
         }
         {
@@ -423,7 +423,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Order as o)
               .where.notIn(o.id, select(o.id).from(Order as o).where.between(o.id, 13, 30))
               .orderBy(o.id)
-          }.map(Order(o)).list.apply()
+          }.map(Order(o)).list().apply()
           inClauseResults.map(_.id) should equal(List(11, 12))
         }
         {
@@ -431,7 +431,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Order as o)
               .where.in(o.id, select(o.id).from(Order as o).where.notBetween(o.id, 14, 16))
               .orderBy(o.id)
-          }.map(Order(o)).list.apply()
+          }.map(Order(o)).list().apply()
           inClauseResults.map(_.id) should equal(List(11, 12, 13, 21, 22, 23, 24, 25, 26))
         }
         {
@@ -439,7 +439,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Order as o)
               .where.notIn(o.id, select(o.id).from(Order as o).where.notBetween(o.id, 13, 30))
               .orderBy(o.id)
-          }.map(Order(o)).list.apply()
+          }.map(Order(o)).list().apply()
           inClauseResults.map(_.id) should equal(List(13, 14, 15, 21, 22, 23, 24, 25, 26))
         }
 
@@ -448,7 +448,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Order as o)
               .where.in((o.id, o.productId), Seq((11, 1), (12, 2), (21, 2)))
               .orderBy(o.id)
-          }.map(Order(o)).list.apply()
+          }.map(Order(o)).list().apply()
           inClauseResults.map(_.id) should equal(List(11, 21))
         }
         {
@@ -456,7 +456,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Order as o)
               .where.in((o.id, o.productId), Seq[(Int, Int)]())
               .orderBy(o.id)
-          }.map(Order(o)).list.apply()
+          }.map(Order(o)).list().apply()
           inClauseResults.map(_.id) should equal(Nil)
         }
         {
@@ -464,7 +464,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Order as o)
               .where.notIn((o.id, o.productId), Seq((11, 1), (12, 2), (13, 1), (14, 1), (15, 1), (21, 2)))
               .orderBy(o.id)
-          }.map(Order(o)).list.apply()
+          }.map(Order(o)).list().apply()
           notInClauseResults.map(_.id) should equal(List(12, 22, 23, 24, 25, 26))
         }
         {
@@ -472,7 +472,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Order as o)
               .where.notIn((o.id, o.productId), Seq[(Int, Int)]())
               .orderBy(o.id)
-          }.map(Order(o)).list.apply()
+          }.map(Order(o)).list().apply()
           notInClauseResults.map(_.id) should equal(List(11, 12, 13, 14, 15, 21, 22, 23, 24, 25, 26))
         }
         {
@@ -480,7 +480,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Order as o)
               .where.not.in((o.id, o.productId), Seq[(Int, Int)]())
               .orderBy(o.id)
-          }.map(Order(o)).list.apply()
+          }.map(Order(o)).list().apply()
           notInClauseResults.map(_.id) should equal(List(11, 12, 13, 14, 15, 21, 22, 23, 24, 25, 26))
         }
 
@@ -490,7 +490,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Account as a)
               .where.like(a.name, "%e%")
               .orderBy(a.id)
-          }.map(Account(a)).list.apply()
+          }.map(Account(a)).list().apply()
           results.map(_.id) should equal(List(1, 4))
         }
         {
@@ -498,7 +498,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select.from(Account as a)
               .where.notLike(a.name, "%e%")
               .orderBy(a.id)
-          }.map(Account(a)).list.apply()
+          }.map(Account(a)).list().apply()
           results.map(_.id) should equal(List(2, 3))
         }
 
@@ -507,7 +507,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
           select(a.id).from(Account as a)
             .where.exists(select.from(Order as o).where.eq(o.accountId, a.id))
             .orderBy(a.id)
-        }.map(_.int(1)).list.apply()
+        }.map(_.int(1)).list().apply()
         existsClauseResults should equal(List(1, 2, 3))
 
         // not exists clause
@@ -516,7 +516,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select(a.id).from(Account as a)
               .where.not.exists(select.from(Order as o).where.eq(o.accountId, a.id))
               .orderBy(a.id)
-          }.map(_.int(1)).list.apply()
+          }.map(_.int(1)).list().apply()
           notExistsClauseResults should equal(List(4))
         }
         {
@@ -524,7 +524,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select(a.id).from(Account as a)
               .where.notExists(sqls"select ${o.id} from ${Order as o} where ${o.accountId} = ${a.id}")
               .orderBy(a.id)
-          }.map(_.int(1)).list.apply()
+          }.map(_.int(1)).list().apply()
           notExistsClauseResults should equal(List(4))
         }
 
@@ -532,7 +532,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
         import sqls.{ distinct, count }
         val productCount = withSQL {
           select(count(distinct(o.productId))).from(Order as o)
-        }.map(_.int(1)).single.apply().get
+        }.map(_.int(1)).single().apply().get
 
         productCount should equal(2)
 
@@ -547,7 +547,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             .innerJoin(Product as p).on(o.productId, p.id)
             .leftJoin(Account as a).on(o.accountId, a.id)
             .groupBy(o.productId)
-        }.map(rs => (rs.int(1), rs.int(2), rs.int(3))).list.apply()
+        }.map(rs => (rs.int(1), rs.int(2), rs.int(3))).list().apply()
 
         wildcardCounts should equal(List((1, 5, 5), (2, 6, 5)))
 
@@ -559,7 +559,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             .groupBy(o.accountId)
             .orderBy(o.accountId).desc
             .limit(2)
-        }.map(rs => (rs.int(1), rs.int(2))).list.apply()
+        }.map(rs => (rs.int(1), rs.int(2))).list().apply()
 
         groupByAfterWhereClauseResults should equal(List((3, 2), (2, 4)))
 
@@ -569,7 +569,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             .union(select(sqls"${p.id} as id").from(Product as p))
             .orderBy(sqls"id").desc
             .limit(3).offset(0)
-        }.map(_.int("id")).list.apply()
+        }.map(_.int("id")).list().apply()
         unionResults should equal(List(4, 3, 2))
 
         // union all
@@ -577,7 +577,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
           select(a.id).from(Account as a)
             .unionAll(select(p.id).from(Product as p))
             .unionAll(select(p.id).from(Product as p))
-        }.map(_.int(1)).list.apply()
+        }.map(_.int(1)).list().apply()
         unionAllResults should equal(List(1, 2, 3, 4, 1, 2, 1, 2))
 
         // except
@@ -587,7 +587,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select(sqls"${a.id} as id").from(Account as a).where.in(a.id, Seq(1, 2, 3))
               .unionAll(select(sqls"${a.id} as id").from(Account as a).where.in(a.id, Seq(1)))
               .except(select(sqls"${p.id} as id").from(Product as p).where.in(p.id, Seq(2)))
-          }.map(_.int("id")).list.apply()
+          }.map(_.int("id")).list().apply()
           exceptResults should equal(List(1, 3))
         }
 
@@ -599,7 +599,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
             select(sqls"${a.id} as id").from(Account as a).where.in(a.id, Seq(1, 2, 3))
               .unionAll(select(sqls"${a.id} as id").from(Account as a).where.in(a.id, Seq(1)))
               .exceptAll(select(sqls"${p.id} as id").from(Product as p).where.in(p.id, Seq(2)))
-          }.map(_.int("id")).list.apply()
+          }.map(_.int("id")).list().apply()
           exceptAllResults should equal(List(1, 1, 3))
         }
 
@@ -609,7 +609,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
           val intersectResults = withSQL {
             select(sqls"${a.id} as id").from(Account as a).where.in(a.id, Seq(1, 2, 3))
               .intersect(select(sqls"${p.id} as id").from(Product as p).where.in(p.id, Seq(1, 2)))
-          }.map(_.int("id")).list.apply()
+          }.map(_.int("id")).list().apply()
           intersectResults should equal(List(1, 2))
         }
 
@@ -623,20 +623,20 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
                   .unionAll(select(sqls"${a.id} as id").from(Account as a).where.in(a.id, Seq(1)))
               }
               .orderBy(sqls"id")
-          }.map(_.int("id")).list.apply()
+          }.map(_.int("id")).list().apply()
           intersectAllResults should equal(List(1, 1, 2))
         }
 
         // between
         val betweenResults = withSQL {
           select(o.result.id).from(Order as o).where.between(o.id, 13, 22)
-        }.map(_.int(1)).list.apply()
+        }.map(_.int(1)).list().apply()
 
         betweenResults should equal(List(13, 14, 15, 21, 22))
 
         val notBetweenResults = withSQL {
           select(o.result.id).from(Order as o).where.notBetween(o.id, 13, 22)
-        }.map(_.int(1)).list.apply()
+        }.map(_.int(1)).list().apply()
 
         notBetweenResults should equal(List(11, 12, 23, 24, 25, 26))
 
@@ -654,18 +654,18 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
         val updateQuery = update(Account).set(ac.name -> "Bob Marley").where.eq(ac.id, 2)
         applyUpdate(updateQuery)
         // of course, this code also works fine.
-        withSQL(update(Account).set(ac.name -> "Bob Marley").where.eq(ac.id, 2)).update.apply()
+        withSQL(update(Account).set(ac.name -> "Bob Marley").where.eq(ac.id, 2)).update().apply()
 
-        val newName = withSQL { select.from(Account as a).where.eq(a.id, 2) }.map(Account(a)).single.apply().get.name
+        val newName = withSQL { select.from(Account as a).where.eq(a.id, 2) }.map(Account(a)).single().apply().get.name
         newName should equal(Some("Bob Marley"))
 
         // TODO compilation error since 2.10.1
         // applyUpdate { delete.from(Order).where.isNull(Order.column.accountId) }
-        withSQL { delete.from(Order).where.isNull(Order.column.accountId) }.update.apply()
+        withSQL { delete.from(Order).where.isNull(Order.column.accountId) }.update().apply()
 
         val noAccountIdOrderCount = withSQL {
           select(count).from(Order as o).where.isNull(o.accountId)
-        }.map(_.long(1)).single.apply().get
+        }.map(_.long(1)).single().apply().get
         noAccountIdOrderCount should equal(0)
 
         val stmt1 = select(count).from(Order as o).where.isNull(o.accountId).toSQL.statement
@@ -674,7 +674,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
         stmt1 should equal(stmt2)
         stmt2 should equal(stmt3)
 
-        val orders = withSQL { QueryDSL.select.from(Order as o).where.isNotNull(o.accountId) }.map(Order(o)).list.apply()
+        val orders = withSQL { QueryDSL.select.from(Order as o).where.isNotNull(o.accountId) }.map(Order(o)).list().apply()
         orders.size should be > (0)
 
         QueryDSL.insert.into(Account).columns(ac.id, ac.name).values(1, "Alice")
@@ -701,7 +701,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
       // for update query
       val o = Order.syntax("o")
       DB localTx { implicit s =>
-        withSQL { select.from(Order as o).where.eq(o.id, 1).forUpdate }.map(Order(o)).single.apply()
+        withSQL { select.from(Order as o).where.eq(o.id, 1).forUpdate }.map(Order(o)).single().apply()
       }
 
     } catch {
@@ -711,10 +711,10 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
     } finally {
       DB localTx { implicit s =>
         try {
-          sql"drop table ${Order.table}".execute.apply()
-          sql"drop table ${LegacyProduct.table}".execute.apply()
-          sql"drop table ${Product.table}".execute.apply()
-          sql"drop table ${Account.table}".execute.apply()
+          sql"drop table ${Order.table}".execute().apply()
+          sql"drop table ${LegacyProduct.table}".execute().apply()
+          sql"drop table ${Product.table}".execute().apply()
+          sql"drop table ${Account.table}".execute().apply()
         } catch { case e: Exception => }
       }
     }
@@ -736,9 +736,9 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
 
   "insert.namedValues" should "accept None under nested AsIsParameterBinder" in {
     DB autoCommit { implicit s =>
-      try sql"drop table ${Account.table}".execute.apply()
+      try sql"drop table ${Account.table}".execute().apply()
       catch { case e: Exception => }
-      sql"create table ${Account.table} (id int not null, name varchar(256))".execute.apply()
+      sql"create table ${Account.table} (id int not null, name varchar(256))".execute().apply()
     }
 
     try {
@@ -748,10 +748,10 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
       query.statement should equal("insert into qi_accounts (id, name) values (?, ?)")
       query.parameters should equal(Seq(123, None))
 
-      DB autoCommit { implicit s => query.update.apply() }
+      DB autoCommit { implicit s => query.update().apply() }
     } finally {
       DB autoCommit { implicit s =>
-        try sql"drop table ${Account.table}".execute.apply()
+        try sql"drop table ${Account.table}".execute().apply()
         catch { case e: Exception => }
       }
     }
@@ -771,9 +771,9 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
     }
 
     DB autoCommit { implicit session =>
-      try sql"drop table ${TimeHolder.table}".execute.apply()
+      try sql"drop table ${TimeHolder.table}".execute().apply()
       catch { case e: Exception => }
-      sql"create table ${TimeHolder.table} (id int, time timestamp)".execute.apply()
+      sql"create table ${TimeHolder.table} (id int, time timestamp)".execute().apply()
     }
 
     try {
@@ -784,11 +784,11 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
           connectionAttributes = session.connectionAttributes.copy(timeZoneSettings = TimeZoneSettings(true, TimeZone.getTimeZone("Asia/Tokyo"))))
 
         applyUpdate(insertInto(TimeHolder).namedValues(TimeHolder.column.id -> 1, TimeHolder.column.time -> time))
-        val jstString = SQL(s"select $castToString as s from ${TimeHolder.tableName} where id = 1").map(_.string("s")).single.apply().get
+        val jstString = SQL(s"select $castToString as s from ${TimeHolder.tableName} where id = 1").map(_.string("s")).single().apply().get
         val expected = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(time)
         jstString should equal(expected)
 
-        val expectedTime1 = withSQL(selectFrom(TimeHolder as t).where.eq(t.id, 1)).map(TimeHolder(t)(_)).single.apply().get.time
+        val expectedTime1 = withSQL(selectFrom(TimeHolder as t).where.eq(t.id, 1)).map(TimeHolder(t)(_)).single().apply().get.time
         expectedTime1.isEqual(time) should equal(true)
       }
 
@@ -799,14 +799,14 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
           connectionAttributes = session.connectionAttributes.copy(timeZoneSettings = TimeZoneSettings(true, TimeZone.getTimeZone("UTC"))))
 
         applyUpdate(insertInto(TimeHolder).namedValues(TimeHolder.column.id -> 2, TimeHolder.column.time -> time))
-        val utcString = SQL(s"select $castToString as s from ${TimeHolder.tableName} where id = 2").map(_.string("s")).single.apply().get
+        val utcString = SQL(s"select $castToString as s from ${TimeHolder.tableName} where id = 2").map(_.string("s")).single().apply().get
         val expected = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(time.withZoneSameInstant(ZoneId.of("UTC")))
         utcString should equal(expected)
 
-        val expectedTime2 = withSQL(selectFrom(TimeHolder as t).where.eq(t.id, 2)).map(TimeHolder(t)(_)).single.apply().get.time
+        val expectedTime2 = withSQL(selectFrom(TimeHolder as t).where.eq(t.id, 2)).map(TimeHolder(t)(_)).single().apply().get.time
         expectedTime2.isEqual(time) should equal(true)
 
-        val map = withSQL(select(sqls"time").from(TimeHolder as t).where.eq(t.id, 2)).map(_.toMap()).single.apply().get
+        val map = withSQL(select(sqls"time").from(TimeHolder as t).where.eq(t.id, 2)).map(_.toMap()).single().apply().get
         if (map.get("time").isDefined) {
           map.get("time") should equal(Some(java.sql.Timestamp.from(time.toInstant)))
         } else {
@@ -815,7 +815,7 @@ class QueryInterfaceSpec extends AnyFlatSpec with Matchers with DBSettings with 
       }
     } finally {
       DB autoCommit { implicit session =>
-        try sql"drop table ${TimeHolder.table}".execute.apply()
+        try sql"drop table ${TimeHolder.table}".execute().apply()
         catch { case e: Exception => }
       }
     }

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
@@ -82,8 +82,8 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
 
   it should "load column names from NamedDB" in {
     NamedDB(Symbol("yetanother")) autoCommit { implicit s =>
-      try sql"select count(1) from named_db_entity".map(_.toMap).single.apply()
-      catch { case e: Exception => sql"create table named_db_entity(id bigint)".execute.apply() }
+      try sql"select count(1) from named_db_entity".map(_.toMap()).single().apply()
+      catch { case e: Exception => sql"create table named_db_entity(id bigint)".execute().apply() }
     }
     NamedDBEntity.columns.size should equal(1)
   }
@@ -92,30 +92,30 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
     DB autoCommit {
       implicit s =>
         try {
-          try sql"drop table users".execute.apply()
+          try sql"drop table users".execute().apply()
           catch { case e: Exception => }
-          sql"create table users (id int not null, first_name varchar(256), group_id int)".execute.apply()
+          sql"create table users (id int not null, first_name varchar(256), group_id int)".execute().apply()
 
-          try sql"drop table groups".execute.apply()
+          try sql"drop table groups".execute().apply()
           catch { case e: Exception => }
-          sql"create table groups (id int not null, website_url varchar(256))".execute.apply()
+          sql"create table groups (id int not null, website_url varchar(256))".execute().apply()
 
-          try sql"drop table group_members".execute.apply()
+          try sql"drop table group_members".execute().apply()
           catch { case e: Exception => }
-          sql"create table group_members (user_id int not null, group_id int not null)".execute.apply()
+          sql"create table group_members (user_id int not null, group_id int not null)".execute().apply()
 
           Seq((1, Some("foo"), None), (2, Some("bar"), None), (3, Some("baz"), Some(1))) foreach {
             case (id, name, groupId) =>
               val c = User.column
               applyUpdate { insert.into(User).columns(c.id, c.firstName, c.groupId).values(id, name, groupId) }
           }
-          sql"insert into groups values (1, ${"http://jp.scala-users.org/"})".update.apply()
-          sql"insert into groups values (2, ${"http://http://www.java-users.jp/"})".update.apply()
-          sql"insert into group_members values (1, 1)".update.apply()
-          sql"insert into group_members values (2, 1)".update.apply()
-          sql"insert into group_members values (1, 2)".update.apply()
-          sql"insert into group_members values (2, 2)".update.apply()
-          sql"insert into group_members values (3, 2)".update.apply()
+          sql"insert into groups values (1, ${"http://jp.scala-users.org/"})".update().apply()
+          sql"insert into groups values (2, ${"http://http://www.java-users.jp/"})".update().apply()
+          sql"insert into group_members values (1, 1)".update().apply()
+          sql"insert into group_members values (2, 1)".update().apply()
+          sql"insert into group_members values (1, 2)".update().apply()
+          sql"insert into group_members values (2, 2)".update().apply()
+          sql"insert into group_members values (3, 2)".update().apply()
 
           val (u, g) = (User.syntax("u"), Group.syntax)
 
@@ -126,7 +126,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
               ${User.as(u)} left join ${Group.as(g)} on ${u.groupId} = ${g.id}
             where
               ${u.id} = 3
-          """.map(rs => User(rs, u.resultName, g.resultName)).single.apply().get
+          """.map(rs => User(rs, u.resultName, g.resultName)).single().apply().get
 
           user.id should equal(3)
           user.firstName should equal(Some("baz"))
@@ -136,7 +136,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
           val user2 = select.all(u, g).from(User as u).leftJoin(Group as g).on(u.groupId, g.id)
             .where.eq(u.id, 3).and.isNotNull(u.firstName)
             .toSQL
-            .map(rs => User(rs, u.resultName, g.resultName)).single.apply().get
+            .map(rs => User(rs, u.resultName, g.resultName)).single().apply().get
 
           user2.id should equal(3)
           user2.firstName should equal(Some("baz"))
@@ -148,7 +148,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
               .from(User as u)
               .leftJoin(Group as g).on(u.groupId, g.id)
               .where.eq(u.id, 3).and.isNotNull(u.firstName)
-          }.map(rs => User(rs, u.resultName, g.resultName)).single.apply().get
+          }.map(rs => User(rs, u.resultName, g.resultName)).single().apply().get
 
           user3.id should equal(3)
           user3.firstName should equal(Some("baz"))
@@ -241,7 +241,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
               .one(rs => Group(rs, g.resultName))
               .toMany(rs => Some(User(rs, u.resultName)))
               .map { (g, us) => g.copy(members = us) }
-              .list.apply()
+              .list().apply()
 
             groupsWithMembers.size should equal(2)
             groupsWithMembers(0).members.size should equal(2)
@@ -262,7 +262,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
             }.one(rs => Group(rs, g.resultName))
               .toMany(rs => Some(User(rs, u.resultName)))
               .map { (g, us) => g.copy(members = us) }
-              .list.apply()
+              .list().apply()
 
             groupsWithMembers.size should equal(2)
             groupsWithMembers(0).members.size should equal(2)
@@ -288,7 +288,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
               .one(rs => Group(rs, g.resultName))
               .toMany(rs => Some(User(rs, u.resultName)))
               .map { (g, us) => g.copy(members = us) }
-              .iterable.apply()
+              .iterable().apply()
 
             groupsWithMembers.size should equal(2)
             groupsWithMembers.head.members.size should equal(2)
@@ -315,7 +315,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
               .one(rs => Group(rs, g.resultName))
               .toMany(rs => Some(User(rs, u.resultName)))
               .map { (g, us) => g.copy(members = us) }
-              .single.apply()
+              .single().apply()
 
             groupWithMembers.isDefined should be(true)
             groupWithMembers.get.members.size should equal(2)
@@ -334,7 +334,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
             order by ${u.id}
             """
               .map(rs => User(rs, u.resultName))
-              .list.apply()
+              .list().apply()
 
             users.size should be(1)
             users(0).id should equal(1)
@@ -346,7 +346,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
                 .append(userId.map(id => sqls"where ${u.id} = ${id}") getOrElse sqls"")
                 .orderBy(u.id)
             }.map(rs => User(rs, u.resultName))
-              .list.apply()
+              .list().apply()
 
             users.size should be(1)
             users(0).id should equal(1)
@@ -363,7 +363,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
             order by ${u.id}
             """
               .map(rs => User(rs, u.resultName))
-              .list.apply()
+              .list().apply()
 
             users.size should be(3)
             users(0).id should equal(1)
@@ -372,11 +372,11 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
           }
 
         } finally {
-          try sql"drop table users".execute.apply()
+          try sql"drop table users".execute().apply()
           catch { case e: Exception => }
-          try sql"drop table groups".execute.apply()
+          try sql"drop table groups".execute().apply()
           catch { case e: Exception => }
-          try sql"drop table group_members".execute.apply()
+          try sql"drop table group_members".execute().apply()
           catch { case e: Exception => }
         }
     }
@@ -407,19 +407,19 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
   it should "be available for empty relation" in {
     DB autoCommit { implicit s =>
       try {
-        sql"create table issue (id int not null, body varchar(256) not null)".execute.apply()
-        sql"create table tag (id int not null, name varchar(256) not null)".execute.apply()
-        sql"create table issue_tag (issue_id int not null, tag_id int not null)".execute.apply()
+        sql"create table issue (id int not null, body varchar(256) not null)".execute().apply()
+        sql"create table tag (id int not null, name varchar(256) not null)".execute().apply()
+        sql"create table issue_tag (issue_id int not null, tag_id int not null)".execute().apply()
       } catch { case e: Exception => }
     }
     try {
       DB localTx {
         implicit s =>
 
-          sql"insert into issue values (1, ${"Alice"})".update.apply()
-          sql"insert into issue values (2, ${"Bob"})".update.apply()
-          sql"insert into issue values (3, ${"Chris"})".update.apply()
-          sql"insert into issue values (4, ${"Dennis"})".update.apply()
+          sql"insert into issue values (1, ${"Alice"})".update().apply()
+          sql"insert into issue values (2, ${"Bob"})".update().apply()
+          sql"insert into issue values (3, ${"Chris"})".update().apply()
+          sql"insert into issue values (4, ${"Dennis"})".update().apply()
 
           // insert, update, delete
           val c = Issue.column
@@ -477,7 +477,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
               .one(rs => Issue(rs.int(i.resultName.id), rs.string(i.resultName.body)))
               .toMany(rs => rs.intOpt(t.resultName.id).map(id => Tag(id, rs.string(t.resultName.name))))
               .map { (i, ts) => i.copy(tags = i.tags ++ ts) }
-              .single
+              .single()
               .apply()
 
             issue.map(i => i.id) should equal(Some(1))
@@ -490,7 +490,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
             val sq = SubQuery.syntax("sq", i.resultName)
             val summary = sql"""
               select ${is.result(idCount).count}, ${is.result(idSum).sum} from (select ${i.result.id} from ${Issue.as(i)}) ${SubQuery.as(sq)}
-              """.map(IssueSummary(is.resultName)).single.apply().get
+              """.map(IssueSummary(is.resultName)).single().apply().get
             summary.count should equal(4)
             summary.sum should equal(10)
           }
@@ -502,18 +502,18 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
             val summary: IssueSummary = withSQL {
               select(is.result(idCount).count, is.result(idSum).sum)
                 .from(select(i.result.id).from(Issue as i).as(sq))
-            }.map(IssueSummary(is.resultName)).single.apply().get
+            }.map(IssueSummary(is.resultName)).single().apply().get
             summary.count should equal(4)
             summary.sum should equal(10)
           }
       }
     } finally {
       DB.autoCommit { implicit s =>
-        try sql"drop table issue".execute.apply()
+        try sql"drop table issue".execute().apply()
         catch { case e: Exception => }
-        try sql"drop table tag".execute.apply()
+        try sql"drop table tag".execute().apply()
         catch { case e: Exception => }
-        try sql"drop table issue_tag".execute.apply()
+        try sql"drop table issue_tag".execute().apply()
         catch { case e: Exception => }
       }
     }
@@ -548,34 +548,34 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
   it should "be available for sub-queries with SQLSyntaxSupport" in {
     try {
       DB autoCommit { implicit s =>
-        sql"create table customers (id int not null, name varchar(256) not null, group_id int)".execute.apply()
-        sql"create table customer_group (id int not null, name varchar(256) not null)".execute.apply()
-        sql"create table products (id int not null, name varchar(256) not null)".execute.apply()
-        sql"create table orders (id int not null, product_id int not null, customer_id int not null, ordered_at timestamp not null)".execute.apply()
+        sql"create table customers (id int not null, name varchar(256) not null, group_id int)".execute().apply()
+        sql"create table customer_group (id int not null, name varchar(256) not null)".execute().apply()
+        sql"create table products (id int not null, name varchar(256) not null)".execute().apply()
+        sql"create table orders (id int not null, product_id int not null, customer_id int not null, ordered_at timestamp not null)".execute().apply()
       }
     } catch { case e: Exception => }
     DB localTx {
       implicit s =>
         try {
-          sql"insert into customers values (1, ${"Alice"}, null)".update.apply()
-          sql"insert into customers values (2, ${"Bob"}, 1)".update.apply()
-          sql"insert into customers values (3, ${"Chris"}, 1)".update.apply()
-          sql"insert into customers values (4, ${"Dennis"}, null)".update.apply()
-          sql"insert into customers values (5, ${"Eric"}, null)".update.apply()
-          sql"insert into customers values (6, ${"Fred"}, 1)".update.apply()
-          sql"insert into customers values (7, ${"George"}, 1)".update.apply()
+          sql"insert into customers values (1, ${"Alice"}, null)".update().apply()
+          sql"insert into customers values (2, ${"Bob"}, 1)".update().apply()
+          sql"insert into customers values (3, ${"Chris"}, 1)".update().apply()
+          sql"insert into customers values (4, ${"Dennis"}, null)".update().apply()
+          sql"insert into customers values (5, ${"Eric"}, null)".update().apply()
+          sql"insert into customers values (6, ${"Fred"}, 1)".update().apply()
+          sql"insert into customers values (7, ${"George"}, 1)".update().apply()
 
-          sql"insert into customer_group values (1, ${"JSA"})".update.apply()
+          sql"insert into customer_group values (1, ${"JSA"})".update().apply()
 
-          sql"insert into products values (1, ${"Bean"})".update.apply()
-          sql"insert into products values (2, ${"Milk"})".update.apply()
-          sql"insert into products values (3, ${"Chocolate"})".update.apply()
+          sql"insert into products values (1, ${"Bean"})".update().apply()
+          sql"insert into products values (2, ${"Milk"})".update().apply()
+          sql"insert into products values (3, ${"Chocolate"})".update().apply()
 
-          sql"insert into orders values (1, 1, 1, current_timestamp)".update.apply()
-          sql"insert into orders values (2, 1, 2, current_timestamp)".update.apply()
-          sql"insert into orders values (3, 2, 3, current_timestamp)".update.apply()
-          sql"insert into orders values (4, 2, 2, current_timestamp)".update.apply()
-          sql"insert into orders values (5, 2, 1, current_timestamp)".update.apply()
+          sql"insert into orders values (1, 1, 1, current_timestamp)".update().apply()
+          sql"insert into orders values (2, 1, 2, current_timestamp)".update().apply()
+          sql"insert into orders values (3, 2, 3, current_timestamp)".update().apply()
+          sql"insert into orders values (4, 2, 2, current_timestamp)".update().apply()
+          sql"insert into orders values (5, 2, 1, current_timestamp)".update().apply()
 
           {
             val (c, cg) = (Customer.syntax("c"), CustomerGroup.syntax("cg"))
@@ -594,7 +594,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
               .one(Customer(sq(c).resultName))
               .toOptionalOne(rs => rs.intOpt(cg.resultName.id).map(id => CustomerGroup(id, rs.string(cg.resultName.name))))
               .map { (c, cg) => c.copy(group = cg) }
-              .list
+              .list()
               .apply()
 
             customers(0).id should equal(4)
@@ -613,7 +613,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
             }.one(Customer(sq(c).resultName))
               .toOptionalOne(rs => rs.intOpt(cg.resultName.id).map(id => CustomerGroup(id, rs.string(cg.resultName.name))))
               .map { (c, cg) => c.copy(group = cg) }
-              .list
+              .list()
               .apply()
 
             customers(0).id should equal(4)
@@ -637,7 +637,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
               .one(rs => Customer(rs.int(sq(c).resultName.id), rs.string(sq(c).resultName.name)))
               .toOptionalOne(rs => rs.intOpt(cg.resultName.id).map(id => CustomerGroup(id, rs.string(cg.resultName.name))))
               .map { (c, cg) => c.copy(group = cg) }
-              .iterable
+              .iterable()
               .apply()
 
             customers.map(u => u.id) should equal(Seq(4, 5))
@@ -661,7 +661,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
               .one(rs => Customer(rs.int(sq(c).resultName.id), rs.string(sq(c).resultName.name)))
               .toOptionalOne(rs => rs.intOpt(cg.resultName.id).map(id => CustomerGroup(id, rs.string(cg.resultName.name))))
               .map { (c, cg) => c.copy(group = cg) }
-              .single
+              .single()
               .apply()
 
             customer.isDefined should be(true)
@@ -678,7 +678,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
               where
                ${c.id} in (select ${o.result.customerId} from ${Order.as(o)})
             """
-              .map(rs => Customer(rs.int(c.resultName.id), rs.string(c.resultName.name))).list.apply()
+              .map(rs => Customer(rs.int(c.resultName.id), rs.string(c.resultName.name))).list().apply()
 
             customers.size should equal(3)
           }
@@ -703,7 +703,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
             """
               .one(rs => Customer(rs.int(c.resultName.id), rs.string(c.resultName.name)))
               .toMany(rs => Some(Order(rs.int(x(o).resultName.customerId), rs.int(x(o).resultName.productId), rs.get(x(o).resultName.orderedAt))))
-              .map { (c, os) => c.copy(orders = os) }.list.apply()
+              .map { (c, os) => c.copy(orders = os) }.list().apply()
 
             customers.size should equal(3)
           }
@@ -714,13 +714,13 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
             throw e
 
         } finally {
-          try sql"drop table customers".execute.apply()
+          try sql"drop table customers".execute().apply()
           catch { case e: Exception => }
-          try sql"drop table customer_group".execute.apply()
+          try sql"drop table customer_group".execute().apply()
           catch { case e: Exception => }
-          try sql"drop table products".execute.apply()
+          try sql"drop table products".execute().apply()
           catch { case e: Exception => }
-          try sql"drop table orders".execute.apply()
+          try sql"drop table orders".execute().apply()
           catch { case e: Exception => }
         }
     }
@@ -730,11 +730,11 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
     DB localTx {
       implicit s =>
         try {
-          sql"create table users (id int not null, first_name varchar(256), full_name varchar(256))".execute.apply()
+          sql"create table users (id int not null, first_name varchar(256), full_name varchar(256))".execute().apply()
           Seq((1, "Alice", "Alice Cooper"), (2, "Bob", "Bob Lee")) foreach {
             case (id, first, full) =>
               val c = UserName.column
-              sql"insert into ${UserName.table} (${c.id}, ${c.first}, ${c.full}) values (${id}, ${first}, ${full})".update.apply()
+              sql"insert into ${UserName.table} (${c.id}, ${c.first}, ${c.full}) values (${id}, ${first}, ${full})".update().apply()
           }
 
           object UserName extends SQLSyntaxSupport[UserName] {
@@ -751,14 +751,14 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
                 id = rs.int(u.resultName.id),
                 first = rs.string(u.resultName.first),
                 full = rs.string(u.resultName.full))
-          }.single.apply()
+          }.single().apply()
 
           user.isDefined should be(true)
           user.get.first should equal("Bob")
           user.get.full should equal("Bob Lee")
 
         } finally {
-          try sql"drop table users".execute.apply()
+          try sql"drop table users".execute().apply()
           catch { case e: Exception => }
         }
     }
@@ -774,23 +774,23 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
   it should "be available with names such as x1, x2" in {
     try {
       DB localTx { implicit s =>
-        sql"create table x_names (x1 varchar(256), x2 varchar(256))".execute.apply()
+        sql"create table x_names (x1 varchar(256), x2 varchar(256))".execute().apply()
       }
       DB localTx {
         implicit s =>
           val (xn, c) = (XNames.syntax("xn"), XNames.column)
           Seq(("Alice", "Alice Cooper"), ("Bob", "Bob Lee")) foreach {
             case (x1, x2) =>
-              sql"insert into ${XNames.table} (${c.x1}, ${c.x2}) values (${x1}, ${x2})".update.apply()
+              sql"insert into ${XNames.table} (${c.x1}, ${c.x2}) values (${x1}, ${x2})".update().apply()
           }
-          val found = sql"select ${xn.result.*} from ${XNames as xn} where ${xn.x1} = 'Alice'".map(XNames(xn.resultName)).single.apply()
+          val found = sql"select ${xn.result.*} from ${XNames as xn} where ${xn.x1} = 'Alice'".map(XNames(xn.resultName)).single().apply()
           found.isDefined should be(true)
           found.get.x1 should equal("Alice")
           found.get.x2 should equal("Alice Cooper")
       }
     } finally {
       DB localTx { implicit s =>
-        try sql"drop table x_names".execute.apply()
+        try sql"drop table x_names".execute().apply()
         catch { case e: Exception => }
       }
     }
@@ -806,18 +806,18 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
   it should "be available with duplicated shorten names" in {
     try {
       DB autoCommit { implicit s =>
-        try sql"drop table names".execute.apply()
+        try sql"drop table names".execute().apply()
         catch { case e: Exception => }
-        sql"create table names (full_name varchar(256), first_name varchar(256), last_name varchar(256))".execute.apply()
+        sql"create table names (full_name varchar(256), first_name varchar(256), last_name varchar(256))".execute().apply()
       }
       DB localTx {
         implicit s =>
           val (n, c) = (Names.syntax("n"), Names.column)
           Seq(("Alice Cooper", "Alice", "Cooper"), ("Bob Lee", "Bob", "Lee")) foreach {
             case (full, first, last) =>
-              sql"insert into ${Names.table} (${c.fullName}, ${c.firstName}, ${c.lastName}) values (${full}, ${first}, ${last})".update.apply()
+              sql"insert into ${Names.table} (${c.fullName}, ${c.firstName}, ${c.lastName}) values (${full}, ${first}, ${last})".update().apply()
           }
-          val found = sql"select ${n.result.*} from ${Names as n} where ${n.firstName} = 'Alice'".map(Names(n.resultName)).single.apply()
+          val found = sql"select ${n.result.*} from ${Names as n} where ${n.firstName} = 'Alice'".map(Names(n.resultName)).single().apply()
           found.isDefined should be(true)
           found.get.firstName should equal("Alice")
           found.get.lastName should equal("Cooper")
@@ -825,7 +825,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
 
           val found2: Option[Names] = withSQL {
             select.all(n).from(Names as n).where.eq(n.firstName, "Alice").append(sqls"order by ${n.firstName}")
-          }.map(Names(n.resultName)).single.apply()
+          }.map(Names(n.resultName)).single().apply()
           found2.isDefined should be(true)
           found2.get.firstName should equal("Alice")
           found2.get.lastName should equal("Cooper")
@@ -834,19 +834,19 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
           {
             val names = withSQL {
               select.all(n).from(Names as n).where.in(n.firstName, Seq("Alice", "Bob", "Chris"))
-            }.map(Names(n.resultName)).list.apply()
+            }.map(Names(n.resultName)).list().apply()
             names.size should equal(2)
           }
           {
             val groupByResult = withSQL {
               select(n.result.firstName, sqls"count(1)").from(Names as n).groupBy(n.firstName)
-            }.map(_.toMap).list.apply()
+            }.map(_.toMap()).list().apply()
             groupByResult.size should equal(2)
           }
       }
     } finally {
       DB localTx { implicit s =>
-        try sql"drop table names".execute.apply()
+        try sql"drop table names".execute().apply()
         catch { case e: Exception => }
       }
     }
@@ -926,22 +926,22 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
     implicit val session = AutoSession
 
     try {
-      sql"create table foo_bar_baz(first_name varchar(64) not null);".execute.apply()
+      sql"create table foo_bar_baz(first_name varchar(64) not null);".execute().apply()
 
       FooBarBaz.column.column("first_name") should equal(SQLSyntax("first_name"))
       intercept[InvalidColumnNameException] { FooBarBaz.column.column("last_name") }
 
-      sql"drop table foo_bar_baz;".execute.apply()
+      sql"drop table foo_bar_baz;".execute().apply()
 
       FooBarBaz.clearLoadedColumns()
 
-      sql"create table foo_bar_baz(first_name varchar(64) not null, last_name varchar(64));".execute.apply()
+      sql"create table foo_bar_baz(first_name varchar(64) not null, last_name varchar(64));".execute().apply()
 
       FooBarBaz.column.column("first_name") should equal(SQLSyntax("first_name"))
       FooBarBaz.column.column("last_name") should equal(SQLSyntax("last_name"))
 
-      sql"drop table foo_bar_baz;".execute.apply()
-      sql"create table foo_bar_baz(first_name varchar(64) not null);".execute.apply()
+      sql"drop table foo_bar_baz;".execute().apply()
+      sql"create table foo_bar_baz(first_name varchar(64) not null);".execute().apply()
 
       FooBarBaz.column.column("first_name") should equal(SQLSyntax("first_name"))
       FooBarBaz.column.column("last_name") should equal(SQLSyntax("last_name"))
@@ -951,15 +951,15 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with DBSettings wit
       FooBarBaz.column.column("first_name") should equal(SQLSyntax("first_name"))
       intercept[InvalidColumnNameException] { FooBarBaz.column.column("last_name") }
 
-      sql"drop table foo_bar_baz;".execute.apply()
-      sql"create table foo_bar_baz(first_name varchar(64) not null, last_name varchar(64));".execute.apply()
+      sql"drop table foo_bar_baz;".execute().apply()
+      sql"create table foo_bar_baz(first_name varchar(64) not null, last_name varchar(64));".execute().apply()
 
       SQLSyntaxSupport.clearLoadedColumns()
 
       FooBarBaz.column.column("first_name") should equal(SQLSyntax("first_name"))
       FooBarBaz.column.column("last_name") should equal(SQLSyntax("last_name"))
     } finally {
-      try sql"drop table foo_bar_baz;".execute.apply()
+      try sql"drop table foo_bar_baz;".execute().apply()
       catch { case NonFatal(_) => }
     }
   }

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SubQuerySpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SubQuerySpec.scala
@@ -17,7 +17,7 @@ class SubQuerySpec extends AnyFlatSpec with Matchers with SQLInterpolation {
   it should "work" in {
 
     NamedDB(Symbol("SubQuerySpec")).autoCommit { implicit session =>
-      sql"create table account(id integer, name varchar(10))".execute.apply()
+      sql"create table account(id integer, name varchar(10))".execute().apply()
     }
 
     val a = Account.syntax("a")

--- a/scalikejdbc-joda-time/src/test/scala/scalikejdbc/DBSessionSpec.scala
+++ b/scalikejdbc-joda-time/src/test/scala/scalikejdbc/DBSessionSpec.scala
@@ -332,10 +332,10 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
     DB autoCommit {
       implicit session =>
         try {
-          SQL("create table dbsessionspec_judate (id integer primary key, date timestamp)").execute.apply()
-          SQL("insert into dbsessionspec_judate values (?, ?)").bind(1, new java.util.Date()).update.apply()
+          SQL("create table dbsessionspec_judate (id integer primary key, date timestamp)").execute().apply()
+          SQL("insert into dbsessionspec_judate values (?, ?)").bind(1, new java.util.Date()).update().apply()
         } finally {
-          SQL("drop table dbsessionspec_judate").execute.apply()
+          SQL("drop table dbsessionspec_judate").execute().apply()
         }
     }
   }
@@ -346,14 +346,14 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
         try {
           // NOTE: id column should be the first one for PostgreSQL
           try {
-            SQL("create table dbsessionspec_genkey (id integer generated always as identity(start with 0), name varchar(30))").execute.apply()
+            SQL("create table dbsessionspec_genkey (id integer generated always as identity(start with 0), name varchar(30))").execute().apply()
           } catch {
             case e: Exception =>
               try {
-                SQL("create table dbsessionspec_genkey (id integer auto_increment, primary key(id), name varchar(30))").execute.apply()
+                SQL("create table dbsessionspec_genkey (id integer auto_increment, primary key(id), name varchar(30))").execute().apply()
               } catch {
                 case e: Exception =>
-                  SQL("create table dbsessionspec_genkey (id serial not null, primary key(id), name varchar(30))").execute.apply()
+                  SQL("create table dbsessionspec_genkey (id serial not null, primary key(id), name varchar(30))").execute().apply()
               }
           }
           var id = -1L
@@ -381,7 +381,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
           //    ids.last should be <= 8L
           //  }
         } finally {
-          SQL("drop table dbsessionspec_genkey").execute.apply()
+          SQL("drop table dbsessionspec_genkey").execute().apply()
         }
     }
   }
@@ -391,27 +391,27 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
       implicit session =>
         try {
           try {
-            SQL("create table dbsessionspec_update_genkey (id integer generated always as identity(start with 0), name varchar(30))").execute.apply()
+            SQL("create table dbsessionspec_update_genkey (id integer generated always as identity(start with 0), name varchar(30))").execute().apply()
           } catch {
             case e: Exception =>
               try {
-                SQL("create table dbsessionspec_update_genkey (id integer auto_increment, name varchar(30), primary key(id))").execute.apply()
+                SQL("create table dbsessionspec_update_genkey (id integer auto_increment, name varchar(30), primary key(id))").execute().apply()
               } catch {
                 case e: Exception =>
-                  SQL("create table dbsessionspec_update_genkey (id serial not null, name varchar(30), primary key(id))").execute.apply()
+                  SQL("create table dbsessionspec_update_genkey (id serial not null, name varchar(30), primary key(id))").execute().apply()
               }
           }
 
-          val id1 = SQL("insert into dbsessionspec_update_genkey (name) values (?)").bind("xxx").updateAndReturnGeneratedKey.apply()
+          val id1 = SQL("insert into dbsessionspec_update_genkey (name) values (?)").bind("xxx").updateAndReturnGeneratedKey().apply()
           id1 should be <= 1L
-          val id2 = SQL("insert into dbsessionspec_update_genkey (name) values (?)").bind("xxx").updateAndReturnGeneratedKey.apply()
+          val id2 = SQL("insert into dbsessionspec_update_genkey (name) values (?)").bind("xxx").updateAndReturnGeneratedKey().apply()
           id2 should be <= 2L
-          val id3 = SQL("insert into dbsessionspec_update_genkey (name) values (?)").bind("xxx").updateAndReturnGeneratedKey.apply()
+          val id3 = SQL("insert into dbsessionspec_update_genkey (name) values (?)").bind("xxx").updateAndReturnGeneratedKey().apply()
           id3 should be <= 3L
-          val id4 = SQL("insert into dbsessionspec_update_genkey (name) values (?)").bind("xxx").updateAndReturnGeneratedKey.apply()
+          val id4 = SQL("insert into dbsessionspec_update_genkey (name) values (?)").bind("xxx").updateAndReturnGeneratedKey().apply()
           id4 should be <= 4L
         } finally {
-          SQL("drop table dbsessionspec_update_genkey").execute.apply()
+          SQL("drop table dbsessionspec_update_genkey").execute().apply()
         }
     }
   }
@@ -421,19 +421,19 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
       implicit session =>
         try {
           try {
-            SQL("create table dbsessionspec_update_genkey2 (name varchar(30), id integer generated always as identity(start with 0))").execute.apply()
+            SQL("create table dbsessionspec_update_genkey2 (name varchar(30), id integer generated always as identity(start with 0))").execute().apply()
           } catch {
             case e: Exception =>
               try {
-                SQL("create table dbsessionspec_update_genkey2 (name varchar(30), id integer auto_increment, primary key(id))").execute.apply()
+                SQL("create table dbsessionspec_update_genkey2 (name varchar(30), id integer auto_increment, primary key(id))").execute().apply()
               } catch {
                 case e: Exception =>
-                  SQL("create table dbsessionspec_update_genkey2 (name varchar(30), id serial not null, primary key(id))").execute.apply()
+                  SQL("create table dbsessionspec_update_genkey2 (name varchar(30), id serial not null, primary key(id))").execute().apply()
               }
           }
 
           if (driverClassName == "org.h2.Driver" || driverClassName == "com.mysql.jdbc.Driver") {
-            val id1 = SQL("insert into dbsessionspec_update_genkey2 (name) values (?)").bind("xxx").updateAndReturnGeneratedKey.apply()
+            val id1 = SQL("insert into dbsessionspec_update_genkey2 (name) values (?)").bind("xxx").updateAndReturnGeneratedKey().apply()
             id1 should be <= 1L
           } else {
             val id1 = SQL("insert into dbsessionspec_update_genkey2 (name) values (?)").bind("xxx").updateAndReturnGeneratedKey("id").apply()
@@ -442,7 +442,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
           val id2 = SQL("insert into dbsessionspec_update_genkey2 (name) values (?)").bind("xxx").updateAndReturnGeneratedKey(2).apply()
           id2 should be <= 2L
         } finally {
-          SQL("drop table dbsessionspec_update_genkey2").execute.apply()
+          SQL("drop table dbsessionspec_update_genkey2").execute().apply()
         }
     }
   }
@@ -470,7 +470,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
               time_value time not null,
               timestamp_value timestamp not null
             )
-                   """).execute.apply()
+                   """).execute().apply()
             } catch {
               case e: Exception =>
                 try {
@@ -482,7 +482,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
               timestamp_value timestamp not null,
               primary key(id)
             )
-                       """).execute.apply()
+                       """).execute().apply()
                 } catch {
                   case e: Exception =>
                     SQL("""
@@ -493,14 +493,14 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
               timestamp_value timestamp not null,
               primary key(id)
             )
-                         """).execute.apply()
+                         """).execute().apply()
 
                 }
 
             }
 
             // clean table
-            SQL("delete from dbsessionspec_dateTimeValues").update.apply()
+            SQL("delete from dbsessionspec_dateTimeValues").update().apply()
 
             SQL("""
             insert into dbsessionspec_dateTimeValues
@@ -510,7 +510,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
                  """).bind(
               date,
               time,
-              timestamp).update.apply()
+              timestamp).update().apply()
 
             SQL("select * from dbsessionspec_dateTimeValues where timestamp_value = ?").bind(timestamp).map {
               rs => (rs.date("date_value"), rs.time("time_value"), rs.timestamp("timestamp_value"))
@@ -585,7 +585,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
 
           } finally {
             try {
-              SQL("drop table dbsessionspec_dateTimeValues").execute.apply()
+              SQL("drop table dbsessionspec_dateTimeValues").execute().apply()
             } catch {
               case e: Exception =>
             }
@@ -600,21 +600,21 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
       implicit session =>
         try {
           try {
-            SQL("create table dbsession_work_with_short_values (id bigint generated always as identity, s smallint)").execute.apply()
+            SQL("create table dbsession_work_with_short_values (id bigint generated always as identity, s smallint)").execute().apply()
           } catch {
             case e: Exception =>
               try {
-                SQL("create table dbsession_work_with_short_values (id bigint auto_increment, s smallint, primary key(id))").execute.apply()
+                SQL("create table dbsession_work_with_short_values (id bigint auto_increment, s smallint, primary key(id))").execute().apply()
               } catch {
                 case e: Exception =>
-                  SQL("create table dbsession_work_with_short_values (id serial not null, s smallint, primary key(id))").execute.apply()
+                  SQL("create table dbsession_work_with_short_values (id serial not null, s smallint, primary key(id))").execute().apply()
               }
           }
           val s: Short = 123
-          SQL("insert into dbsession_work_with_short_values (s) values (?)").bind(s).update.apply()
+          SQL("insert into dbsession_work_with_short_values (s) values (?)").bind(s).update().apply()
         } finally {
           try {
-            SQL("drop table dbsession_work_with_short_values").execute.apply()
+            SQL("drop table dbsession_work_with_short_values").execute().apply()
           } catch {
             case e: Exception => e.printStackTrace
           }
@@ -627,21 +627,21 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
       implicit session =>
         try {
           try {
-            SQL("create table dbsession_work_with_scala_big_decimal_values (id bigint generated always as identity, s bigint)").execute.apply()
+            SQL("create table dbsession_work_with_scala_big_decimal_values (id bigint generated always as identity, s bigint)").execute().apply()
           } catch {
             case e: Exception =>
               try {
-                SQL("create table dbsession_work_with_scala_big_decimal_values (id bigint auto_increment, s bigint, primary key(id))").execute.apply()
+                SQL("create table dbsession_work_with_scala_big_decimal_values (id bigint auto_increment, s bigint, primary key(id))").execute().apply()
               } catch {
                 case e: Exception =>
-                  SQL("create table dbsession_work_with_scala_big_decimal_values (id serial not null, s bigint, primary key(id))").execute.apply()
+                  SQL("create table dbsession_work_with_scala_big_decimal_values (id serial not null, s bigint, primary key(id))").execute().apply()
               }
           }
           val s: BigDecimal = BigDecimal(123)
-          SQL("insert into dbsession_work_with_scala_big_decimal_values (s) values (?)").bind(s).update.apply()
+          SQL("insert into dbsession_work_with_scala_big_decimal_values (s) values (?)").bind(s).update().apply()
         } finally {
           try {
-            SQL("drop table dbsession_work_with_scala_big_decimal_values").execute.apply()
+            SQL("drop table dbsession_work_with_scala_big_decimal_values").execute().apply()
           } catch {
             case e: Exception => e.printStackTrace
           }
@@ -654,21 +654,21 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
       implicit session =>
         try {
           try {
-            SQL("create table dbsession_work_with_java_big_decimal_values (id bigint generated always as identity, s bigint)").execute.apply()
+            SQL("create table dbsession_work_with_java_big_decimal_values (id bigint generated always as identity, s bigint)").execute().apply()
           } catch {
             case e: Exception =>
               try {
-                SQL("create table dbsession_work_with_java_big_decimal_values (id bigint auto_increment, s bigint, primary key(id))").execute.apply()
+                SQL("create table dbsession_work_with_java_big_decimal_values (id bigint auto_increment, s bigint, primary key(id))").execute().apply()
               } catch {
                 case e: Exception =>
-                  SQL("create table dbsession_work_with_java_big_decimal_values (id serial not null, s bigint, primary key(id))").execute.apply()
+                  SQL("create table dbsession_work_with_java_big_decimal_values (id serial not null, s bigint, primary key(id))").execute().apply()
               }
           }
           val s: BigDecimal = BigDecimal(123)
-          SQL("insert into dbsession_work_with_java_big_decimal_values (s) values (?)").bind(s).update.apply()
+          SQL("insert into dbsession_work_with_java_big_decimal_values (s) values (?)").bind(s).update().apply()
         } finally {
           try {
-            SQL("drop table dbsession_work_with_java_big_decimal_values").execute.apply()
+            SQL("drop table dbsession_work_with_java_big_decimal_values").execute().apply()
           } catch {
             case e: Exception => e.printStackTrace
           }
@@ -681,21 +681,21 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
       implicit session =>
         try {
           try {
-            SQL("create table dbsession_work_with_scala_big_int_values (id bigint generated always as identity, s bigint)").execute.apply()
+            SQL("create table dbsession_work_with_scala_big_int_values (id bigint generated always as identity, s bigint)").execute().apply()
           } catch {
             case e: Exception =>
               try {
-                SQL("create table dbsession_work_with_scala_big_int_values (id bigint auto_increment, s bigint, primary key(id))").execute.apply()
+                SQL("create table dbsession_work_with_scala_big_int_values (id bigint auto_increment, s bigint, primary key(id))").execute().apply()
               } catch {
                 case e: Exception =>
-                  SQL("create table dbsession_work_with_scala_big_int_values (id serial not null, s bigint, primary key(id))").execute.apply()
+                  SQL("create table dbsession_work_with_scala_big_int_values (id serial not null, s bigint, primary key(id))").execute().apply()
               }
           }
           val s: BigInt = BigInt(123)
-          SQL("insert into dbsession_work_with_scala_big_int_values (s) values (?)").bind(s).update.apply()
+          SQL("insert into dbsession_work_with_scala_big_int_values (s) values (?)").bind(s).update().apply()
         } finally {
           try {
-            SQL("drop table dbsession_work_with_scala_big_int_values").execute.apply()
+            SQL("drop table dbsession_work_with_scala_big_int_values").execute().apply()
           } catch {
             case e: Exception => e.printStackTrace
           }
@@ -708,21 +708,21 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
       implicit session =>
         try {
           try {
-            SQL("create table dbsession_work_with_java_big_integer_values (id bigint generated always as identity, s bigint)").execute.apply()
+            SQL("create table dbsession_work_with_java_big_integer_values (id bigint generated always as identity, s bigint)").execute().apply()
           } catch {
             case e: Exception =>
               try {
-                SQL("create table dbsession_work_with_java_big_integer_values (id bigint auto_increment, s bigint, primary key(id))").execute.apply()
+                SQL("create table dbsession_work_with_java_big_integer_values (id bigint auto_increment, s bigint, primary key(id))").execute().apply()
               } catch {
                 case e: Exception =>
-                  SQL("create table dbsession_work_with_java_big_integer_values (id serial not null, s bigint, primary key(id))").execute.apply()
+                  SQL("create table dbsession_work_with_java_big_integer_values (id serial not null, s bigint, primary key(id))").execute().apply()
               }
           }
           val s: BigInt = BigInt(123)
-          SQL("insert into dbsession_work_with_java_big_integer_values (s) values (?)").bind(s).update.apply()
+          SQL("insert into dbsession_work_with_java_big_integer_values (s) values (?)").bind(s).update().apply()
         } finally {
           try {
-            SQL("drop table dbsession_work_with_java_big_integer_values").execute.apply()
+            SQL("drop table dbsession_work_with_java_big_integer_values").execute().apply()
           } catch {
             case e: Exception => e.printStackTrace
           }
@@ -747,7 +747,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
             v_short smallint,
             v_timestamp timestamp
           )
-                 """).execute.apply()
+                 """).execute().apply()
           } catch {
             case e: Exception =>
               try {
@@ -764,7 +764,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
             v_timestamp datetime,
             primary key(id)
           )
-                     """).execute.apply()
+                     """).execute().apply()
               } catch {
                 case e: Exception =>
                   SQL("""
@@ -780,7 +780,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
             v_timestamp timestamp,
             primary key(id)
           )
-                       """).execute.apply()
+                       """).execute().apply()
 
               }
 
@@ -790,7 +790,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
           (v_boolean, v_byte, v_double, v_float, v_int, v_long, v_short, v_timestamp) values 
           (?,?,?,?,?,?,?,?)
                         """).bind(
-            None, None, None, None, None, None, None, None).updateAndReturnGeneratedKey.apply()
+            None, None, None, None, None, None, None, None).updateAndReturnGeneratedKey().apply()
 
           case class Result(vBoolean: Option[Boolean], vByte: Option[Byte], vDouble: Option[Double],
             vFloat: Option[Float], vInt: Option[Int], vLong: Option[Long], vShort: Option[Short],
@@ -834,7 +834,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
                 vLong = rs.longOpt("v_long"),
                 vShort = rs.shortOpt("v_short"),
                 vTimestamp = rs.jodaDateTimeOpt("v_timestamp"))
-          }.single.apply())
+          }.single().apply())
 
           assert(SQL("select * from dbsession_work_with_optional_values where id = ?").bind(id).map {
             rs =>
@@ -847,7 +847,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
                 vLong = Option(rs.nullableLong("v_long").asInstanceOf[Long]),
                 vShort = Option(rs.nullableShort("v_short").asInstanceOf[Short]),
                 vTimestamp = Option(rs.timestamp("v_timestamp")).map(_.toJodaDateTime))
-          }.single.apply())
+          }.single().apply())
 
           // should use nullable*** methods
           intercept[ResultSetExtractorException](SQL("select * from dbsession_work_with_optional_values where id = ?").bind(id).map {
@@ -861,7 +861,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
                 vLong = opt[Long](rs.long("v_long")),
                 vShort = opt[Short](rs.short("v_short")),
                 vTimestamp = Option(rs.timestamp("v_timestamp")).map(_.toJodaDateTime))
-          }.single.apply())
+          }.single().apply())
 
           assert(SQL("select * from dbsession_work_with_optional_values where id = ?").bind(id).map {
             rs =>
@@ -874,7 +874,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
                 vLong = opt[Long](rs.nullableLong("v_long")),
                 vShort = opt[Short](rs.nullableShort("v_short")),
                 vTimestamp = Option(rs.timestamp("v_timestamp")).map(_.toJodaDateTime))
-          }.single.apply())
+          }.single().apply())
 
           assert(SQL("select * from dbsession_work_with_optional_values where id = ?").bind(id).map {
             rs =>
@@ -887,11 +887,11 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
                 vLong = rs.longOpt("v_long"),
                 vShort = rs.shortOpt("v_short"),
                 vTimestamp = Option(rs.timestamp("v_timestamp")).map(_.toJodaDateTime))
-          }.single.apply())
+          }.single().apply())
 
         } finally {
           try {
-            SQL("drop table dbsession_work_with_optional_values").execute.apply()
+            SQL("drop table dbsession_work_with_optional_values").execute().apply()
           } catch {
             case e: Exception => e.printStackTrace
           }
@@ -903,11 +903,11 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
     DB autoCommit { implicit s =>
       try {
         try {
-          SQL("create table image_data (name varchar(255), data blob);").execute.apply()
+          SQL("create table image_data (name varchar(255), data blob);").execute().apply()
         } catch {
           case e: Exception =>
             // PostgreSQL doesn't have blob
-            SQL("create table image_data (name varchar(255), data bytea);").execute.apply()
+            SQL("create table image_data (name varchar(255), data bytea);").execute().apply()
         }
         using(this.getClass.getClassLoader.getResourceAsStream("google.png")) { stream =>
           try {
@@ -915,7 +915,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
               .bindByName(
                 Symbol("name") -> "logo",
                 Symbol("data") -> stream)
-              .update.apply()
+              .update().apply()
           } catch {
             case e: Exception =>
               // PostgreSQL does not support #setBinaryStream
@@ -923,7 +923,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
               else fail("Failed to insert data because " + e.getMessage, e)
           }
         }
-        SQL("select * from image_data;").map(rs => rs.binaryStream("data")).single.apply().map { bs =>
+        SQL("select * from image_data;").map(rs => rs.binaryStream("data")).single().apply().map { bs =>
           using(new java.io.ByteArrayOutputStream) { bos =>
             var next: Int = bs.read()
             while (next > -1) {
@@ -936,7 +936,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
         }
       } finally {
         try {
-          SQL("drop table image_data;").execute.apply()
+          SQL("drop table image_data;").execute().apply()
         } catch { case e: Exception => }
       }
     }
@@ -946,11 +946,11 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
     DB autoCommit { implicit s =>
       try {
         try {
-          SQL("create table image_data2 (name varchar(255), data blob);").execute.apply()
+          SQL("create table image_data2 (name varchar(255), data blob);").execute().apply()
         } catch {
           case e: Exception =>
             // PostgreSQL doesn't have blob
-            SQL("create table image_data2 (name varchar(255), data bytea);").execute.apply()
+            SQL("create table image_data2 (name varchar(255), data bytea);").execute().apply()
         }
         using(this.getClass.getClassLoader.getResourceAsStream("google.png")) { stream =>
           using(new java.io.ByteArrayOutputStream) { bos =>
@@ -964,10 +964,10 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
               .bindByName(
                 Symbol("name") -> "logo",
                 Symbol("data") -> bos.toByteArray)
-              .update.apply()
+              .update().apply()
           }
         }
-        SQL("select * from image_data2").map(rs => rs.binaryStream("data")).single.apply().map { bs =>
+        SQL("select * from image_data2").map(rs => rs.binaryStream("data")).single().apply().map { bs =>
           using(new java.io.ByteArrayOutputStream) { bos =>
             var next: Int = bs.read()
             while (next > -1) {
@@ -980,7 +980,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
         }
       } finally {
         try {
-          SQL("drop table image_data2").execute.apply()
+          SQL("drop table image_data2").execute().apply()
         } catch { case e: Exception => }
       }
     }
@@ -992,17 +992,17 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
       implicit session =>
         try {
           try {
-            SQL("create table dbsession_issue_218 (id bigint generated always as identity, s bigint)").execute.apply()
+            SQL("create table dbsession_issue_218 (id bigint generated always as identity, s bigint)").execute().apply()
           } catch {
             case e: Exception =>
               try {
-                SQL("create table dbsession_issue_218 (id bigint auto_increment, s bigint, primary key(id))").execute.apply()
+                SQL("create table dbsession_issue_218 (id bigint auto_increment, s bigint, primary key(id))").execute().apply()
               } catch {
                 case e: Exception =>
-                  SQL("create table dbsession_issue_218 (id serial not null, s bigint, primary key(id))").execute.apply()
+                  SQL("create table dbsession_issue_218 (id serial not null, s bigint, primary key(id))").execute().apply()
               }
           }
-          val sql = SQL("insert into dbsession_issue_218 (s) values (?)").bind(123).update
+          val sql = SQL("insert into dbsession_issue_218 (s) values (?)").bind(123).update()
           val executor = session.toStatementExecutor(sql.statement, sql.parameters)
           import ExecutionContext.Implicits.global
           scala.concurrent.Future {
@@ -1012,7 +1012,7 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
           executor.underlying.cancel()
         } finally {
           try {
-            SQL("drop table dbsession_issue_218").execute.apply()
+            SQL("drop table dbsession_issue_218").execute().apply()
           } catch {
             case e: Exception => e.printStackTrace
           }
@@ -1025,21 +1025,21 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
       implicit session =>
         try {
           try {
-            SQL("create table dbsession_work_with_parameter_binder (id bigint, data blob)").execute.apply()
+            SQL("create table dbsession_work_with_parameter_binder (id bigint, data blob)").execute().apply()
           } catch {
             case e: Exception =>
               // PostgreSQL doesn't have blob
-              SQL("create table dbsession_work_with_parameter_binder (id bigint, data bytea)").execute.apply()
+              SQL("create table dbsession_work_with_parameter_binder (id bigint, data bytea)").execute().apply()
           }
           val bytes = scala.Array[Byte](1, 2, 3, 4, 5, 6, 7)
           val in = new ByteArrayInputStream(bytes)
           val v = ParameterBinder(
             value = in,
             binder = (stmt: PreparedStatement, idx: Int) => stmt.setBinaryStream(idx, in, bytes.length))
-          SQL("insert into dbsession_work_with_parameter_binder (data) values (?)").bind(v).update.apply()
+          SQL("insert into dbsession_work_with_parameter_binder (data) values (?)").bind(v).update().apply()
         } finally {
           try {
-            SQL("drop table dbsession_work_with_parameter_binder").execute.apply()
+            SQL("drop table dbsession_work_with_parameter_binder").execute().apply()
           } catch {
             case e: Exception => e.printStackTrace()
           }
@@ -1061,10 +1061,10 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
 
     try {
       DB autoCommit { implicit session =>
-        try SQL("drop table zone_test").execute.apply()
+        try SQL("drop table zone_test").execute().apply()
         catch { case e: Exception => }
 
-        SQL("create table zone_test (id int primary key, t timestamp)").execute.apply()
+        SQL("create table zone_test (id int primary key, t timestamp)").execute().apply()
       }
 
       /**
@@ -1075,11 +1075,11 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
           conn = session.conn,
           connectionAttributes = session.connectionAttributes.copy(timeZoneSettings = TimeZoneSettings(true, TimeZone.getTimeZone("Asia/Tokyo"))))
 
-        SQL("insert into zone_test values (?, ?)").bind(1, time).execute.apply()(jstSession)
-        val jstString = SQL(s"select $castToString as s from zone_test where id = 1").map(_.string("s")).single.apply().get
+        SQL("insert into zone_test values (?, ?)").bind(1, time).execute().apply()(jstSession)
+        val jstString = SQL(s"select $castToString as s from zone_test where id = 1").map(_.string("s")).single().apply().get
         jstString should equal(time.toString("yyyy-MM-dd HH:mm:ss"))
 
-        val expectedTime1 = SQL("select t from zone_test where id = 1").map(_.jodaDateTime("t")).single.apply().get
+        val expectedTime1 = SQL("select t from zone_test where id = 1").map(_.jodaDateTime("t")).single().apply().get
         expectedTime1.isEqual(time) should equal(true)
       }
 
@@ -1091,16 +1091,16 @@ class DBSessionSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with S
           conn = session.conn,
           connectionAttributes = session.connectionAttributes.copy(timeZoneSettings = TimeZoneSettings(true, TimeZone.getTimeZone("UTC"))))
 
-        SQL("insert into zone_test values (?, ?)").bind(2, time).execute.apply()
-        val utcString = SQL(s"select $castToString as s from zone_test where id = 2").map(_.string("s")).single.apply().get
+        SQL("insert into zone_test values (?, ?)").bind(2, time).execute().apply()
+        val utcString = SQL(s"select $castToString as s from zone_test where id = 2").map(_.string("s")).single().apply().get
         utcString should equal(time.withZone(DateTimeZone.forID("UTC")).toString("yyyy-MM-dd HH:mm:ss"))
 
-        val expectedTime2 = SQL("select t from zone_test where id = 2").map(_.jodaDateTime("t")).single.apply().get
+        val expectedTime2 = SQL("select t from zone_test where id = 2").map(_.jodaDateTime("t")).single().apply().get
         expectedTime2.isEqual(time) should equal(true)
       }
     } finally {
       DB autoCommit { implicit session =>
-        try SQL("drop table zone_test").execute.apply()
+        try SQL("drop table zone_test").execute().apply()
         catch { case e: Exception => }
       }
     }

--- a/scalikejdbc-joda-time/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
+++ b/scalikejdbc-joda-time/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
@@ -28,20 +28,20 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with LogSupport wit
     DB localTx {
       implicit s =>
         try {
-          sql"""create table interpolation_users (id int, name varchar(256))""".execute.apply()
+          sql"""create table interpolation_users (id int, name varchar(256))""".execute().apply()
 
           Seq((1, "foo"), (2, "bar"), (3, "baz")) foreach {
             case (id, name) =>
-              sql"""insert into interpolation_users values (${id}, ${name})""".update.apply()
+              sql"""insert into interpolation_users values (${id}, ${name})""".update().apply()
           }
 
           val id = 3
           val user = sql"""select * from interpolation_users where id = ${id}""".map {
             rs => User(id = rs.int("id"), name = rs.stringOpt("name"))
-          }.single.apply()
+          }.single().apply()
           user.isDefined should equal(true)
         } finally {
-          sql"""drop table interpolation_users""".execute.apply()
+          sql"""drop table interpolation_users""".execute().apply()
         }
     }
   }
@@ -50,21 +50,21 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with LogSupport wit
     DB localTx {
       implicit s =>
         try {
-          sql"create table interpolation_users (id int not null, name varchar(256))".execute.apply()
+          sql"create table interpolation_users (id int not null, name varchar(256))".execute().apply()
 
           Seq((1, Some("foo")), (2, None)) foreach {
             case (id, name) =>
-              sql"insert into interpolation_users values (${id}, ${name})".update.apply()
+              sql"insert into interpolation_users values (${id}, ${name})".update().apply()
           }
 
           val id = 2
           val user: User = sql"select * from interpolation_users where id = ${id}".map {
             rs => User(id = rs.int("id"), name = rs.stringOpt("name"))
-          }.single.apply().get
+          }.single().apply().get
           user.id should equal(2)
           user.name should be(None)
         } finally {
-          sql"drop table interpolation_users".execute.apply()
+          sql"drop table interpolation_users".execute().apply()
         }
     }
   }
@@ -73,20 +73,20 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with LogSupport wit
     DB localTx {
       implicit s =>
         try {
-          sql"create table interpolation_users (id int not null, name varchar(256))".execute.apply()
+          sql"create table interpolation_users (id int not null, name varchar(256))".execute().apply()
           Seq((1, "foo"), (2, "bar"), (3, "baz")) foreach {
             case (id, name) =>
-              sql"insert into interpolation_users values (${id}, ${name})".update.apply()
+              sql"insert into interpolation_users values (${id}, ${name})".update().apply()
           }
 
           val ids = List(1, 2, 4) ::: (100 until 200).toList
           val interpolation_users = sql"select * from interpolation_users where id in (${ids})".map {
             rs => User(id = rs.int("id"), name = rs.stringOpt("name"))
-          }.list.apply()
+          }.list().apply()
           interpolation_users.size should equal(2)
           interpolation_users.map(_.name) should equal(Seq(Some("foo"), Some("bar")))
         } finally {
-          sql"drop table interpolation_users".execute.apply()
+          sql"drop table interpolation_users".execute().apply()
         }
     }
   }
@@ -95,21 +95,21 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with LogSupport wit
     DB localTx {
       implicit s =>
         try {
-          sql"create table interpolation_users (id int not null, name varchar(256))".execute.apply()
+          sql"create table interpolation_users (id int not null, name varchar(256))".execute().apply()
           Seq((1, "foo"), (2, "bar"), (3, "baz")) foreach {
             case (id, name) =>
-              sql"insert into interpolation_users values (${id}, ${name})".update.apply()
+              sql"insert into interpolation_users values (${id}, ${name})".update().apply()
           }
 
           val ids = List(1, 2, 4) ::: (100 until 200).toList
           val sorting = sqls"desc"
           val interpolation_users = sql"select * from interpolation_users where id in (${ids}) order by id ${sorting}".map {
             rs => User(id = rs.int("id"), name = rs.stringOpt("name"))
-          }.list.apply()
+          }.list().apply()
           interpolation_users.size should equal(2)
           interpolation_users.map(_.name) should equal(Seq(Some("bar"), Some("foo")))
         } finally {
-          sql"drop table interpolation_users".execute.apply()
+          sql"drop table interpolation_users".execute().apply()
         }
     }
   }
@@ -118,63 +118,63 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with LogSupport wit
     import scalikejdbc.interpolation.SQLSyntax._
     try {
       DB autoCommit { implicit s =>
-        sql"create table sqlsyntax_spec (id int not null, name varchar(256))".execute.apply()
-        sql"insert into sqlsyntax_spec values (1, ${"Alice"})".execute.apply()
+        sql"create table sqlsyntax_spec (id int not null, name varchar(256))".execute().apply()
+        sql"insert into sqlsyntax_spec values (1, ${"Alice"})".execute().apply()
       }
       DB readOnly { implicit s =>
         // abs
         {
           val v = sqls"${123}"
-          val doubleResult = sql"select ${abs(v)} from sqlsyntax_spec limit 1".map(_.double(1)).single.apply().get
+          val doubleResult = sql"select ${abs(v)} from sqlsyntax_spec limit 1".map(_.double(1)).single().apply().get
           doubleResult should equal(123.0d)
-          val floatResult = sql"select ${abs(v)} from sqlsyntax_spec limit 1".map(_.float(1)).single.apply().get
+          val floatResult = sql"select ${abs(v)} from sqlsyntax_spec limit 1".map(_.float(1)).single().apply().get
           floatResult should equal(123.0f)
-          val intResult = sql"select ${abs(v)} from sqlsyntax_spec limit 1".map(_.int(1)).single.apply().get
+          val intResult = sql"select ${abs(v)} from sqlsyntax_spec limit 1".map(_.int(1)).single().apply().get
           intResult should equal(123)
-          val longResult = sql"select ${abs(v)} from sqlsyntax_spec limit 1".map(_.long(1)).single.apply().get
+          val longResult = sql"select ${abs(v)} from sqlsyntax_spec limit 1".map(_.long(1)).single().apply().get
           longResult should equal(123L)
         }
         // floor
         {
           val v = sqls"${123.4}"
-          val doubleResult = sql"select ${floor(v)} from sqlsyntax_spec limit 1".map(_.double(1)).single.apply().get
+          val doubleResult = sql"select ${floor(v)} from sqlsyntax_spec limit 1".map(_.double(1)).single().apply().get
           doubleResult should equal(123.0d)
-          val floatResult = sql"select ${floor(v)} from sqlsyntax_spec limit 1".map(_.float(1)).single.apply().get
+          val floatResult = sql"select ${floor(v)} from sqlsyntax_spec limit 1".map(_.float(1)).single().apply().get
           floatResult should equal(123.0d)
-          val intResult = sql"select ${floor(v)} from sqlsyntax_spec limit 1".map(_.int(1)).single.apply().get
+          val intResult = sql"select ${floor(v)} from sqlsyntax_spec limit 1".map(_.int(1)).single().apply().get
           intResult should equal(123)
-          val longResult = sql"select ${floor(v)} from sqlsyntax_spec limit 1".map(_.long(1)).single.apply().get
+          val longResult = sql"select ${floor(v)} from sqlsyntax_spec limit 1".map(_.long(1)).single().apply().get
           longResult should equal(123L)
         }
         // ceiling
         {
           val v = sqls"${123.4}"
-          val doubleResult = sql"select ${ceiling(v)} from sqlsyntax_spec limit 1".map(_.double(1)).single.apply().get
+          val doubleResult = sql"select ${ceiling(v)} from sqlsyntax_spec limit 1".map(_.double(1)).single().apply().get
           doubleResult should equal(124.0d)
-          val floatResult = sql"select ${ceiling(v)} from sqlsyntax_spec limit 1".map(_.float(1)).single.apply().get
+          val floatResult = sql"select ${ceiling(v)} from sqlsyntax_spec limit 1".map(_.float(1)).single().apply().get
           floatResult should equal(124.0d)
-          val intResult = sql"select ${ceiling(v)} from sqlsyntax_spec limit 1".map(_.int(1)).single.apply().get
+          val intResult = sql"select ${ceiling(v)} from sqlsyntax_spec limit 1".map(_.int(1)).single().apply().get
           intResult should equal(124)
-          val longResult = sql"select ${ceiling(v)} from sqlsyntax_spec limit 1".map(_.long(1)).single.apply().get
+          val longResult = sql"select ${ceiling(v)} from sqlsyntax_spec limit 1".map(_.long(1)).single().apply().get
           longResult should equal(124L)
         }
         // current_date
         {
-          val t = sql"select ${currentDate} from sqlsyntax_spec limit 1".map(_.date(1)).single.apply().get
+          val t = sql"select ${currentDate} from sqlsyntax_spec limit 1".map(_.date(1)).single().apply().get
           log.warn("current_date: " + t + "," + t.getTime)
           // Timezone issue
           // t.toLocalDate should equal(LocalDate.now)
         }
         // current_timestamp
         {
-          val t = sql"select ${currentTimestamp} from sqlsyntax_spec limit 1".map(_.timestamp(1)).single.apply().get
+          val t = sql"select ${currentTimestamp} from sqlsyntax_spec limit 1".map(_.timestamp(1)).single().apply().get
           log.warn("current_timestamp: " + t + "," + t.getTime)
           t.toJodaDateTime.getMillis should be < (DateTime.now.plusDays(1).getMillis)
         }
       }
     } finally {
       DB autoCommit { implicit s =>
-        sql"drop table sqlsyntax_spec".execute.apply()
+        sql"drop table sqlsyntax_spec".execute().apply()
       }
     }
   }
@@ -184,20 +184,20 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with LogSupport wit
     DB localTx {
       implicit s =>
         try {
-          sql"""create table interpolation_users (id int, name varchar(256))""".execute.apply()
+          sql"""create table interpolation_users (id int, name varchar(256))""".execute().apply()
 
           Seq((1, "foo"), (2, "bar"), (3, "baz")) foreach {
             case (id, name) =>
-              sql"""insert into interpolation_users values (${id}, ${name})""".update.apply()
+              sql"""insert into interpolation_users values (${id}, ${name})""".update().apply()
           }
 
           val names = """.*?""".r.findAllIn("""a&""").toSeq
           val users = sql"""select * from interpolation_users where name in (${names})""".map {
             rs => User(id = rs.int("id"), name = rs.stringOpt("name"))
-          }.list.apply()
+          }.list().apply()
           users should have size (0)
         } finally {
-          sql"""drop table interpolation_users""".execute.apply()
+          sql"""drop table interpolation_users""".execute().apply()
         }
     }
   }
@@ -206,21 +206,21 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with LogSupport wit
     DB localTx {
       implicit s =>
         try {
-          sql"""create table interpolation_users (id int, name varchar(256))""".execute.apply()
+          sql"""create table interpolation_users (id int, name varchar(256))""".execute().apply()
 
           Seq((1, "foo"), (2, "bar"), (3, "baz")) foreach {
             case (id, name) =>
-              sql"""insert into interpolation_users values (${id}, ${name})""".update.apply()
+              sql"""insert into interpolation_users values (${id}, ${name})""".update().apply()
           }
 
           //val names = """.*?""".r.findAllIn("""a&""").toSeq
           val names = """.*?""".r.findAllIn("""a&""").toList
           val users = sql"""select * from interpolation_users where name in (${names})""".map {
             rs => User(id = rs.int("id"), name = rs.stringOpt("name"))
-          }.list.apply()
+          }.list().apply()
           users should have size (0)
         } finally {
-          sql"""drop table interpolation_users""".execute.apply()
+          sql"""drop table interpolation_users""".execute().apply()
         }
     }
   }
@@ -229,9 +229,9 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with LogSupport wit
     DB localTx {
       implicit s =>
         try {
-          sql"""create table interpolation_users_216 (id int, name varchar(256))""".execute.apply()
+          sql"""create table interpolation_users_216 (id int, name varchar(256))""".execute().apply()
           Seq((1, "foo"), (2, "bar"), (3, "baz")) foreach {
-            case (id, name) => sql"""insert into interpolation_users_216 values (${id}, ${name})""".update.apply()
+            case (id, name) => sql"""insert into interpolation_users_216 values (${id}, ${name})""".update().apply()
           }
           val columns: collection.Seq[SQLSyntax] = Seq("id", "name").map(SQLSyntax.createUnsafely(_, Nil))
           val values: collection.Seq[SQLSyntax] = Seq(Seq(1, "foo"), Seq(2, "bar"), Seq(3, "bazzzz")).map { xs => sqls"($xs)" }
@@ -243,7 +243,7 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with LogSupport wit
           //sql.map(_.long(1)).single.apply() should equal(Some(2))
 
         } finally {
-          sql"""drop table interpolation_users_216""".execute.apply()
+          sql"""drop table interpolation_users_216""".execute().apply()
         }
     }
   }
@@ -252,18 +252,18 @@ class SQLInterpolationSpec extends AnyFlatSpec with Matchers with LogSupport wit
     DB localTx {
       implicit s =>
         try {
-          sql"""create table interpolation_users_set (id int, name varchar(256))""".execute.apply()
+          sql"""create table interpolation_users_set (id int, name varchar(256))""".execute().apply()
           Seq((1, "foo"), (2, "bar"), (3, "baz")) foreach {
-            case (id, name) => sql"""insert into interpolation_users_set values (${id}, ${name})""".update.apply()
+            case (id, name) => sql"""insert into interpolation_users_set values (${id}, ${name})""".update().apply()
           }
           val sql = sql"select count(1) from interpolation_users_set where id in (${Set(1, 3)})"
 
           sql.statement should equal("select count(1) from interpolation_users_set where id in (?, ?)")
           sql.parameters should equal(Seq(1, 3))
-          sql.map(_.long(1)).single.apply() should equal(Some(2))
+          sql.map(_.long(1)).single().apply() should equal(Some(2))
 
         } finally {
-          sql"""drop table interpolation_users_set""".execute.apply()
+          sql"""drop table interpolation_users_set""".execute().apply()
         }
     }
   }

--- a/scalikejdbc-library/src/test/scala/documentation/TopPageExampleSpec.scala
+++ b/scalikejdbc-library/src/test/scala/documentation/TopPageExampleSpec.scala
@@ -34,18 +34,18 @@ create table members (
   name varchar(64),
   created_at timestamp not null
 )
-""".execute.apply()
+""".execute().apply()
 
     // insert initial data
     Seq("Alice", "Bob", "Chris") foreach { name =>
-      sql"insert into members (name, created_at) values (${name}, current_timestamp)".update.apply()
+      sql"insert into members (name, created_at) values (${name}, current_timestamp)".update().apply()
     }
 
     // for now, retrieves all data as Map value
-    val entities: List[Map[String, Any]] = sql"select * from members".map(_.toMap).list.apply()
+    val entities: List[Map[String, Any]] = sql"select * from members".map(_.toMap()).list().apply()
 
     // find all members
-    val members: List[Member] = sql"select * from members".map(rs => Member(rs)).list.apply()
+    val members: List[Member] = sql"select * from members".map(rs => Member(rs)).list().apply()
 
     entities.size should equal(3)
     members.size should equal(3)

--- a/scalikejdbc-mapper-generator-core/src/test/scala/MapperGeneratorWithH2Spec.scala
+++ b/scalikejdbc-mapper-generator-core/src/test/scala/MapperGeneratorWithH2Spec.scala
@@ -27,7 +27,7 @@ class MapperGeneratorWithH2Spec extends AnyFlatSpec with Matchers {
           _underscore varchar(30),
           primary key(id)
         )
-      """).execute.apply()
+      """).execute().apply()
     }
     Model(url, username, password).table(null, "MEMBER_GROUP").map { table =>
       {
@@ -67,7 +67,7 @@ class MapperGeneratorWithH2Spec extends AnyFlatSpec with Matchers {
           created_at timestamp not null,
           primary key(id)
         )
-      """).execute.apply()
+      """).execute().apply()
     }
 
     Model(url, username, password).table(null, "MEMBER").map {
@@ -150,7 +150,7 @@ class MapperGeneratorWithH2Spec extends AnyFlatSpec with Matchers {
           created_at timestamp not null,
           primary key(id)
         )
-      """).execute.apply()
+      """).execute().apply()
     }
 
     Model(url, username, password).table(null, "UN_NORMALIZED").map {
@@ -175,7 +175,7 @@ class MapperGeneratorWithH2Spec extends AnyFlatSpec with Matchers {
           bbb int,
           created_at timestamp not null
         )
-      """).execute.apply()
+      """).execute().apply()
     }
 
     Model(url, username, password).table(null, "WITHOUT_PK").map {
@@ -207,7 +207,7 @@ class MapperGeneratorWithH2Spec extends AnyFlatSpec with Matchers {
           execution_time int not null,
           success bit not null
         )
-      """).execute.apply()
+      """).execute().apply()
     }
 
     Model(url, username, password).table(null, "SCHEMA_VERSION").map {

--- a/scalikejdbc-streams/src/test/scala/somewhere/DatabasePublisherSpec.scala
+++ b/scalikejdbc-streams/src/test/scala/somewhere/DatabasePublisherSpec.scala
@@ -42,7 +42,7 @@ class DatabasePublisherSpec
 
   it should "be subscribed by SyncSubscriber" in {
     val publisher: DatabasePublisher[Int] = DB readOnlyStream {
-      SQL(s"select id from $tableName").map(r => r.int("id")).iterator
+      SQL(s"select id from $tableName").map(r => r.int("id")).iterator()
     }
 
     val consumedCountPromise: Promise[Int] = Promise[Int]()
@@ -72,7 +72,7 @@ class DatabasePublisherSpec
 
   it should "emit elements in order" in {
     val publisher: DatabasePublisher[Int] = DB readOnlyStream {
-      SQL(s"select id from $tableName order by id").map(r => r.int("id")).iterator
+      SQL(s"select id from $tableName order by id").map(r => r.int("id")).iterator()
     }
 
     val expectedElements = (1 to totalRows)
@@ -103,7 +103,7 @@ class DatabasePublisherSpec
   it should "be subscribed and use the modified DB session" in {
     val passedStreamReadySwitcher: AtomicBoolean = new AtomicBoolean(false)
     val publisher: DatabasePublisher[Int] = DB.readOnlyStream {
-      SQL(s"select id from $tableName").map(r => r.int("id")).iterator.withDBSessionForceAdjuster(session => {
+      SQL(s"select id from $tableName").map(r => r.int("id")).iterator().withDBSessionForceAdjuster(session => {
         passedStreamReadySwitcher.set(true)
       })
     }
@@ -139,7 +139,7 @@ class DatabasePublisherSpec
 
   it should "be subscribed by AsyncSubscriber" in {
     val publisher: DatabasePublisher[Int] = DB readOnlyStream {
-      SQL(s"select id from $tableName").map(r => r.int("id")).iterator
+      SQL(s"select id from $tableName").map(r => r.int("id")).iterator()
     }
 
     val consumedCountPromise: Promise[Int] = Promise[Int]()
@@ -180,7 +180,7 @@ class DatabasePublisherSpec
 
   it should "be subscribed and cancelled by AsyncSubscriber" in {
     val publisher: DatabasePublisher[Int] = DB readOnlyStream {
-      SQL(s"select id from $tableName").map(r => r.int("id")).iterator
+      SQL(s"select id from $tableName").map(r => r.int("id")).iterator()
     }
 
     val expectedCountOfElements = 20

--- a/scalikejdbc-streams/src/test/scala/somewhere/DatabasePublisherTckTest.scala
+++ b/scalikejdbc-streams/src/test/scala/somewhere/DatabasePublisherTckTest.scala
@@ -38,13 +38,13 @@ class DatabasePublisherTckTest(env: TestEnvironment, publisherShutdownTimeout: L
     if (elements == Long.MaxValue) throw new SkipException("DatabasePublisher doesn't support infinite streaming.")
 
     DB readOnlyStream {
-      SQL(s"select id from $tableName limit $elements").map(r => User(r.int("id"))).iterator
+      SQL(s"select id from $tableName limit $elements").map(r => User(r.int("id"))).iterator()
     }
   }
 
   override def createFailedPublisher(): Publisher[User] = {
     DB readOnlyStream {
-      SQL(s"select id from $tableName").map[User](_ => throw new RuntimeException("this is failed publisher.")).iterator
+      SQL(s"select id from $tableName").map[User](_ => throw new RuntimeException("this is failed publisher.")).iterator()
     }
   }
 

--- a/scalikejdbc-streams/src/test/scala/somewhere/ReadOnlyStreamBlocksSpec.scala
+++ b/scalikejdbc-streams/src/test/scala/somewhere/ReadOnlyStreamBlocksSpec.scala
@@ -12,14 +12,14 @@ class ReadOnlyStreamBlocksSpec extends AnyFlatSpec with Matchers {
 
   "DB.readOnlyStream" should "create DatabasePublisher" in {
     val publisher: DatabasePublisher[Int] = DB readOnlyStream {
-      sql"select id from users".map(r => r.int("id")).iterator
+      sql"select id from users".map(r => r.int("id")).iterator()
     }
     publisher shouldBe a[DatabasePublisher[_]]
   }
 
   "NamedDB.readOnlyStream" should "create DatabasePublisher" in {
     val publisher: DatabasePublisher[Long] = NamedDB(Symbol("default")) readOnlyStream {
-      sql"select id from users".map(r => r.long("id")).iterator
+      sql"select id from users".map(r => r.long("id")).iterator()
     }
     publisher shouldBe a[DatabasePublisher[_]]
   }

--- a/scalikejdbc-syntax-support-macro/src/test/scala/foo/AutoNamedValuesSpec.scala
+++ b/scalikejdbc-syntax-support-macro/src/test/scala/foo/AutoNamedValuesSpec.scala
@@ -32,14 +32,14 @@ class AutoNamedValuesSpec extends AnyFlatSpec with Matchers with DBSettings {
   it should "execute" in {
     DB autoCommit { implicit s =>
       try {
-        try sql"drop table issue".execute.apply() catch { case ignore: Exception => }
-        sql"create table issue (id int not null, first_name varchar(256), group_id int)".execute.apply()
+        try sql"drop table issue".execute().apply() catch { case ignore: Exception => }
+        sql"create table issue (id int not null, first_name varchar(256), group_id int)".execute().apply()
 
-        try sql"drop table organization".execute.apply() catch { case ignore: Exception => }
-        sql"create table organization (id int not null, website_url varchar(256))".execute.apply()
+        try sql"drop table organization".execute().apply() catch { case ignore: Exception => }
+        sql"create table organization (id int not null, website_url varchar(256))".execute().apply()
 
-        try sql"drop table person".execute.apply() catch { case ignore: Exception => }
-        sql"create table person(id int not null, name varchar(256) not null, organization_id bigint, group_id bigint)".execute.apply()
+        try sql"drop table person".execute().apply() catch { case ignore: Exception => }
+        sql"create table person(id int not null, name varchar(256) not null, organization_id bigint, group_id bigint)".execute().apply()
 
         val issue1 = Issue(1L, "ユーザ1", 1L)
         val issue2 = Issue(2L, "ユーザ2", 1L)
@@ -76,9 +76,9 @@ class AutoNamedValuesSpec extends AnyFlatSpec with Matchers with DBSettings {
         p1.flatMap(_.organizationId) should equal(Some(1L))
 
       } finally {
-        try sql"drop table issue".execute.apply() catch { case ignore: Exception => }
-        try sql"drop table organization".execute.apply() catch { case ignore: Exception => }
-        try sql"drop table person".execute.apply() catch { case ignore: Exception => }
+        try sql"drop table issue".execute().apply() catch { case ignore: Exception => }
+        try sql"drop table organization".execute().apply() catch { case ignore: Exception => }
+        try sql"drop table person".execute().apply() catch { case ignore: Exception => }
       }
     }
   }

--- a/scalikejdbc-syntax-support-macro/src/test/scala/foo/AutoSpec.scala
+++ b/scalikejdbc-syntax-support-macro/src/test/scala/foo/AutoSpec.scala
@@ -27,14 +27,14 @@ class AutoSpec extends AnyFlatSpec with Matchers with DBSettings {
   it should "execute" in {
     DB autoCommit { implicit s =>
       try {
-        try sql"drop table issue".execute.apply() catch { case ignore: Exception => }
-        sql"create table issue (id int not null, first_name varchar(256), group_id int)".execute.apply()
+        try sql"drop table issue".execute().apply() catch { case ignore: Exception => }
+        sql"create table issue (id int not null, first_name varchar(256), group_id int)".execute().apply()
 
-        try sql"drop table organization".execute.apply() catch { case ignore: Exception => }
-        sql"create table organization (id int not null, website_url varchar(256))".execute.apply()
+        try sql"drop table organization".execute().apply() catch { case ignore: Exception => }
+        sql"create table organization (id int not null, website_url varchar(256))".execute().apply()
 
-        try sql"drop table person".execute.apply() catch { case ignore: Exception => }
-        sql"create table person(id int not null, name varchar(256) not null, organization_id bigint, group_id bigint)".execute.apply()
+        try sql"drop table person".execute().apply() catch { case ignore: Exception => }
+        sql"create table person(id int not null, name varchar(256) not null, organization_id bigint, group_id bigint)".execute().apply()
 
         val issue1 = Issue(1L, "ユーザ1", 1L)
         val issue2 = Issue(2L, "ユーザ2", 1L)
@@ -71,9 +71,9 @@ class AutoSpec extends AnyFlatSpec with Matchers with DBSettings {
         p1.flatMap(_.organizationId) should equal(Some(1L))
 
       } finally {
-        try sql"drop table issue".execute.apply() catch { case ignore: Exception => }
-        try sql"drop table organization".execute.apply() catch { case ignore: Exception => }
-        try sql"drop table person".execute.apply() catch { case ignore: Exception => }
+        try sql"drop table issue".execute().apply() catch { case ignore: Exception => }
+        try sql"drop table organization".execute().apply() catch { case ignore: Exception => }
+        try sql"drop table person".execute().apply() catch { case ignore: Exception => }
       }
     }
   }

--- a/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/AsyncAutoRollbackSpec.scala
+++ b/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/AsyncAutoRollbackSpec.scala
@@ -15,8 +15,8 @@ trait AsyncFlatSpecWithCommonTraits extends FixtureAsyncFlatSpec with Matchers w
 class AsyncAutoRollbackSpec extends AsyncFlatSpecWithCommonTraits with AsyncAutoRollback {
 
   override def fixture(implicit session: DBSession): Unit = {
-    SQL("insert into ScalaTest_members values (?, ?, ?)").bind(1, "Alice", DateTime.now).update.apply()
-    SQL("insert into ScalaTest_members values (?, ?, ?)").bind(2, "Bob", DateTime.now).update.apply()
+    SQL("insert into ScalaTest_members values (?, ?, ?)").bind(1, "Alice", DateTime.now).update().apply()
+    SQL("insert into ScalaTest_members values (?, ?, ?)").bind(2, "Bob", DateTime.now).update().apply()
   }
 
   behavior of "AsyncAutoRollbackFixture"
@@ -39,11 +39,11 @@ class AsyncAutoRollbackSpec extends AsyncFlatSpecWithCommonTraits with AsyncAuto
 
 class NamedAsyncAutoRollbackSpec extends AsyncFlatSpecWithCommonTraits with AsyncAutoRollback {
 
-  override def db = NamedDB(Symbol("db2")).toDB
+  override def db = NamedDB(Symbol("db2")).toDB()
 
   override def fixture(implicit session: DBSession): Unit = {
-    SQL("insert into scalatest_members2 values (?, ?, ?)").bind(1, "Alice", DateTime.now).update.apply()
-    SQL("insert into scalatest_members2 values (?, ?, ?)").bind(2, "Bob", DateTime.now).update.apply()
+    SQL("insert into scalatest_members2 values (?, ?, ?)").bind(1, "Alice", DateTime.now).update().apply()
+    SQL("insert into scalatest_members2 values (?, ?, ?)").bind(2, "Bob", DateTime.now).update().apply()
   }
 
   behavior of "Named AsyncAutoRollbackFixture"
@@ -66,7 +66,7 @@ class NamedAsyncAutoRollbackSpec extends AsyncFlatSpecWithCommonTraits with Asyn
 
 class AsyncAutoRollbackWithNoArgTestFixtureSpec extends AsyncFlatSpecWithCommonTraits with AsyncAutoRollback with AsyncBufferMixin {
 
-  override def db = NamedDB(Symbol("db2")).toDB
+  override def db = NamedDB(Symbol("db2")).toDB()
 
   behavior of "AsyncAutoRollback with NoArgTestFixture"
 

--- a/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/AutoRollbackSpec.scala
+++ b/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/AutoRollbackSpec.scala
@@ -13,8 +13,8 @@ trait FlatSpecWithCommonTraits extends FixtureAnyFlatSpec with Matchers with DBS
 class AutoRollbackSpec extends FlatSpecWithCommonTraits with AutoRollback {
 
   override def fixture(implicit session: DBSession): Unit = {
-    SQL("insert into ScalaTest_members values (?, ?, ?)").bind(1, "Alice", DateTime.now).update.apply()
-    SQL("insert into ScalaTest_members values (?, ?, ?)").bind(2, "Bob", DateTime.now).update.apply()
+    SQL("insert into ScalaTest_members values (?, ?, ?)").bind(1, "Alice", DateTime.now).update().apply()
+    SQL("insert into ScalaTest_members values (?, ?, ?)").bind(2, "Bob", DateTime.now).update().apply()
   }
 
   behavior of "AutoRollbackFixture"
@@ -33,11 +33,11 @@ class AutoRollbackSpec extends FlatSpecWithCommonTraits with AutoRollback {
 
 class NamedAutoRollbackSpec extends FlatSpecWithCommonTraits with AutoRollback {
 
-  override def db = NamedDB(Symbol("db2")).toDB
+  override def db = NamedDB(Symbol("db2")).toDB()
 
   override def fixture(implicit session: DBSession): Unit = {
-    SQL("insert into scalatest_members2 values (?, ?, ?)").bind(1, "Alice", DateTime.now).update.apply()
-    SQL("insert into scalatest_members2 values (?, ?, ?)").bind(2, "Bob", DateTime.now).update.apply()
+    SQL("insert into scalatest_members2 values (?, ?, ?)").bind(1, "Alice", DateTime.now).update().apply()
+    SQL("insert into scalatest_members2 values (?, ?, ?)").bind(2, "Bob", DateTime.now).update().apply()
   }
 
   behavior of "Named AutoRollbackFixture"
@@ -56,7 +56,7 @@ class NamedAutoRollbackSpec extends FlatSpecWithCommonTraits with AutoRollback {
 
 class AutoRollbackWithNoArgTestFixtureSpec extends FlatSpecWithCommonTraits with AutoRollback with BufferMixin {
 
-  override def db = NamedDB(Symbol("db2")).toDB
+  override def db = NamedDB(Symbol("db2")).toDB()
 
   behavior of "AutoRollback with NoArgTestFixture"
 

--- a/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/ScalaTestMember.scala
+++ b/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/ScalaTestMember.scala
@@ -6,16 +6,16 @@ import org.joda.time.DateTime
 object ScalaTestMember {
 
   def count()(implicit session: DBSession = AutoSession): Long = {
-    SQL("select count(1) from scalatest_members").map(_.long(1)).single.apply().get
+    SQL("select count(1) from scalatest_members").map(_.long(1)).single().apply().get
   }
 
   def create(id: Long, name: String)(implicit session: DBSession = AutoSession): Unit = {
     SQL("insert into scalatest_members values (?, ?, ?)")
-      .bind(id, name, DateTime.now).update.apply()
+      .bind(id, name, DateTime.now).update().apply()
   }
 
   def delete(id: Long)(implicit session: DBSession = AutoSession): Unit = {
-    SQL("delete from scalatest_members where id = ?").bind(id).update.apply()
+    SQL("delete from scalatest_members where id = ?").bind(id).update().apply()
   }
 
 }

--- a/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/ScalaTestMember2.scala
+++ b/scalikejdbc-test/src/test/scala/scalikejdbc/scalatest/ScalaTestMember2.scala
@@ -6,16 +6,16 @@ import org.joda.time.DateTime
 object ScalaTestMember2 {
 
   def count()(implicit session: DBSession = NamedAutoSession(Symbol("db2"))): Long = {
-    SQL("select count(1) from scalatest_members2").map(_.long(1)).single.apply().get
+    SQL("select count(1) from scalatest_members2").map(_.long(1)).single().apply().get
   }
 
   def create(id: Long, name: String)(implicit session: DBSession = NamedAutoSession(Symbol("db2"))): Unit = {
     SQL("insert into scalatest_members2 values (?, ?, ?)")
-      .bind(id, name, DateTime.now).update.apply()
+      .bind(id, name, DateTime.now).update().apply()
   }
 
   def delete(id: Long)(implicit session: DBSession = NamedAutoSession(Symbol("db2"))): Unit = {
-    SQL("delete from scalatest_members2 where id = ?").bind(id).update.apply()
+    SQL("delete from scalatest_members2 where id = ?").bind(id).update().apply()
   }
 
 }

--- a/scalikejdbc-test/src/test/scala/scalikejdbc/specs2/AutoRollbackSpec.scala
+++ b/scalikejdbc-test/src/test/scala/scalikejdbc/specs2/AutoRollbackSpec.scala
@@ -45,8 +45,8 @@ class AutoRollbackSpec extends Specification with DBSettings with PreparingTable
 
   case class autoRollbackWithFixture() extends AutoRollback {
     override def fixture(implicit session: DBSession): Unit = {
-      SQL("insert into members values (?, ?, ?)").bind(1, "Alice", DateTime.now).update.apply()
-      SQL("insert into members values (?, ?, ?)").bind(2, "Bob", DateTime.now).update.apply()
+      SQL("insert into members values (?, ?, ?)").bind(1, "Alice", DateTime.now).update().apply()
+      SQL("insert into members values (?, ?, ?)").bind(2, "Bob", DateTime.now).update().apply()
     }
 
     def shouldBeRolledBack = this{
@@ -72,7 +72,7 @@ class AutoRollbackSpec extends Specification with DBSettings with PreparingTable
   }
 
   case class db2AutoRollback() extends AutoRollback {
-    override def db = NamedDB(Symbol("db2")).toDB
+    override def db = NamedDB(Symbol("db2")).toDB()
 
     def beforeTest = this{
       Member2.count() must_== (0)
@@ -85,11 +85,11 @@ class AutoRollbackSpec extends Specification with DBSettings with PreparingTable
   }
 
   case class db2AutoRollbackWithFixture() extends AutoRollback {
-    override def db = NamedDB(Symbol("db2")).toDB
+    override def db = NamedDB(Symbol("db2")).toDB()
 
     override def fixture(implicit session: DBSession): Unit = {
-      SQL("insert into members2 values (?, ?, ?)").bind(1, "Alice", DateTime.now).update.apply()
-      SQL("insert into members2 values (?, ?, ?)").bind(2, "Bob", DateTime.now).update.apply()
+      SQL("insert into members2 values (?, ?, ?)").bind(1, "Alice", DateTime.now).update().apply()
+      SQL("insert into members2 values (?, ?, ?)").bind(2, "Bob", DateTime.now).update().apply()
     }
 
     def test = this{

--- a/scalikejdbc-test/src/test/scala/scalikejdbc/specs2/Member.scala
+++ b/scalikejdbc-test/src/test/scala/scalikejdbc/specs2/Member.scala
@@ -6,16 +6,16 @@ import org.joda.time.DateTime
 object Member {
 
   def count()(implicit session: DBSession = AutoSession): Long = {
-    SQL("select count(1) from members").map(_.long(1)).single.apply().get
+    SQL("select count(1) from members").map(_.long(1)).single().apply().get
   }
 
   def create(id: Long, name: String)(implicit session: DBSession = AutoSession): Unit = {
     SQL("insert into members values (?, ?, ?)")
-      .bind(id, name, DateTime.now).update.apply()
+      .bind(id, name, DateTime.now).update().apply()
   }
 
   def delete(id: Long)(implicit session: DBSession = AutoSession): Unit = {
-    SQL("delete from members where id = ?").bind(id).update.apply()
+    SQL("delete from members where id = ?").bind(id).update().apply()
   }
 
 }

--- a/scalikejdbc-test/src/test/scala/scalikejdbc/specs2/Member2.scala
+++ b/scalikejdbc-test/src/test/scala/scalikejdbc/specs2/Member2.scala
@@ -6,16 +6,16 @@ import org.joda.time.DateTime
 object Member2 {
 
   def count()(implicit session: DBSession = NamedAutoSession(Symbol("db2"))): Long = {
-    SQL("select count(1) from members2").map(_.long(1)).single.apply().get
+    SQL("select count(1) from members2").map(_.long(1)).single().apply().get
   }
 
   def create(id: Long, name: String)(implicit session: DBSession = NamedAutoSession(Symbol("db2"))): Unit = {
     SQL("insert into members2 values (?, ?, ?)")
-      .bind(id, name, DateTime.now).update.apply()
+      .bind(id, name, DateTime.now).update().apply()
   }
 
   def delete(id: Long)(implicit session: DBSession = NamedAutoSession(Symbol("db2"))): Unit = {
-    SQL("delete from members2 where id = ?").bind(id).update.apply()
+    SQL("delete from members2 where id = ?").bind(id).update().apply()
   }
 
 }

--- a/scalikejdbc-test/src/test/scala/scalikejdbc/specs2/mutable/AutoRollbackSpec.scala
+++ b/scalikejdbc-test/src/test/scala/scalikejdbc/specs2/mutable/AutoRollbackSpec.scala
@@ -88,8 +88,8 @@ class AutoRollbackSpec extends Specification with DBSettings with PreparingTable
 
 trait AutoRollbackWithFixture extends AutoRollback {
   override def fixture(implicit session: DBSession): Unit = {
-    SQL("insert into mutable_members values (?, ?, ?)").bind(1, "Alice", DateTime.now).update.apply()
-    SQL("insert into mutable_members values (?, ?, ?)").bind(2, "Bob", DateTime.now).update.apply()
+    SQL("insert into mutable_members values (?, ?, ?)").bind(1, "Alice", DateTime.now).update().apply()
+    SQL("insert into mutable_members values (?, ?, ?)").bind(2, "Bob", DateTime.now).update().apply()
   }
 }
 
@@ -104,14 +104,14 @@ trait AutoRollbackWithWrongFixture extends AutoRollback {
 }
 
 trait DB2AutoRollbackWithFixture extends AutoRollback {
-  override def db = NamedDB(Symbol("db2")).toDB
+  override def db = NamedDB(Symbol("db2")).toDB()
   override def fixture(implicit session: DBSession): Unit = {
-    SQL("insert into mutable_members2 values (?, ?, ?)").bind(1, "Alice", DateTime.now).update.apply()
-    SQL("insert into mutable_members2 values (?, ?, ?)").bind(2, "Bob", DateTime.now).update.apply()
+    SQL("insert into mutable_members2 values (?, ?, ?)").bind(1, "Alice", DateTime.now).update().apply()
+    SQL("insert into mutable_members2 values (?, ?, ?)").bind(2, "Bob", DateTime.now).update().apply()
   }
 }
 
 trait DB2AutoRollback extends AutoRollback {
-  override def db = NamedDB(Symbol("db2")).toDB
+  override def db = NamedDB(Symbol("db2")).toDB()
 }
 

--- a/scalikejdbc-test/src/test/scala/scalikejdbc/specs2/mutable/MutableMember.scala
+++ b/scalikejdbc-test/src/test/scala/scalikejdbc/specs2/mutable/MutableMember.scala
@@ -6,16 +6,16 @@ import org.joda.time.DateTime
 object MutableMember {
 
   def count()(implicit session: DBSession = AutoSession): Long = {
-    SQL("select count(1) from mutable_members").map(_.long(1)).single.apply().get
+    SQL("select count(1) from mutable_members").map(_.long(1)).single().apply().get
   }
 
   def create(id: Long, name: String)(implicit session: DBSession = AutoSession): Unit = {
     SQL("insert into mutable_members values (?, ?, ?)")
-      .bind(id, name, DateTime.now).update.apply()
+      .bind(id, name, DateTime.now).update().apply()
   }
 
   def delete(id: Long)(implicit session: DBSession = AutoSession): Unit = {
-    SQL("delete from mutable_members where id = ?").bind(id).update.apply()
+    SQL("delete from mutable_members where id = ?").bind(id).update().apply()
   }
 
 }

--- a/scalikejdbc-test/src/test/scala/scalikejdbc/specs2/mutable/MutableMember2.scala
+++ b/scalikejdbc-test/src/test/scala/scalikejdbc/specs2/mutable/MutableMember2.scala
@@ -6,16 +6,16 @@ import org.joda.time.DateTime
 object MutableMember2 {
 
   def count()(implicit session: DBSession = NamedAutoSession(Symbol("db2"))): Long = {
-    SQL("select count(1) from mutable_members2").map(_.long(1)).single.apply().get
+    SQL("select count(1) from mutable_members2").map(_.long(1)).single().apply().get
   }
 
   def create(id: Long, name: String)(implicit session: DBSession = NamedAutoSession(Symbol("db2"))): Unit = {
     SQL("insert into mutable_members2 values (?, ?, ?)")
-      .bind(id, name, DateTime.now).update.apply()
+      .bind(id, name, DateTime.now).update().apply()
   }
 
   def delete(id: Long)(implicit session: DBSession = NamedAutoSession(Symbol("db2"))): Unit = {
-    SQL("delete from mutable_members2 where id = ?").bind(id).update.apply()
+    SQL("delete from mutable_members2 where id = ?").bind(id).update().apply()
   }
 
 }

--- a/scalikejdbc-test/src/test/scala/unit/PreparingTables.scala
+++ b/scalikejdbc-test/src/test/scala/unit/PreparingTables.scala
@@ -6,37 +6,37 @@ trait PreparingTables {
 
   try {
     DB autoCommit { implicit s =>
-      SQL("create table members (id integer primary key, name varchar(30), created_at timestamp not null)").execute.apply()
+      SQL("create table members (id integer primary key, name varchar(30), created_at timestamp not null)").execute().apply()
     }
   } catch { case e: Exception => }
 
   try {
     DB autoCommit { implicit s =>
-      SQL("create table mutable_members (id integer primary key, name varchar(30), created_at timestamp not null)").execute.apply()
+      SQL("create table mutable_members (id integer primary key, name varchar(30), created_at timestamp not null)").execute().apply()
     }
   } catch { case e: Exception => }
 
   try {
     DB autoCommit { implicit s =>
-      SQL("create table scalatest_members (id integer primary key, name varchar(30), created_at timestamp not null)").execute.apply()
+      SQL("create table scalatest_members (id integer primary key, name varchar(30), created_at timestamp not null)").execute().apply()
     }
   } catch { case e: Exception => }
 
   try {
     NamedDB(Symbol("db2")) autoCommit { implicit s =>
-      SQL("create table members2 (id integer primary key, name varchar(30), created_at timestamp not null)").execute.apply()
+      SQL("create table members2 (id integer primary key, name varchar(30), created_at timestamp not null)").execute().apply()
     }
   } catch { case e: Exception => }
 
   try {
     NamedDB(Symbol("db2")) autoCommit { implicit s =>
-      SQL("create table mutable_members2 (id integer primary key, name varchar(30), created_at timestamp not null)").execute.apply()
+      SQL("create table mutable_members2 (id integer primary key, name varchar(30), created_at timestamp not null)").execute().apply()
     }
   } catch { case e: Exception => }
 
   try {
     NamedDB(Symbol("db2")) autoCommit { implicit s =>
-      SQL("create table scalatest_members2 (id integer primary key, name varchar(30), created_at timestamp not null)").execute.apply()
+      SQL("create table scalatest_members2 (id integer primary key, name varchar(30), created_at timestamp not null)").execute().apply()
     }
   } catch { case e: Exception => }
 


### PR DESCRIPTION
**1095 warnings** since Scala 2.13.3! 😇 😇 😇 

https://travis-ci.com/github/scalikejdbc/scalikejdbc/jobs/354732287

```
[warn] /home/travis/build/scalikejdbc/scalikejdbc/scalikejdbc-config/src/test/scala/scalikejdbc/config/DBsSpec.scala:20:59: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method single,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]           SQL("SELECT 1 as one").map(rs => rs.int("one")).single.apply()
[warn]                                                           ^
```

rewrite use https://github.com/scala/scala-rewrites/pull/14

Maybe some methods does not have side effects.
Should we remove `()` from method definition instead of this pull request? 🤔 (but not source compatible 😢 )