### PR TITLE
adding useAutoCommit to AutoSession

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/AutoSession.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/AutoSession.scala
@@ -5,7 +5,7 @@ import java.sql.Connection
 /**
  * Represents that already existing session will be used or a new session will be started.
  */
-case class AutoSession(settings: SettingsProvider) extends DBSession {
+case class AutoSession(settings: SettingsProvider = SettingsProvider.default, useAutoCommit: Boolean = true) extends DBSession {
   override private[scalikejdbc] val conn: Connection = null
   override val tx: Option[Tx] = None
   val isReadOnly: Boolean = false
@@ -18,13 +18,13 @@ case class AutoSession(settings: SettingsProvider) extends DBSession {
   override private[scalikejdbc] lazy val connectionAttributes: DBConnectionAttributes = unexpectedInvocation
 }
 
-object AutoSession extends AutoSession(SettingsProvider.default)
+object AutoSession extends AutoSession(SettingsProvider.default, useAutoCommit = true)
 
 /**
  * Represents that already existing session will be used or a new session
  * which is retrieved from named connection pool will be started.
  */
-case class NamedAutoSession(name: Any, settings: SettingsProvider = SettingsProvider.default) extends DBSession {
+case class NamedAutoSession(name: Any, settings: SettingsProvider = SettingsProvider.default, useAutoCommit: Boolean = true) extends DBSession {
   override private[scalikejdbc] val conn: Connection = null
   override val tx: Option[Tx] = None
   val isReadOnly: Boolean = false

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/RelationalSQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/RelationalSQL.scala
@@ -13,8 +13,8 @@ private[scalikejdbc] trait RelationalSQLResultSetOperations[Z] {
 
   private[scalikejdbc] def executeQuery[R[Z]](session: DBSession, op: DBSession => R[Z]): R[Z] = try {
     session match {
-      case AutoSession | ReadOnlyAutoSession => DB readOnly op
-      case NamedAutoSession(name, _) => NamedDB(name, session.settings) readOnly op
+      case AutoSession(_, _) | ReadOnlyAutoSession => DB readOnly op
+      case NamedAutoSession(name, _, _) => NamedDB(name, session.settings) readOnly op
       case ReadOnlyNamedAutoSession(name, _) => NamedDB(name, session.settings) readOnly op
       case _ => op(session)
     }


### PR DESCRIPTION
Currently, AutoSession executes the auto-commit blocks for any write-like operation.
The PR introduces the `useAutoCommit: Boolean` flag for `AutoSeession/NamedAutoSession`:
```scala
useAutoCommit match {
  case true => autoCommit(...)
  case false => localTx(...)
}
```
The default value is `true` for the backward compatibility. 

**Why is the option important?** 
The answer lies in a difference between autoCommit and localTx blocks - the atomicity guarantee.
```scala
def fail(): Unit = {
  throw new RuntimeExcepion()
}

def executeSeveralSQLStatements(implicit s: DBSession = AutoSession(useAutoCommit = ???)){
  sql"insert into table1(a, b, c) values (1, 2, 3)".update.apply
  fail()
  sql"insert into table1(a, b, c) values (4, 5, 6)".update.apply
}
```
In the case when `useAutoCommit = true` the `(1, 2, 3)` will be committed to the DB, otherwise the first statement will be rolled back. 
It would be nice to have the ability to control the behavior of AutoSession commit mode, that's why `useAutoCommit` option is added.