### PR TITLE
[scalikejdbc-mapper-generator] improve generate code that remove unnecessnary braces

### DIFF
--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
@@ -1,6 +1,6 @@
 package scalikejdbc.mapper
 
-import scalikejdbc.*
+import scalikejdbc._
 import scala.language.implicitConversions
 
 /**
@@ -11,8 +11,8 @@ class CodeGenerator(table: Table, specifiedClassName: Option[String] = None)(
 ) extends Generator
   with LoanPattern {
 
-  import java.sql.JDBCType as JavaSqlTypes
-  import java.io.{File, FileOutputStream, OutputStreamWriter}
+  import java.sql.{ JDBCType => JavaSqlTypes }
+  import java.io.{ OutputStreamWriter, FileOutputStream, File }
 
   private val packageName = config.packageName
   private val className =
@@ -830,7 +830,7 @@ class CodeGenerator(table: Table, specifiedClassName: Option[String] = None)(
 
     table.allColumns.map(_.rawTypeInScala).filter(timeClasses) match {
       case classes if classes.nonEmpty =>
-        val (l,r)= if(classes.size==1) ("","") else ("{","}")
+        val (l,r)= if(classes.size==1) ("", "") else ("{", "}")
         if (config.dateTimeClass == DateTimeClass.JodaDateTime) {
           "import org.joda.time." + classes.distinct.mkString(l, ", ", r) + eol +
             "import scalikejdbc.jodatime.JodaParameterBinderFactory._" + eol +

--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
@@ -830,9 +830,13 @@ class CodeGenerator(table: Table, specifiedClassName: Option[String] = None)(
 
     table.allColumns.map(_.rawTypeInScala).filter(timeClasses) match {
       case classes if classes.nonEmpty =>
-        val (l,r)= if(classes.size==1) ("", "") else ("{", "}")
+        val (l, r) = if (classes.size == 1) ("", "") else ("{", "}")
         if (config.dateTimeClass == DateTimeClass.JodaDateTime) {
-          "import org.joda.time." + classes.distinct.mkString(l, ", ", r) + eol +
+          "import org.joda.time." + classes.distinct.mkString(
+            l,
+            ", ",
+            r
+          ) + eol +
             "import scalikejdbc.jodatime.JodaParameterBinderFactory._" + eol +
             "import scalikejdbc.jodatime.JodaTypeBinder._" + eol
         } else {

--- a/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
+++ b/scalikejdbc-mapper-generator-core/src/main/scala/scalikejdbc/mapper/CodeGenerator.scala
@@ -1,6 +1,6 @@
 package scalikejdbc.mapper
 
-import scalikejdbc._
+import scalikejdbc.*
 import scala.language.implicitConversions
 
 /**
@@ -11,8 +11,8 @@ class CodeGenerator(table: Table, specifiedClassName: Option[String] = None)(
 ) extends Generator
   with LoanPattern {
 
-  import java.sql.{ JDBCType => JavaSqlTypes }
-  import java.io.{ OutputStreamWriter, FileOutputStream, File }
+  import java.sql.JDBCType as JavaSqlTypes
+  import java.io.{File, FileOutputStream, OutputStreamWriter}
 
   private val packageName = config.packageName
   private val className =
@@ -830,14 +830,13 @@ class CodeGenerator(table: Table, specifiedClassName: Option[String] = None)(
 
     table.allColumns.map(_.rawTypeInScala).filter(timeClasses) match {
       case classes if classes.nonEmpty =>
+        val (l,r)= if(classes.size==1) ("","") else ("{","}")
         if (config.dateTimeClass == DateTimeClass.JodaDateTime) {
-          "import org.joda.time.{" + classes.distinct.mkString(
-            ", "
-          ) + "}" + eol +
+          "import org.joda.time." + classes.distinct.mkString(l, ", ", r) + eol +
             "import scalikejdbc.jodatime.JodaParameterBinderFactory._" + eol +
             "import scalikejdbc.jodatime.JodaTypeBinder._" + eol
         } else {
-          "import java.time.{" + classes.distinct.mkString(", ") + "}" + eol
+          "import java.time." + classes.distinct.mkString(l, ", ", r) + eol
         }
       case _ => ""
     }


### PR DESCRIPTION
## motivation
when there is only one item need to import
we shouldn't use `{`,`}`
![image](https://github.com/scalikejdbc/scalikejdbc/assets/35491928/9af45c23-888c-47fb-a81d-30c1f6552167)
 not generate
```scala
import java.time.{ZonedDateTime}
```
## test 
simple, and test locally