### PR TITLE
Fix generation error of tables with the same table name belong to different catalogs/schemas

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.7

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.8

--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/Model.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/Model.scala
@@ -61,7 +61,11 @@ case class Model(url: String, username: String, password: String)
   def allViews(schema: String = null): collection.Seq[Table] =
     listAllTables(schema, List("VIEW")).flatMap(t => table(schema, t._2, t._1))
 
-  def table(schema: String = null, tableName: String, catalog: String = null): Option[Table] = {
+  def table(
+    schema: String = null,
+    tableName: String,
+    catalog: String = null
+  ): Option[Table] = {
     val _schema = if (schema == null || schema.isEmpty) null else schema
     using(ConnectionPool.get(poolName).borrow()) { conn =>
       val meta = conn.getMetaData

--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/Model.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/Model.scala
@@ -38,7 +38,7 @@ case class Model(url: String, username: String, password: String)
   private[this] def listAllTables(
     schema: String,
     types: List[String]
-  ): collection.Seq[String] = {
+  ): collection.Seq[(String, String)] = {
     using(ConnectionPool.get(poolName).borrow()) { conn =>
       val meta = conn.getMetaData
       val (catalog, _schema) = {
@@ -51,18 +51,17 @@ case class Model(url: String, username: String, password: String)
       }
       new ResultSetIterator(
         meta.getTables(catalog, _schema, "%", types.toArray)
-      ).map { _.string("TABLE_NAME") }.toList
+      ).map(rs => (rs.string("TABLE_CAT"), rs.string("TABLE_NAME"))).toList
     }
   }
 
   def allTables(schema: String = null): collection.Seq[Table] =
-    listAllTables(schema, List("TABLE")).flatMap(table(schema, _))
+    listAllTables(schema, List("TABLE")).flatMap(t => table(schema, t._2, t._1))
 
   def allViews(schema: String = null): collection.Seq[Table] =
-    listAllTables(schema, List("VIEW")).flatMap(table(schema, _))
+    listAllTables(schema, List("VIEW")).flatMap(t => table(schema, t._2, t._1))
 
-  def table(schema: String = null, tableName: String): Option[Table] = {
-    val catalog = null
+  def table(schema: String = null, tableName: String, catalog: String = null): Option[Table] = {
     val _schema = if (schema == null || schema.isEmpty) null else schema
     using(ConnectionPool.get(poolName).borrow()) { conn =>
       val meta = conn.getMetaData

--- a/scalikejdbc-mapper-generator-core/src/test/scala/MapperGeneratorWithH2Spec.scala
+++ b/scalikejdbc-mapper-generator-core/src/test/scala/MapperGeneratorWithH2Spec.scala
@@ -323,27 +323,31 @@ class MapperGeneratorWithH2Spec extends AnyFlatSpec with Matchers {
         )
       """).execute.apply()
     }
-    Model(url, username, password).table("INFORMATION_SCHEMA", "TABLES", "MAPPER_GENERATOR_H2").map { table =>
-      if (table.allColumns.map(_.name).contains("SCALIKEJDBC")){
-        fail("the table generate extra column")
-      }
-      val generator = new CodeGenerator(table)(
-        GeneratorConfig(srcDir = srcDir, packageName = "com.example")
-      )
-      generator.writeModel()
-    } getOrElse {
+    Model(url, username, password)
+      .table("INFORMATION_SCHEMA", "TABLES", "MAPPER_GENERATOR_H2")
+      .map { table =>
+        if (table.allColumns.map(_.name).contains("SCALIKEJDBC")) {
+          fail("the table generate extra column")
+        }
+        val generator = new CodeGenerator(table)(
+          GeneratorConfig(srcDir = srcDir, packageName = "com.example")
+        )
+        generator.writeModel()
+      } getOrElse {
       fail("The table is not found.")
     }
 
-    Model(url, username, password).table("PUBLIC", "TABLES", "MAPPER_GENERATOR_H2").map { table =>
-      if (!table.allColumns.map(_.name).contains("SCALIKEJDBC")){
-        fail("the table does not generate specify column")
-      }
-      val generator = new CodeGenerator(table)(
-        GeneratorConfig(srcDir = srcDir, packageName = "com.example")
-      )
-      generator.writeModel()
-    } getOrElse {
+    Model(url, username, password)
+      .table("PUBLIC", "TABLES", "MAPPER_GENERATOR_H2")
+      .map { table =>
+        if (!table.allColumns.map(_.name).contains("SCALIKEJDBC")) {
+          fail("the table does not generate specify column")
+        }
+        val generator = new CodeGenerator(table)(
+          GeneratorConfig(srcDir = srcDir, packageName = "com.example")
+        )
+        generator.writeModel()
+      } getOrElse {
       fail("The table is not found.")
     }
     Thread.sleep(500)

--- a/scalikejdbc-mapper-generator-core/src/test/scala/MapperGeneratorWithH2Spec.scala
+++ b/scalikejdbc-mapper-generator-core/src/test/scala/MapperGeneratorWithH2Spec.scala
@@ -213,40 +213,6 @@ class MapperGeneratorWithH2Spec extends AnyFlatSpec with Matchers {
     Thread.sleep(500)
   }
 
-  it should "work fine with tableName_same_to_metatable" in {
-    DB autoCommit { implicit session =>
-      SQL("""
-        create table "TABLES" (
-          SCALIKEJDBC varchar(30) not null
-        )
-      """).execute.apply()
-    }
-    Model(url, username, password).table("INFORMATION_SCHEMA", "TABLES", "MAPPER_GENERATOR_H2").map { table =>
-      if (table.allColumns.map(_.name).contains("SCALIKEJDBC")){
-        fail("the table generate extra column")
-      }
-      val generator = new CodeGenerator(table)(
-        GeneratorConfig(srcDir = srcDir, packageName = "com.example")
-      )
-      generator.writeModel()
-    } getOrElse {
-      fail("The table is not found.")
-    }
-
-    Model(url, username, password).table("PUBLIC", "TABLES", "MAPPER_GENERATOR_H2").map { table =>
-      if (!table.allColumns.map(_.name).contains("SCALIKEJDBC")){
-        fail("the table does not generate specify column")
-      }
-      val generator = new CodeGenerator(table)(
-        GeneratorConfig(srcDir = srcDir, packageName = "com.example")
-      )
-      generator.writeModel()
-    } getOrElse {
-      fail("The table is not found.")
-    }
-    Thread.sleep(500)
-  }
-
   it should "skip the table if skip settings contain the name of table" in {
     DB autoCommit { implicit session =>
       // Here is an example of flyway metadata table.
@@ -347,5 +313,39 @@ class MapperGeneratorWithH2Spec extends AnyFlatSpec with Matchers {
     } getOrElse {
       fail("The table is not found.")
     }
+  }
+
+  it should "work fine with tableName_same_to_metatable" in {
+    DB autoCommit { implicit session =>
+      SQL("""
+        create table "TABLES" (
+          SCALIKEJDBC varchar(30) not null
+        )
+      """).execute.apply()
+    }
+    Model(url, username, password).table("INFORMATION_SCHEMA", "TABLES", "MAPPER_GENERATOR_H2").map { table =>
+      if (table.allColumns.map(_.name).contains("SCALIKEJDBC")){
+        fail("the table generate extra column")
+      }
+      val generator = new CodeGenerator(table)(
+        GeneratorConfig(srcDir = srcDir, packageName = "com.example")
+      )
+      generator.writeModel()
+    } getOrElse {
+      fail("The table is not found.")
+    }
+
+    Model(url, username, password).table("PUBLIC", "TABLES", "MAPPER_GENERATOR_H2").map { table =>
+      if (!table.allColumns.map(_.name).contains("SCALIKEJDBC")){
+        fail("the table does not generate specify column")
+      }
+      val generator = new CodeGenerator(table)(
+        GeneratorConfig(srcDir = srcDir, packageName = "com.example")
+      )
+      generator.writeModel()
+    } getOrElse {
+      fail("The table is not found.")
+    }
+    Thread.sleep(500)
   }
 }

--- a/scalikejdbc-mapper-generator-core/src/test/scala/MapperGeneratorWithH2Spec.scala
+++ b/scalikejdbc-mapper-generator-core/src/test/scala/MapperGeneratorWithH2Spec.scala
@@ -213,6 +213,40 @@ class MapperGeneratorWithH2Spec extends AnyFlatSpec with Matchers {
     Thread.sleep(500)
   }
 
+  it should "work fine with tableName_same_to_metatable" in {
+    DB autoCommit { implicit session =>
+      SQL("""
+        create table "TABLES" (
+          SCALIKEJDBC varchar(30) not null
+        )
+      """).execute.apply()
+    }
+    Model(url, username, password).table("INFORMATION_SCHEMA", "TABLES", "MAPPER_GENERATOR_H2").map { table =>
+      if (table.allColumns.map(_.name).contains("SCALIKEJDBC")){
+        fail("the table generate extra column")
+      }
+      val generator = new CodeGenerator(table)(
+        GeneratorConfig(srcDir = srcDir, packageName = "com.example")
+      )
+      generator.writeModel()
+    } getOrElse {
+      fail("The table is not found.")
+    }
+
+    Model(url, username, password).table("PUBLIC", "TABLES", "MAPPER_GENERATOR_H2").map { table =>
+      if (!table.allColumns.map(_.name).contains("SCALIKEJDBC")){
+        fail("the table does not generate specify column")
+      }
+      val generator = new CodeGenerator(table)(
+        GeneratorConfig(srcDir = srcDir, packageName = "com.example")
+      )
+      generator.writeModel()
+    } getOrElse {
+      fail("The table is not found.")
+    }
+    Thread.sleep(500)
+  }
+
   it should "skip the table if skip settings contain the name of table" in {
     DB autoCommit { implicit session =>
       // Here is an example of flyway metadata table.


### PR DESCRIPTION
## motivation
close #2126 
most databse use catalog.schema.table to locate the table.
And now the catalog is allways null. and listAllTables only return Seq(tableName)，it will cause unable to filter table correctly.
## how to
add catalog to scalikejdbc.mapper.Model#table
and scalikejdbc.mapper.Model#listAllTables show return the Seq(catalogName, tableName)
## test
add a test for H2, and test inlocaly for mysql