### PR TITLE
Support for type casts (#893)

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
@@ -92,7 +92,7 @@ private[scalikejdbc] case class ContramappedParameterBinder(
 
 private[scalikejdbc] case class TypedParameterBinder[A, B](
   value: A,
-  dbType: SQLSyntax,
+  typeName: SQLSyntax,
   contramap: A => B
 ) extends ParameterBinderWithValue {
   def apply(stmt: PreparedStatement, idx: Int): Unit = {

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
@@ -92,7 +92,7 @@ private[scalikejdbc] case class ContramappedParameterBinder(
 
 private[scalikejdbc] case class TypedParameterBinder[A, B](
   value: A,
-  dbType: String,
+  dbType: SQLSyntax,
   contramap: A => B
 ) extends ParameterBinderWithValue {
   def apply(stmt: PreparedStatement, idx: Int): Unit = {

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinder.scala
@@ -90,6 +90,16 @@ private[scalikejdbc] case class ContramappedParameterBinder(
   def apply(stmt: PreparedStatement, idx: Int): Unit = underlying(stmt, idx)
 }
 
+private[scalikejdbc] case class TypedParameterBinder[A, B](
+  value: A,
+  dbType: String,
+  contramap: A => B
+) extends ParameterBinderWithValue {
+  def apply(stmt: PreparedStatement, idx: Int): Unit = {
+    stmt.setObject(idx, contramap(value))
+  }
+}
+
 // ------------------------------------------------------------------------------
 
 /**

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinderFactory.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinderFactory.scala
@@ -145,6 +145,12 @@ object ParameterBinderFactory
     : ParameterBinderFactory[SQLSyntax] =
     (value: SQLSyntax) => SQLSyntaxParameterBinder(value)
 
+  def typedParameterBinderFactory[A, B](
+    dbType: String,
+    contramap: A => B
+  ): ParameterBinderFactory[A] =
+    (value: A) => TypedParameterBinder(value, dbType, contramap)
+
   implicit val optionalSqlSyntaxParameterBinderFactory
     : ParameterBinderFactory[Option[SQLSyntax]] =
     (value: Option[SQLSyntax]) => {

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinderFactory.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinderFactory.scala
@@ -146,10 +146,10 @@ object ParameterBinderFactory
     (value: SQLSyntax) => SQLSyntaxParameterBinder(value)
 
   def typedParameterBinderFactory[A, B](
-    dbType: String,
+    typeName: String,
     contramap: A => B
   ): ParameterBinderFactory[A] =
-    (value: A) => TypedParameterBinder(value, SQLSyntax(dbType), contramap)
+    (value: A) => TypedParameterBinder(value, SQLSyntax(typeName), contramap)
 
   implicit val optionalSqlSyntaxParameterBinderFactory
     : ParameterBinderFactory[Option[SQLSyntax]] =

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinderFactory.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/ParameterBinderFactory.scala
@@ -149,7 +149,7 @@ object ParameterBinderFactory
     dbType: String,
     contramap: A => B
   ): ParameterBinderFactory[A] =
-    (value: A) => TypedParameterBinder(value, dbType, contramap)
+    (value: A) => TypedParameterBinder(value, SQLSyntax(dbType), contramap)
 
   implicit val optionalSqlSyntaxParameterBinderFactory
     : ParameterBinderFactory[Option[SQLSyntax]] =

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/SQLInterpolationString.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/SQLInterpolationString.scala
@@ -47,6 +47,7 @@ class SQLInterpolationString(private val s: StringContext) extends AnyVal {
           .map {
             case SQLSyntax(s, _)                           => s
             case SQLSyntaxParameterBinder(SQLSyntax(s, _)) => s
+            case TypedParameterBinder(_, dbType, _)        => "? :: " + dbType
             case _                                         => "?"
           }
           .addString(sb, ", ")
@@ -54,6 +55,7 @@ class SQLInterpolationString(private val s: StringContext) extends AnyVal {
       case LastParameter                             => sb
       case SQLSyntax(s, _)                           => sb ++= s
       case SQLSyntaxParameterBinder(SQLSyntax(s, _)) => sb ++= s
+      case TypedParameterBinder(_, dbType, _)        => sb ++= "? :: " + dbType
       case _                                         => sb += '?'
     }
 

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/SQLInterpolationString.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/SQLInterpolationString.scala
@@ -47,8 +47,8 @@ class SQLInterpolationString(private val s: StringContext) extends AnyVal {
           .map {
             case SQLSyntax(s, _)                           => s
             case SQLSyntaxParameterBinder(SQLSyntax(s, _)) => s
-            case TypedParameterBinder(_, SQLSyntax(dbType, _), _) =>
-              "? :: " + dbType
+            case TypedParameterBinder(_, SQLSyntax(typeName, _), _) =>
+              "? :: " + typeName
             case _ => "?"
           }
           .addString(sb, ", ")
@@ -56,8 +56,8 @@ class SQLInterpolationString(private val s: StringContext) extends AnyVal {
       case LastParameter                             => sb
       case SQLSyntax(s, _)                           => sb ++= s
       case SQLSyntaxParameterBinder(SQLSyntax(s, _)) => sb ++= s
-      case TypedParameterBinder(_, SQLSyntax(dbType, _), _) =>
-        sb ++= "? :: " + dbType
+      case TypedParameterBinder(_, SQLSyntax(typeName, _), _) =>
+        sb ++= "? :: " + typeName
       case _ => sb += '?'
     }
 

--- a/scalikejdbc-core/src/main/scala/scalikejdbc/SQLInterpolationString.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/SQLInterpolationString.scala
@@ -47,16 +47,18 @@ class SQLInterpolationString(private val s: StringContext) extends AnyVal {
           .map {
             case SQLSyntax(s, _)                           => s
             case SQLSyntaxParameterBinder(SQLSyntax(s, _)) => s
-            case TypedParameterBinder(_, dbType, _)        => "? :: " + dbType
-            case _                                         => "?"
+            case TypedParameterBinder(_, SQLSyntax(dbType, _), _) =>
+              "? :: " + dbType
+            case _ => "?"
           }
           .addString(sb, ", ")
       }
       case LastParameter                             => sb
       case SQLSyntax(s, _)                           => sb ++= s
       case SQLSyntaxParameterBinder(SQLSyntax(s, _)) => sb ++= s
-      case TypedParameterBinder(_, dbType, _)        => sb ++= "? :: " + dbType
-      case _                                         => sb += '?'
+      case TypedParameterBinder(_, SQLSyntax(dbType, _), _) =>
+        sb ++= "? :: " + dbType
+      case _ => sb += '?'
     }
 
   private def buildParams(params: collection.Seq[Any]): collection.Seq[Any] =

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DB_MetaDataSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DB_MetaDataSpec.scala
@@ -616,6 +616,26 @@ class DB_MetaDataSpec
 
   }
 
+  it should "PostgreSQL enum" in {
+    if (driverClassName == "org.postgresql.Driver") {
+      DB autoCommit { implicit s =>
+        execute("drop table if exists enum_test")
+        execute("drop type if exists some_enum")
+        execute("create type some_enum as enum ('Foo', 'Bar')")
+        execute("""
+                  create table enum_test(
+                    enum_column some_enum not null
+                  );
+                  """)
+      }
+      DB.getTable("enum_test")
+        .get
+        .columns
+        .filter(_.name.toLowerCase == "enum_column")
+        .map(m => m.typeName) should contain("some_enum")
+    }
+  }
+
   private def execute(sqls: String*)(implicit session: DBSession): Unit = {
     @annotation.tailrec
     def loop(xs: List[String], errors: List[Throwable]): Unit = {

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DB_MetaDataSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DB_MetaDataSpec.scala
@@ -616,7 +616,7 @@ class DB_MetaDataSpec
 
   }
 
-  it should "PostgreSQL enum" in {
+  it should "accept PostgreSQL enum parameters" in {
     if (driverClassName == "org.postgresql.Driver") {
       DB autoCommit { implicit s =>
         execute("drop table if exists enum_test")

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/SQLInterpolationStringSuite.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/SQLInterpolationStringSuite.scala
@@ -4,6 +4,7 @@ import java.{ util => ju }
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import scalikejdbc.interpolation.SQLSyntax
 
 class SQLInterpolationStringSuite extends AnyFlatSpec with Matchers {
 
@@ -43,7 +44,7 @@ class SQLInterpolationStringSuite extends AnyFlatSpec with Matchers {
   it should "interpolate TypedParameterBinder" in {
     val binder = TypedParameterBinder[EnumLike, String](
       EnumLike.Foo,
-      "enum_like",
+      SQLSyntax("enum_like"),
       _.toString
     )
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/SQLInterpolationStringSuite.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/SQLInterpolationStringSuite.scala
@@ -44,7 +44,7 @@ class SQLInterpolationStringSuite extends AnyFlatSpec with Matchers {
   it should "interpolate TypedParameterBinder" in {
     val binder = TypedParameterBinder[EnumLike, String](
       EnumLike.Foo,
-      SQLSyntax("enum_like"),
+      sqls"enum_like",
       _.toString
     )
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/SQLInterpolationStringSuite.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/SQLInterpolationStringSuite.scala
@@ -40,6 +40,18 @@ class SQLInterpolationStringSuite extends AnyFlatSpec with Matchers {
     s.parameters should equal(List(1, 2, 3))
   }
 
+  it should "interpolate TypedParameterBinder" in {
+    val binder = TypedParameterBinder[EnumLike, String](
+      EnumLike.Foo,
+      "enum_like",
+      _.toString
+    )
+
+    val s = sqls"s = $binder"
+    s.value should equal("s = ? :: enum_like")
+    s.parameters should equal(Seq(EnumLike.Foo))
+  }
+
   it should "strip margin by stripMargin" in {
     sql"""SELECT
          |${1}


### PR DESCRIPTION
I want to use PostgresSQL enum, so I tried to support it.

Sample code

```scala
object CustomType {
  implicit val customTypeParameterBinderFactory: ParameterBinderFactory[CustomType] =
    typedParameterBinderFactory("custom_type", _.value)
}
```
