### PR TITLE
Add `getOpt` method in WrappedResultSet

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/WrappedResultSet.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/WrappedResultSet.scala
@@ -33,9 +33,9 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
 
   def array(columnLabel: String): java.sql.Array = get[java.sql.Array](columnLabel)
 
-  def arrayOpt(columnIndex: Int): Option[java.sql.Array] = get[Option[java.sql.Array]](columnIndex)
+  def arrayOpt(columnIndex: Int): Option[java.sql.Array] = getOpt[java.sql.Array](columnIndex)
 
-  def arrayOpt(columnLabel: String): Option[java.sql.Array] = get[Option[java.sql.Array]](columnLabel)
+  def arrayOpt(columnLabel: String): Option[java.sql.Array] = getOpt[java.sql.Array](columnLabel)
 
   def asciiStream(columnIndex: Int): java.io.InputStream = get[java.io.InputStream](columnIndex)(TypeBinder.asciiStream)
 
@@ -43,45 +43,45 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
 
   def asciiStreamOpt(columnIndex: Int): Option[java.io.InputStream] = {
     implicit val binder = TypeBinder.asciiStream
-    get[Option[java.io.InputStream]](columnIndex)
+    getOpt[java.io.InputStream](columnIndex)
   }
 
   def asciiStreamOpt(columnLabel: String): Option[java.io.InputStream] = {
     implicit val binder = TypeBinder.asciiStream
-    get[Option[java.io.InputStream]](columnLabel)
+    getOpt[java.io.InputStream](columnLabel)
   }
 
   def bigDecimal(columnIndex: Int): java.math.BigDecimal = get[java.math.BigDecimal](columnIndex)
 
   def bigDecimal(columnLabel: String): java.math.BigDecimal = get[java.math.BigDecimal](columnLabel)
 
-  def bigDecimalOpt(columnIndex: Int): Option[java.math.BigDecimal] = get[Option[java.math.BigDecimal]](columnIndex)
+  def bigDecimalOpt(columnIndex: Int): Option[java.math.BigDecimal] = getOpt[java.math.BigDecimal](columnIndex)
 
-  def bigDecimalOpt(columnLabel: String): Option[java.math.BigDecimal] = get[Option[java.math.BigDecimal]](columnLabel)
+  def bigDecimalOpt(columnLabel: String): Option[java.math.BigDecimal] = getOpt[java.math.BigDecimal](columnLabel)
 
   def bigInt(columnIndex: Int): java.math.BigInteger = get[java.math.BigInteger](columnIndex)
 
   def bigInt(columnLabel: String): java.math.BigInteger = get[java.math.BigInteger](columnLabel)
 
-  def bigIntOpt(columnIndex: Int): Option[java.math.BigInteger] = get[Option[java.math.BigInteger]](columnIndex)
+  def bigIntOpt(columnIndex: Int): Option[java.math.BigInteger] = getOpt[java.math.BigInteger](columnIndex)
 
-  def bigIntOpt(columnLabel: String): Option[java.math.BigInteger] = get[Option[java.math.BigInteger]](columnLabel)
+  def bigIntOpt(columnLabel: String): Option[java.math.BigInteger] = getOpt[java.math.BigInteger](columnLabel)
 
   def binaryStream(columnIndex: Int): java.io.InputStream = get[java.io.InputStream](columnIndex)
 
   def binaryStream(columnLabel: String): java.io.InputStream = get[java.io.InputStream](columnLabel)
 
-  def binaryStreamOpt(columnIndex: Int): Option[java.io.InputStream] = get[Option[java.io.InputStream]](columnIndex)
+  def binaryStreamOpt(columnIndex: Int): Option[java.io.InputStream] = getOpt[java.io.InputStream](columnIndex)
 
-  def binaryStreamOpt(columnLabel: String): Option[java.io.InputStream] = get[Option[java.io.InputStream]](columnLabel)
+  def binaryStreamOpt(columnLabel: String): Option[java.io.InputStream] = getOpt[java.io.InputStream](columnLabel)
 
   def blob(columnIndex: Int): java.sql.Blob = get[java.sql.Blob](columnIndex)
 
   def blob(columnLabel: String): java.sql.Blob = get[java.sql.Blob](columnLabel)
 
-  def blobOpt(columnIndex: Int): Option[java.sql.Blob] = get[Option[java.sql.Blob]](columnIndex)
+  def blobOpt(columnIndex: Int): Option[java.sql.Blob] = getOpt[java.sql.Blob](columnIndex)
 
-  def blobOpt(columnLabel: String): Option[java.sql.Blob] = get[Option[java.sql.Blob]](columnLabel)
+  def blobOpt(columnLabel: String): Option[java.sql.Blob] = getOpt[java.sql.Blob](columnLabel)
 
   def nullableBoolean(columnIndex: Int): java.lang.Boolean = get[java.lang.Boolean](columnIndex)
 
@@ -91,9 +91,9 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
 
   def boolean(columnLabel: String): Boolean = get[Boolean](columnLabel)
 
-  def booleanOpt(columnIndex: Int): Option[Boolean] = get[Option[Boolean]](columnIndex)
+  def booleanOpt(columnIndex: Int): Option[Boolean] = getOpt[Boolean](columnIndex)
 
-  def booleanOpt(columnLabel: String): Option[Boolean] = get[Option[Boolean]](columnLabel)
+  def booleanOpt(columnLabel: String): Option[Boolean] = getOpt[Boolean](columnLabel)
 
   def nullableByte(columnIndex: Int): java.lang.Byte = get[java.lang.Byte](columnIndex)
 
@@ -103,33 +103,33 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
 
   def byte(columnLabel: String): Byte = get[Byte](columnLabel)
 
-  def byteOpt(columnIndex: Int): Option[Byte] = get[Option[Byte]](columnIndex)
+  def byteOpt(columnIndex: Int): Option[Byte] = getOpt[Byte](columnIndex)
 
-  def byteOpt(columnLabel: String): Option[Byte] = get[Option[Byte]](columnLabel)
+  def byteOpt(columnLabel: String): Option[Byte] = getOpt[Byte](columnLabel)
 
   def bytes(columnIndex: Int): Array[Byte] = get[Array[Byte]](columnIndex)
 
   def bytes(columnLabel: String): Array[Byte] = get[Array[Byte]](columnLabel)
 
-  def bytesOpt(columnIndex: Int): Option[Array[Byte]] = get[Option[Array[Byte]]](columnIndex)
+  def bytesOpt(columnIndex: Int): Option[Array[Byte]] = getOpt[Array[Byte]](columnIndex)
 
-  def bytesOpt(columnLabel: String): Option[Array[Byte]] = get[Option[Array[Byte]]](columnLabel)
+  def bytesOpt(columnLabel: String): Option[Array[Byte]] = getOpt[Array[Byte]](columnLabel)
 
   def characterStream(columnIndex: Int): java.io.Reader = get[java.io.Reader](columnIndex)
 
   def characterStream(columnLabel: String): java.io.Reader = get[java.io.Reader](columnLabel)
 
-  def characterStreamOpt(columnIndex: Int): Option[java.io.Reader] = get[Option[java.io.Reader]](columnIndex)
+  def characterStreamOpt(columnIndex: Int): Option[java.io.Reader] = getOpt[java.io.Reader](columnIndex)
 
-  def characterStreamOpt(columnLabel: String): Option[java.io.Reader] = get[Option[java.io.Reader]](columnLabel)
+  def characterStreamOpt(columnLabel: String): Option[java.io.Reader] = getOpt[java.io.Reader](columnLabel)
 
   def clob(columnIndex: Int): java.sql.Clob = get[java.sql.Clob](columnIndex)
 
   def clob(columnLabel: String): java.sql.Clob = get[java.sql.Clob](columnLabel)
 
-  def clobOpt(columnIndex: Int): Option[java.sql.Clob] = get[Option[java.sql.Clob]](columnIndex)
+  def clobOpt(columnIndex: Int): Option[java.sql.Clob] = getOpt[java.sql.Clob](columnIndex)
 
-  def clobOpt(columnLabel: String): Option[java.sql.Clob] = get[Option[java.sql.Clob]](columnLabel)
+  def clobOpt(columnLabel: String): Option[java.sql.Clob] = getOpt[java.sql.Clob](columnLabel)
 
   def concurrency: Int = {
     ensureCursor()
@@ -155,18 +155,18 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
     get[java.sql.Date](columnLabel)
   }
 
-  def dateOpt(columnIndex: Int): Option[java.sql.Date] = get[Option[java.sql.Date]](columnIndex)
+  def dateOpt(columnIndex: Int): Option[java.sql.Date] = getOpt[java.sql.Date](columnIndex)
 
-  def dateOpt(columnLabel: String): Option[java.sql.Date] = get[Option[java.sql.Date]](columnLabel)
+  def dateOpt(columnLabel: String): Option[java.sql.Date] = getOpt[java.sql.Date](columnLabel)
 
   def dateOpt(columnIndex: Int, cal: Calendar): Option[java.sql.Date] = {
     implicit val binder: TypeBinder[java.sql.Date] = TypeBinder((rs, i) => rs.getDate(i, cal))((rs, l) => rs.getDate(l, cal))
-    get[Option[java.sql.Date]](columnIndex)
+    getOpt[java.sql.Date](columnIndex)
   }
 
   def dateOpt(columnLabel: String, cal: Calendar): Option[java.sql.Date] = {
     implicit val binder: TypeBinder[java.sql.Date] = TypeBinder((rs, i) => rs.getDate(i, cal))((rs, l) => rs.getDate(l, cal))
-    get[Option[java.sql.Date]](columnLabel)
+    getOpt[java.sql.Date](columnLabel)
   }
 
   def nullableDouble(columnIndex: Int): java.lang.Double = get[java.lang.Double](columnIndex)
@@ -177,9 +177,9 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
 
   def double(columnLabel: String): Double = get[Double](columnLabel)
 
-  def doubleOpt(columnIndex: Int): Option[Double] = get[Option[Double]](columnIndex)
+  def doubleOpt(columnIndex: Int): Option[Double] = getOpt[Double](columnIndex)
 
-  def doubleOpt(columnLabel: String): Option[Double] = get[Option[Double]](columnLabel)
+  def doubleOpt(columnLabel: String): Option[Double] = getOpt[Double](columnLabel)
 
   def fetchDirection: Int = {
     ensureCursor()
@@ -199,9 +199,9 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
 
   def float(columnLabel: String): Float = get[Float](columnLabel)
 
-  def floatOpt(columnIndex: Int): Option[Float] = get[Option[Float]](columnIndex)
+  def floatOpt(columnIndex: Int): Option[Float] = getOpt[Float](columnIndex)
 
-  def floatOpt(columnLabel: String): Option[Float] = get[Option[Float]](columnLabel)
+  def floatOpt(columnLabel: String): Option[Float] = getOpt[Float](columnLabel)
 
   def holdability: Int = {
     ensureCursor()
@@ -216,9 +216,9 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
 
   def int(columnLabel: String): Int = get[Int](columnLabel)
 
-  def intOpt(columnIndex: Int): Option[Int] = get[Option[Int]](columnIndex)
+  def intOpt(columnIndex: Int): Option[Int] = getOpt[Int](columnIndex)
 
-  def intOpt(columnLabel: String): Option[Int] = get[Option[Int]](columnLabel)
+  def intOpt(columnLabel: String): Option[Int] = getOpt[Int](columnLabel)
 
   def nullableLong(columnIndex: Int): java.lang.Long = get[java.lang.Long](columnIndex)
 
@@ -228,9 +228,9 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
 
   def long(columnLabel: String): Long = get[Long](columnLabel)
 
-  def longOpt(columnIndex: Int): Option[Long] = get[Option[Long]](columnIndex)
+  def longOpt(columnIndex: Int): Option[Long] = getOpt[Long](columnIndex)
 
-  def longOpt(columnLabel: String): Option[Long] = get[Option[Long]](columnLabel)
+  def longOpt(columnLabel: String): Option[Long] = getOpt[Long](columnLabel)
 
   def metaData: java.sql.ResultSetMetaData = {
     ensureCursor()
@@ -243,21 +243,21 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
 
   def nCharacterStreamOpt(columnIndex: Int): Option[java.io.Reader] = {
     implicit val binder = TypeBinder.nCharacterStream
-    get[Option[java.io.Reader]](columnIndex)
+    getOpt[java.io.Reader](columnIndex)
   }
 
   def nCharacterStreamOpt(columnLabel: String): Option[java.io.Reader] = {
     implicit val binder = TypeBinder.nCharacterStream
-    get[Option[java.io.Reader]](columnLabel)
+    getOpt[java.io.Reader](columnLabel)
   }
 
   def nClob(columnIndex: Int): java.sql.NClob = get[java.sql.NClob](columnIndex)
 
   def nClob(columnLabel: String): java.sql.NClob = get[java.sql.NClob](columnLabel)
 
-  def nClobOpt(columnIndex: Int): Option[java.sql.NClob] = get[Option[java.sql.NClob]](columnIndex)
+  def nClobOpt(columnIndex: Int): Option[java.sql.NClob] = getOpt[java.sql.NClob](columnIndex)
 
-  def nClobOpt(columnLabel: String): Option[java.sql.NClob] = get[Option[java.sql.NClob]](columnLabel)
+  def nClobOpt(columnLabel: String): Option[java.sql.NClob] = getOpt[java.sql.NClob](columnLabel)
 
   def nString(columnIndex: Int): String = get[String](columnIndex)(TypeBinder.nString)
 
@@ -265,12 +265,12 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
 
   def nStringOpt(columnIndex: Int): Option[String] = {
     implicit val binder = TypeBinder.nString
-    get[Option[String]](columnIndex)
+    getOpt[String](columnIndex)
   }
 
   def nStringOpt(columnLabel: String): Option[String] = {
     implicit val binder = TypeBinder.nString
-    get[Option[String]](columnLabel)
+    getOpt[String](columnLabel)
   }
 
   def any(columnIndex: Int): Any = get[Any](columnIndex)(TypeBinder.any)
@@ -289,31 +289,31 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
 
   def anyOpt(columnIndex: Int): Option[Any] = {
     implicit val binder: TypeBinder[Any] = TypeBinder.any
-    get[Option[Any]](columnIndex)(TypeBinder.option(binder))
+    getOpt[Any](columnIndex)(binder)
   }
 
   def anyOpt(columnLabel: String): Option[Any] = {
     implicit val binder: TypeBinder[Any] = TypeBinder.any
-    get[Option[Any]](columnLabel)(TypeBinder.option(binder))
+    getOpt[Any](columnLabel)(binder)
   }
 
   def anyOpt(columnIndex: Int, map: Map[String, Class[_]]): Option[Any] = {
     implicit val binder: TypeBinder[Any] = TypeBinder((rs, i) => rs.getObject(i, map.asJava))((rs, l) => rs.getObject(l, map.asJava))
-    get[Option[Any]](columnIndex)(TypeBinder.option(binder))
+    getOpt[Any](columnIndex)(binder)
   }
 
   def anyOpt(columnLabel: String, map: Map[String, Class[_]]): Option[Any] = {
     implicit val binder: TypeBinder[Any] = TypeBinder((rs, i) => rs.getObject(i, map.asJava))((rs, l) => rs.getObject(l, map.asJava))
-    get[Option[Any]](columnLabel)(TypeBinder.option(binder))
+    getOpt[Any](columnLabel)(binder)
   }
 
   def ref(columnIndex: Int): java.sql.Ref = get[java.sql.Ref](columnIndex)
 
   def ref(columnLabel: String): java.sql.Ref = get[java.sql.Ref](columnLabel)
 
-  def refOpt(columnIndex: Int): Option[java.sql.Ref] = get[Option[java.sql.Ref]](columnIndex)
+  def refOpt(columnIndex: Int): Option[java.sql.Ref] = getOpt[java.sql.Ref](columnIndex)
 
-  def refOpt(columnLabel: String): Option[java.sql.Ref] = get[Option[java.sql.Ref]](columnLabel)
+  def refOpt(columnLabel: String): Option[java.sql.Ref] = getOpt[java.sql.Ref](columnLabel)
 
   def row: Int = {
     ensureCursor()
@@ -332,17 +332,17 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
 
   def short(columnLabel: String): Short = get[Short](columnLabel)
 
-  def shortOpt(columnIndex: Int): Option[Short] = get[Option[Short]](columnIndex)
+  def shortOpt(columnIndex: Int): Option[Short] = getOpt[Short](columnIndex)
 
-  def shortOpt(columnLabel: String): Option[Short] = get[Option[Short]](columnLabel)
+  def shortOpt(columnLabel: String): Option[Short] = getOpt[Short](columnLabel)
 
   def sqlXml(columnIndex: Int): java.sql.SQLXML = get[java.sql.SQLXML](columnIndex)
 
   def sqlXml(columnLabel: String): java.sql.SQLXML = get[java.sql.SQLXML](columnLabel)
 
-  def sqlXmlOpt(columnIndex: Int): Option[java.sql.SQLXML] = get[Option[java.sql.SQLXML]](columnIndex)
+  def sqlXmlOpt(columnIndex: Int): Option[java.sql.SQLXML] = getOpt[java.sql.SQLXML](columnIndex)
 
-  def sqlXmlOpt(columnLabel: String): Option[java.sql.SQLXML] = get[Option[java.sql.SQLXML]](columnLabel)
+  def sqlXmlOpt(columnLabel: String): Option[java.sql.SQLXML] = getOpt[java.sql.SQLXML](columnLabel)
 
   def statement: java.sql.Statement = {
     ensureCursor()
@@ -353,9 +353,9 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
 
   def string(columnLabel: String): String = get[String](columnLabel)
 
-  def stringOpt(columnIndex: Int): Option[String] = get[Option[String]](columnIndex)
+  def stringOpt(columnIndex: Int): Option[String] = getOpt[String](columnIndex)
 
-  def stringOpt(columnLabel: String): Option[String] = get[Option[String]](columnLabel)
+  def stringOpt(columnLabel: String): Option[String] = getOpt[String](columnLabel)
 
   def time(columnIndex: Int): java.sql.Time = get[java.sql.Time](columnIndex)
 
@@ -371,18 +371,18 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
     get[java.sql.Time](columnLabel)
   }
 
-  def timeOpt(columnIndex: Int): Option[java.sql.Time] = get[Option[java.sql.Time]](columnIndex)
+  def timeOpt(columnIndex: Int): Option[java.sql.Time] = getOpt[java.sql.Time](columnIndex)
 
-  def timeOpt(columnLabel: String): Option[java.sql.Time] = get[Option[java.sql.Time]](columnLabel)
+  def timeOpt(columnLabel: String): Option[java.sql.Time] = getOpt[java.sql.Time](columnLabel)
 
   def timeOpt(columnIndex: Int, cal: Calendar): Option[java.sql.Time] = {
     implicit val binder: TypeBinder[java.sql.Time] = TypeBinder((rs, i) => rs.getTime(i, cal))((rs, l) => rs.getTime(l, cal))
-    get[Option[java.sql.Time]](columnIndex)
+    getOpt[java.sql.Time](columnIndex)
   }
 
   def timeOpt(columnLabel: String, cal: Calendar): Option[java.sql.Time] = {
     implicit val binder: TypeBinder[java.sql.Time] = TypeBinder((rs, i) => rs.getTime(i, cal))((rs, l) => rs.getTime(l, cal))
-    get[Option[java.sql.Time]](columnLabel)
+    getOpt[java.sql.Time](columnLabel)
   }
 
   def timestamp(columnIndex: Int): java.sql.Timestamp = get[java.sql.Timestamp](columnIndex)
@@ -399,27 +399,27 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
     get[java.sql.Timestamp](columnLabel)
   }
 
-  def timestampOpt(columnIndex: Int): Option[java.sql.Timestamp] = get[Option[java.sql.Timestamp]](columnIndex)
+  def timestampOpt(columnIndex: Int): Option[java.sql.Timestamp] = getOpt[java.sql.Timestamp](columnIndex)
 
-  def timestampOpt(columnLabel: String): Option[java.sql.Timestamp] = get[Option[java.sql.Timestamp]](columnLabel)
+  def timestampOpt(columnLabel: String): Option[java.sql.Timestamp] = getOpt[java.sql.Timestamp](columnLabel)
 
   def timestampOpt(columnIndex: Int, cal: Calendar): Option[java.sql.Timestamp] = {
     implicit val binder: TypeBinder[java.sql.Timestamp] = TypeBinder((rs, i) => rs.getTimestamp(i, cal))((rs, l) => rs.getTimestamp(l, cal))
-    get[Option[java.sql.Timestamp]](columnIndex)
+    getOpt[java.sql.Timestamp](columnIndex)
   }
 
   def timestampOpt(columnLabel: String, cal: Calendar): Option[java.sql.Timestamp] = {
     implicit val binder: TypeBinder[java.sql.Timestamp] = TypeBinder((rs, i) => rs.getTimestamp(i, cal))((rs, l) => rs.getTimestamp(l, cal))
-    get[Option[java.sql.Timestamp]](columnLabel)
+    getOpt[java.sql.Timestamp](columnLabel)
   }
 
   def url(columnIndex: Int): java.net.URL = get[java.net.URL](columnIndex)
 
   def url(columnLabel: String): java.net.URL = get[java.net.URL](columnLabel)
 
-  def urlOpt(columnIndex: Int): Option[java.net.URL] = get[Option[java.net.URL]](columnIndex)
+  def urlOpt(columnIndex: Int): Option[java.net.URL] = getOpt[java.net.URL](columnIndex)
 
-  def urlOpt(columnLabel: String): Option[java.net.URL] = get[Option[java.net.URL]](columnLabel)
+  def urlOpt(columnLabel: String): Option[java.net.URL] = getOpt[java.net.URL](columnLabel)
 
   def dateTime(columnIndex: Int): ZonedDateTime = zonedDateTime(columnIndex)
   def dateTime(columnLabel: String): ZonedDateTime = zonedDateTime(columnLabel)
@@ -442,20 +442,20 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
   def dateTimeOpt(columnIndex: Int): Option[ZonedDateTime] = zonedDateTimeOpt(columnIndex)
   def dateTimeOpt(columnLabel: String): Option[ZonedDateTime] = zonedDateTimeOpt(columnLabel)
 
-  def zonedDateTimeOpt(columnIndex: Int): Option[ZonedDateTime] = get[Option[ZonedDateTime]](columnIndex)
-  def zonedDateTimeOpt(columnLabel: String): Option[ZonedDateTime] = get[Option[ZonedDateTime]](columnLabel)
+  def zonedDateTimeOpt(columnIndex: Int): Option[ZonedDateTime] = getOpt[ZonedDateTime](columnIndex)
+  def zonedDateTimeOpt(columnLabel: String): Option[ZonedDateTime] = getOpt[ZonedDateTime](columnLabel)
 
-  def offsetDateTimeOpt(columnIndex: Int): Option[OffsetDateTime] = get[Option[OffsetDateTime]](columnIndex)
-  def offsetDateTimeOpt(columnLabel: String): Option[OffsetDateTime] = get[Option[OffsetDateTime]](columnLabel)
+  def offsetDateTimeOpt(columnIndex: Int): Option[OffsetDateTime] = getOpt[OffsetDateTime](columnIndex)
+  def offsetDateTimeOpt(columnLabel: String): Option[OffsetDateTime] = getOpt[OffsetDateTime](columnLabel)
 
-  def localDateOpt(columnIndex: Int): Option[LocalDate] = get[Option[LocalDate]](columnIndex)
-  def localDateOpt(columnLabel: String): Option[LocalDate] = get[Option[LocalDate]](columnLabel)
+  def localDateOpt(columnIndex: Int): Option[LocalDate] = getOpt[LocalDate](columnIndex)
+  def localDateOpt(columnLabel: String): Option[LocalDate] = getOpt[LocalDate](columnLabel)
 
-  def localTimeOpt(columnIndex: Int): Option[LocalTime] = get[Option[LocalTime]](columnIndex)
-  def localTimeOpt(columnLabel: String): Option[LocalTime] = get[Option[LocalTime]](columnLabel)
+  def localTimeOpt(columnIndex: Int): Option[LocalTime] = getOpt[LocalTime](columnIndex)
+  def localTimeOpt(columnLabel: String): Option[LocalTime] = getOpt[LocalTime](columnLabel)
 
-  def localDateTimeOpt(columnIndex: Int): Option[LocalDateTime] = get[Option[LocalDateTime]](columnIndex)
-  def localDateTimeOpt(columnLabel: String): Option[LocalDateTime] = get[Option[LocalDateTime]](columnLabel)
+  def localDateTimeOpt(columnIndex: Int): Option[LocalDateTime] = getOpt[LocalDateTime](columnIndex)
+  def localDateTimeOpt(columnLabel: String): Option[LocalDateTime] = getOpt[LocalDateTime](columnLabel)
 
   def warnings: java.sql.SQLWarning = {
     ensureCursor()
@@ -478,6 +478,10 @@ case class WrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, inde
     ensureCursor()
     wrapIfError(implicitly[TypeBinder[A]].apply(underlying, columnLabel))
   }
+
+  def getOpt[A: TypeBinder](columnIndex: Int): Option[A] = get[Option[A]](columnIndex)
+
+  def getOpt[A: TypeBinder](columnLabel: String): Option[A] = get[Option[A]](columnLabel)
 
 }
 

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/PostgreSQL_JSON_Objects_Spec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/PostgreSQL_JSON_Objects_Spec.scala
@@ -103,19 +103,19 @@ class PostgreSQL_JSON_Objects_Spec extends AnyFlatSpec with Matchers with DBSett
 
       DB.readOnly { implicit s =>
         val apps: Seq[Option[String]] = sql"select config::jsonb->'applications' apps from $tableName order by id"
-          .map(_.get[Option[String]]("apps"))
+          .map(_.getOpt[String]("apps"))
           .list
           .apply()
         apps should equal(Seq(None, Some("""["frontend", "backend-api", "database"]""")))
 
         val credentials: Seq[Option[String]] = sql"select config::jsonb#>'{credentials,api-2}' c from $tableName order by id"
-          .map(_.get[Option[String]]("c"))
+          .map(_.getOpt[String]("c"))
           .list
           .apply()
         credentials should equal(Seq(Some("\"abcdef\""), None))
 
         val credentials2: Seq[Option[String]] = sql"select config::jsonb#>>'{credentials,api-2}' c from $tableName order by id"
-          .map(_.get[Option[String]]("c"))
+          .map(_.getOpt[String]("c"))
           .list
           .apply()
         credentials2 should equal(Seq(Some("abcdef"), None))

--- a/scalikejdbc-joda-time/src/main/scala/scalikejdbc/jodatime/JodaWrappedResultSet.scala
+++ b/scalikejdbc-joda-time/src/main/scala/scalikejdbc/jodatime/JodaWrappedResultSet.scala
@@ -47,17 +47,17 @@ case class JodaWrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, 
   def jodaLocalDateTime(columnIndex: Int): JodaLocalDateTime = get[JodaLocalDateTime](columnIndex)
   def jodaLocalDateTime(columnLabel: String): JodaLocalDateTime = get[JodaLocalDateTime](columnLabel)
 
-  def jodaDateTimeOpt(columnIndex: Int): Option[DateTime] = get[Option[DateTime]](columnIndex)
-  def jodaDateTimeOpt(columnLabel: String): Option[DateTime] = get[Option[DateTime]](columnLabel)
+  def jodaDateTimeOpt(columnIndex: Int): Option[DateTime] = getOpt[DateTime](columnIndex)
+  def jodaDateTimeOpt(columnLabel: String): Option[DateTime] = getOpt[DateTime](columnLabel)
 
-  def jodaLocalDateOpt(columnIndex: Int): Option[JodaLocalDate] = get[Option[JodaLocalDate]](columnIndex)
-  def jodaLocalDateOpt(columnLabel: String): Option[JodaLocalDate] = get[Option[JodaLocalDate]](columnLabel)
+  def jodaLocalDateOpt(columnIndex: Int): Option[JodaLocalDate] = getOpt[JodaLocalDate](columnIndex)
+  def jodaLocalDateOpt(columnLabel: String): Option[JodaLocalDate] = getOpt[JodaLocalDate](columnLabel)
 
-  def jodaLocalTimeOpt(columnIndex: Int): Option[JodaLocalTime] = get[Option[JodaLocalTime]](columnIndex)
-  def jodaLocalTimeOpt(columnLabel: String): Option[JodaLocalTime] = get[Option[JodaLocalTime]](columnLabel)
+  def jodaLocalTimeOpt(columnIndex: Int): Option[JodaLocalTime] = getOpt[JodaLocalTime](columnIndex)
+  def jodaLocalTimeOpt(columnLabel: String): Option[JodaLocalTime] = getOpt[JodaLocalTime](columnLabel)
 
-  def jodaLocalDateTimeOpt(columnIndex: Int): Option[JodaLocalDateTime] = get[Option[JodaLocalDateTime]](columnIndex)
-  def jodaLocalDateTimeOpt(columnLabel: String): Option[JodaLocalDateTime] = get[Option[JodaLocalDateTime]](columnLabel)
+  def jodaLocalDateTimeOpt(columnIndex: Int): Option[JodaLocalDateTime] = getOpt[JodaLocalDateTime](columnIndex)
+  def jodaLocalDateTimeOpt(columnLabel: String): Option[JodaLocalDateTime] = getOpt[JodaLocalDateTime](columnLabel)
 
   private[this] def get[A: TypeBinder](columnIndex: Int): A = {
     ensureCursor()
@@ -68,6 +68,10 @@ case class JodaWrappedResultSet(underlying: ResultSet, cursor: ResultSetCursor, 
     ensureCursor()
     wrapIfError(implicitly[TypeBinder[A]].apply(underlying, columnLabel))
   }
+
+  private[this] def getOpt[A: TypeBinder](columnIndex: Int): Option[A] = get[Option[A]](columnIndex)
+
+  private[this] def getOpt[A: TypeBinder](columnLabel: String): Option[A] = get[Option[A]](columnLabel)
 
 }
 


### PR DESCRIPTION
This PR adds a new helper method `getOpt`.
it is quite tedious to write `rs.get[Option[MyClass]]` every time when you need to extract a nullable field. I know that type inference can help in these cases, but sometimes it is better to write desired types explicitly.
Also, methods like `stringOpt` or `dateOpt` already exist, so I think it would be nice to have an explicit `getOpt` method.