### PR TITLE
version 4.0.0-RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ def Scala3 = "3.0.1-RC2"
 def Scala212 = "2.12.14"
 def Scala213 = "2.13.6"
 
-ThisBuild / version := "4.0.0-SNAPSHOT"
+ThisBuild / version := "4.0.0-RC2"
 
 val isScala3 = Def.setting(
   CrossVersion.partialVersion(scalaVersion.value).exists(_._1 == 3)

--- a/notes/4.0.0.markdown
+++ b/notes/4.0.0.markdown
@@ -9,6 +9,7 @@ Thanks for all the contributors for this release :+1:
 * @myazinn added `getOpt` method to `WrappedResultSet` for more convenience!
 * @dieselmat improved the mapper-generator to support more table name patterns like `TABLE_1_2_3`!
 * @capacman pointed "Working with IO monads" document issue and @matil019 resolved the issue in both the document and code examples!
+* @osiire enabled non-ascii character support in SQL templates
 
 Refer to [this release's GitHub milestone](https://github.com/scalikejdbc/scalikejdbc/milestone/44?closed=1) for all the pull requests by awesome contributors!
 


### PR DESCRIPTION
We're releasing the second RC version of v4.0.0

If I catch all the things, here is the comprehensive list of human's contributions (I didn't add PRs by bots): https://github.com/scalikejdbc/scalikejdbc/milestone/44?closed=1