### PR TITLE
use new syntax in generated code

### DIFF
--- a/project/GenerateOneToManies.scala
+++ b/project/GenerateOneToManies.scala
@@ -88,7 +88,7 @@ ${(1 to n)
 
   private[scalikejdbc] def toIterable(session: DBSession, sql: String, params: scala.collection.Seq[?], zExtractor: (A, $seq) => Z): Iterable[Z] = {
     val attributesSwitcher = createDBSessionAttributesSwitcher
-    DBSessionWrapper(session, attributesSwitcher).foldLeft(statement, rawParameters.toSeq*)(LinkedHashMap[A, ($seq)]())(processResultSet _).map {
+    DBSessionWrapper(session, attributesSwitcher).foldLeft(statement, rawParameters.toSeq*)(LinkedHashMap[A, ($seq)]())(processResultSet).map {
       case (one, (${(1 to n)
         .map("t" + _)
         .mkString(", ")})) => zExtractor(one, ${(1 to n)

--- a/project/GenerateOneToXSQL.scala
+++ b/project/GenerateOneToXSQL.scala
@@ -21,7 +21,7 @@ class OneToXSQL[A, E <: WithExtractor, Z](
     val q: OneToManySQL[A, B, E, Z] = new OneToManySQL(statement, rawParameters)(one)(to)((a, bs) => a.asInstanceOf[Z])
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags.toSeq: _*)
+    q.tags(tags.toSeq*)
     q
   }
 
@@ -58,7 +58,7 @@ object OneToXSQL {
       .mkString(", ")}) => a.asInstanceOf[Z])
     q.queryTimeout(queryTimeout)
     q.fetchSize(fetchSize)
-    q.tags(tags.toSeq: _*)
+    q.tags(tags.toSeq*)
   }
 """
 }


### PR DESCRIPTION
avoid Scala 3.4 warnings