### PR TITLE
use new syntax in generated code

### DIFF
--- a/project/GenerateOneToManies.scala
+++ b/project/GenerateOneToManies.scala
@@ -86,9 +86,9 @@ ${(1 to n)
     }
   }
 
-  private[scalikejdbc] def toIterable(session: DBSession, sql: String, params: scala.collection.Seq[_], zExtractor: (A, $seq) => Z): Iterable[Z] = {
+  private[scalikejdbc] def toIterable(session: DBSession, sql: String, params: scala.collection.Seq[?], zExtractor: (A, $seq) => Z): Iterable[Z] = {
     val attributesSwitcher = createDBSessionAttributesSwitcher
-    DBSessionWrapper(session, attributesSwitcher).foldLeft(statement, rawParameters.toSeq: _*)(LinkedHashMap[A, ($seq)]())(processResultSet _).map {
+    DBSessionWrapper(session, attributesSwitcher).foldLeft(statement, rawParameters.toSeq*)(LinkedHashMap[A, ($seq)]())(processResultSet _).map {
       case (one, (${(1 to n)
         .map("t" + _)
         .mkString(", ")})) => zExtractor(one, ${(1 to n)


### PR DESCRIPTION
avoid warnings with Scala 3.4