### PR TITLE
exclude protobuf from mysql-connector-j

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,8 @@ def scalatestVersion = "3.2.19"
 lazy val mockitoVersion = "4.11.0"
 val specs2 = "org.specs2" %% "specs2-core" % "4.20.8" % "provided"
 
-val mysqlConnectorJ = "com.mysql" % "mysql-connector-j" % "9.0.0" % Test
+val mysqlConnectorJ =
+  "com.mysql" % "mysql-connector-j" % "9.0.0" % Test exclude ("com.google.protobuf", "protobuf-java")
 
 def gitHash: String = try {
   sys.process.Process("git rev-parse HEAD").lineStream_!.head


### PR DESCRIPTION
https://dev.mysql.com/doc/connector-j/en/connector-j-installing-maven.html

> Notice that if you use Maven to manage your project dependencies, you do not need to explicitly refer to the library protobuf-java as it is resolved by dependency transitivity. However, if you do not want to use the X DevAPI features, you may also want to add a dependency exclusion to avoid linking the unneeded sub-library. For example:
> 
> ```xml
> <dependency>
>     <groupId>com.mysql</groupId>
>     <artifactId>mysql-connector-j</artifactId>
>     <version>x.y.z</version>
>     <exclusions>
>         <exclusion>
>             <groupId>com.google.protobuf</groupId>
>             <artifactId>protobuf-java</artifactId>
>         </exclusion>
>     </exclusions> 
> </dependency>
> ```