### PR TITLE
[ScalikejdbcPlugin] add config  `jdbc.database`

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.7

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.8

--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/Model.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/Model.scala
@@ -55,14 +55,13 @@ case class Model(url: String, username: String, password: String)
     }
   }
 
-  def allTables(schema: String = null): collection.Seq[Table] =
-    listAllTables(schema, List("TABLE")).flatMap(table(schema, _))
+  def allTables(schema: String = null, catalog: String = null): collection.Seq[Table] =
+    listAllTables(schema, List("TABLE")).flatMap(table(schema, _, catalog))
 
-  def allViews(schema: String = null): collection.Seq[Table] =
-    listAllTables(schema, List("VIEW")).flatMap(table(schema, _))
+  def allViews(schema: String = null, catalog: String = null): collection.Seq[Table] =
+    listAllTables(schema, List("VIEW")).flatMap(table(schema, _, catalog))
 
-  def table(schema: String = null, tableName: String): Option[Table] = {
-    val catalog = null
+  def table(schema: String = null, tableName: String, catalog: String = null): Option[Table] = {
     val _schema = if (schema == null || schema.isEmpty) null else schema
     using(ConnectionPool.get(poolName).borrow()) { conn =>
       val meta = conn.getMetaData

--- a/scalikejdbc-mapper-generator-core/src/test/scala/MapperGeneratorWithH2Spec.scala
+++ b/scalikejdbc-mapper-generator-core/src/test/scala/MapperGeneratorWithH2Spec.scala
@@ -213,6 +213,40 @@ class MapperGeneratorWithH2Spec extends AnyFlatSpec with Matchers {
     Thread.sleep(500)
   }
 
+  it should "work fine with tableName_same_to_metatable" in {
+    DB autoCommit { implicit session =>
+      SQL("""
+        create table "TABLES" (
+          SCALIKEJDBC varchar(30) not null
+        )
+      """).execute.apply()
+    }
+    Model(url, username, password).table("INFORMATION_SCHEMA", "TABLES", "MAPPER_GENERATOR_H2").map { table =>
+      if (table.allColumns.map(_.name).contains("SCALIKEJDBC")){
+        fail("the table generate extra column")
+      }
+      val generator = new CodeGenerator(table)(
+        GeneratorConfig(srcDir = srcDir, packageName = "com.example")
+      )
+      generator.writeModel()
+    } getOrElse {
+      fail("The table is not found.")
+    }
+
+    Model(url, username, password).table("PUBLIC", "TABLES", "MAPPER_GENERATOR_H2").map { table =>
+      if (!table.allColumns.map(_.name).contains("SCALIKEJDBC")){
+        fail("the table does not generate specify column")
+      }
+      val generator = new CodeGenerator(table)(
+        GeneratorConfig(srcDir = srcDir, packageName = "com.example")
+      )
+      generator.writeModel()
+    } getOrElse {
+      fail("The table is not found.")
+    }
+    Thread.sleep(500)
+  }
+
   it should "skip the table if skip settings contain the name of table" in {
     DB autoCommit { implicit session =>
       // Here is an example of flyway metadata table.

--- a/scalikejdbc-mapper-generator/src/main/scala/scalikejdbc/mapper/ScalikejdbcPlugin.scala
+++ b/scalikejdbc-mapper-generator/src/main/scala/scalikejdbc/mapper/ScalikejdbcPlugin.scala
@@ -319,7 +319,7 @@ object ScalikejdbcPlugin extends AutoPlugin {
     clazz: Option[String]
   )
 
-  import complete.DefaultParsers.*
+  import complete.DefaultParsers._
 
   private def genTaskParser(
     keyName: String


### PR DESCRIPTION
# Motivation:
close #2126 
most databse use  `catalog.schema.table` to locate the table.
And now the catalog is allways null.  for some database like mysql, the schema is null, and the database is catalogName.
for h2, the default schema is PUBLIC, for Postgresql, the default schema is PUBLIC，and pg can create a schema by `CREATE SCHEMA schema_name;`

# Test:
add a test for H2, and test inlocaly for mysql


