### PR TITLE
fix warnings

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/SQL.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/SQL.scala
@@ -1092,8 +1092,6 @@ trait SQLToResult[A, E <: WithExtractor, C[_]]
   import GeneralizedTypeConstraintsForWithExtractor._
 
   def result[AA](f: WrappedResultSet => AA, session: DBSession): C[AA]
-  val statement: String
-  private[scalikejdbc] val rawParameters: scala.collection.Seq[Any]
   def apply()(implicit
     session: DBSession,
     context: ConnectionPoolContext = NoConnectionPoolContext,
@@ -1184,8 +1182,6 @@ trait SQLToCollection[A, E <: WithExtractor]
   extends SQL[A, E]
   with Extractor[A] {
   import GeneralizedTypeConstraintsForWithExtractor._
-  val statement: String
-  private[scalikejdbc] val rawParameters: scala.collection.Seq[Any]
   def apply[C[_]]()(implicit
     session: DBSession,
     context: ConnectionPoolContext = NoConnectionPoolContext,


### PR DESCRIPTION
```
$ scala -deprecation
Welcome to Scala 3.3.0 (11.0.19, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.

scala> class A(val x: Int); trait B extends A { val x: Int }
1 warning found
-- Deprecation Warning: --------------------------------------------------------
1 |class A(val x: Int); trait B extends A { val x: Int }
  |                                             ^
  |overriding val parameter value x in class A is deprecated, will be illegal in a future version
```