### PR TITLE
`-Xsource:3-cross`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,8 +79,21 @@ lazy val baseSettings = Def.settings(
     } else {
       Seq(
         "-language:higherKinds",
-        "-Xsource:3"
       )
+    }
+  },
+  scalacOptions ++= {
+    scalaBinaryVersion.value match {
+      case "2.12" =>
+        Seq(
+          "-Xsource:3",
+        )
+      case "2.13" =>
+        Seq(
+          "-Xsource:3-cross",
+        )
+      case _ =>
+        Nil
     }
   },
   scalacOptions ++= PartialFunction


### PR DESCRIPTION
https://docs.scala-lang.org/scala3/guides/migration/tooling-scala2-xsource3.html