### PR TITLE
fix scala 3 warnings

### DIFF
--- a/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfig.scala
+++ b/scalikejdbc-config/src/main/scala/scalikejdbc/config/TypesafeConfig.scala
@@ -6,5 +6,5 @@ import com.typesafe.config.Config
  * A Trait that holds configuration
  */
 trait TypesafeConfig {
-  val config: Config
+  def config: Config
 }

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DBSession.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DBSession.scala
@@ -32,7 +32,7 @@ trait DBSession extends LogSupport with LoanPattern with AutoCloseable {
 
   private[scalikejdbc] val conn: Connection
 
-  private[scalikejdbc] val connectionAttributes: DBConnectionAttributes
+  private[scalikejdbc] def connectionAttributes: DBConnectionAttributes
 
   /**
    * Returns current transaction if exists.

--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
@@ -345,7 +345,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
     /**
      * Delimiter for alias names in SQL.
      */
-    val delimiterForResultName: String
+    def delimiterForResultName: String
 
     /**
      * True if you need to convert field names to snake_case column names in SQL.


### PR DESCRIPTION
```
scala> trait A { val a: String } ; class B extends A { lazy val a: String = "a" }
1 |trait A { val a: String } ; class B extends A { lazy val a: String = "a" }
  |                                                         ^
  |           error overriding value a in trait A of type String;
  |             lazy value a of type String may not override a non-lazy value

scala> trait A { def a: String } ; class B extends A { lazy val a: String = "a" }                                                                                                                                                    
// defined trait A
// defined class B
```