### PR TITLE
Handling connection failures by DB.futureLocalTx 

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/DB.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/DB.scala
@@ -3,6 +3,7 @@ package scalikejdbc
 import java.sql.Connection
 import scalikejdbc.metadata._
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.Try
 
 /**
  * Basic Database Accessor
@@ -313,7 +314,8 @@ object DB extends LoanPattern {
   ): Future[A] = {
     // Enable TxBoundary implicits
     import scalikejdbc.TxBoundary.Future._
-    localTx(execution)(context, implicitly, settings)
+    Try(localTx(execution)(context, implicitly, settings))
+      .fold(err => Future.failed(err), a => a)
   }
 
   /**

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DBSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DBSpec.scala
@@ -398,6 +398,19 @@ class DBSpec
     }
   }
 
+  it should "return failed future on connection failure" in {
+    implicit val failingPool: ConnectionPoolContext = {
+      new ConnectionPoolContext {
+        override def set(name: Any, pool: ConnectionPool): Unit =
+          throw new RuntimeException
+        override def get(name: Any): ConnectionPool = null
+      }
+    }
+    val fallback = 2
+    val fResult = DB futureLocalTx { _ => Future.successful(1) } recover { case _: IllegalStateException => fallback }
+    whenReady(fResult) { _ should equal(fallback) }
+  }
+
   // --------------------
   // localTx with an IO monad example
 

--- a/scalikejdbc-core/src/test/scala/scalikejdbc/DBSpec.scala
+++ b/scalikejdbc-core/src/test/scala/scalikejdbc/DBSpec.scala
@@ -407,7 +407,9 @@ class DBSpec
       }
     }
     val fallback = 2
-    val fResult = DB futureLocalTx { _ => Future.successful(1) } recover { case _: IllegalStateException => fallback }
+    val fResult = DB futureLocalTx { _ => Future.successful(1) } recover {
+      case _: IllegalStateException => fallback
+    }
     whenReady(fResult) { _ should equal(fallback) }
   }
 


### PR DESCRIPTION
`DB.futureLocalTx` throws exception in case of a connection failure. Instead, a `Future.failed` would be more convenient and aligned with the method signature.