### PR TITLE
support SQL contains non-ascii characters

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/SQLTemplateParser.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/SQLTemplateParser.scala
@@ -137,6 +137,6 @@ object SQLTemplateParser extends JavaTokenParsers with LogSupport {
   // square brackets are allowed in T-SQL
   // colon are allowed for postgres type cast
   private def token: Parser[String] =
-    "[\\w\\(\\)\\.\\-\\+\\*&|!/=,<>%;`\\[\\]:]+".r ^^ (_ => "")
+    "(?U)[\\w\\(\\)\\.\\-\\+\\*&|!/=,<>%;`\\[\\]:]+".r ^^ (_ => "")
 
 }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/SQLTemplateParserSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/SQLTemplateParserSpec.scala
@@ -254,6 +254,6 @@ users"""
     val sql = "SELECT 名前 FROM ユーザ WHERE user_id = {id})"
     val params = SQLTemplateParser.extractAllParameters(sql)
     params.size should equal(1)
-    params.head should equal('id)
+    params.head should equal("id")
   }
 }

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/SQLTemplateParserSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/SQLTemplateParserSpec.scala
@@ -249,4 +249,11 @@ users"""
     SQLTemplateParser.convertToSQLWithPlaceHolders(sql) should equal(expected)
   }
 
+  //https://github.com/scalikejdbc/scalikejdbc/issues/967
+  it should "support SQL contains non-ascii characters" in {
+    val sql = "SELECT 名前 FROM ユーザ WHERE user_id = {id})"
+    val params = SQLTemplateParser.extractAllParameters(sql)
+    params.size should equal(1)
+    params.head should equal('id)
+  }
 }


### PR DESCRIPTION
this is a PR to improve issue #967 

- simple solution using UNICODE_CHARACTER_CLASS.
- no impact to current behavior unless parsing huge SQL sentence. 

thank you.