### PR TITLE
Fix snake_case names with acronyms both in the middle and at the end

### DIFF
--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
@@ -384,7 +384,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
 
     private val acronymRegExpStr = "[A-Z]{2,}"
     private val acronymRegExp = acronymRegExpStr.r
-    private val endsWithAcronymRegExpStr = "[A-Z]{2,}$"
+    private val endsWithAcronymRegExp = "[A-Z]{2,}$".r
     private val singleUpperCaseRegExp = """[A-Z]""".r
 
     /**
@@ -403,15 +403,11 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
       }
       if (useSnakeCaseColumnName) {
         val acronymsFiltered = acronymRegExp.replaceAllIn(
-          acronymRegExp
-            .findFirstMatchIn(convertersApplied)
-            .map { m =>
-              convertersApplied.replaceFirst(
-                endsWithAcronymRegExpStr,
-                "_" + m.matched.toLowerCase(en)
-              )
-            }
-            .getOrElse(convertersApplied), // might end with an acronym
+          endsWithAcronymRegExp
+            .replaceAllIn(
+              convertersApplied,
+              { m => "_" + m.matched.toLowerCase(en) }
+            ), // might end with an acronym
           { m =>
             "_" + m.matched.init.toLowerCase(en) + "_" + m.matched.last.toString
               .toLowerCase(en)

--- a/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
+++ b/scalikejdbc-interpolation/src/test/scala/scalikejdbc/SQLInterpolationSpec.scala
@@ -47,6 +47,9 @@ class SQLInterpolationSpec
       Map("wonderful" -> ""),
       true
     ) should equal("my_html")
+    SQLSyntaxProvider.toColumnName("mySQLAsHTML", Map(), true) should equal(
+      "my_sql_as_html"
+    )
 
     SQLSyntaxProvider.toColumnName("firstName", Map(), false) should equal(
       "firstName"


### PR DESCRIPTION
For example, `mySQLAsHTML` was getting converted to `my_sql_as_sqla`.

It’s been doing this since the very moment case conversion was introduced in 8a0797e4a529da3694c2d73e8462b61b7a956ef9 in 2013.

This is technically a breaking change. It’s hard to imagine anyone _willingly_ relying on the old behaviour, but I could totally see someone “hitting it until it works” and using the broken names in their database just to appease ScalikeJDBC. It’s your call as to how/where to integrate/backport this.