### PR TITLE
Change regex invocations to improve performance, master

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
@@ -351,6 +351,9 @@ trait AsteriskProvider {
  */
 object SQLSyntax {
 
+  private val andRegExp = ".+\\s+and\\s+.+".r
+  private val orRegExp = ".+\\s+or\\s+.+".r
+
   import Implicits._
 
   val empty: SQLSyntax = sqls""
@@ -404,8 +407,8 @@ object SQLSyntax {
 
   private[this] def hasAndOr(s: SQLSyntax): Boolean = {
     val statement = s.value.toLowerCase(ENGLISH)
-    statement.matches(".+\\s+and\\s+.+") ||
-    statement.matches(".+\\s+or\\s+.+")
+    andRegExp.pattern.matcher(statement).matches ||
+    orRegExp.pattern.matcher(statement).matches
   }
 
   def joinWithAnd(parts: SQLSyntax*): SQLSyntax =


### PR DESCRIPTION
> We create the regex once and than repeatedly use it, saving on performance at scale.
> 
> © Bold Security Technology B.V. Licensed under Apache 2.0

## Changes
All changes are based on the logging that I've gathered from our environments. That way I hope to limit the impact on scalikejdbc, while also getting the some real-world performance improvements. See https://github.com/scalikejdbc/scalikejdbc/issues/2302 for more discussion.

## Unchanged
Some instances of `.replaceFirst()` are not that important for performance, and changing these invocations would hurt readability. One good example where Regex would only make things unclear, is here:

### SQLSyntaxSupportFeature, line 133

```scala
    def tableName: String = {
      val className = getClassSimpleName(this)
        .replaceFirst("\\$$", "")
        .replaceFirst("^.+\\.", "")
        .replaceFirst("^.+\\$", "")
      )
    }
```

If I were to change this code, it would look more like:

```scala

private val dollarEndRegex = "\\$$".r
private val dollarStartRegex = "^.+\\$".r
private val dotRegex = "^.+\\.".r

def tableName: String = {
      val simpleName = getClassSimpleName(this)

      val className =
        dollarEndRegex.replaceFirstIn(
          dollarStartRegex
            .replaceFirstIn(dotRegex.replaceFirstIn(simpleName, ""), ""),
          ""
        )
    }
```
This would not make anything any better, and the limitations with Scala in relation to [Regex chaining](https://groups.google.com/g/scala-user/c/c-DNXdm6CnY) shine through at a moment like this.

## Testing
No additional tests, but all tests succeed locally and scalafmt has also been applied.