### PR TITLE
Change regex invocations to improve performance, 4.3.x

### DIFF
--- a/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
+++ b/scalikejdbc-core/src/main/scala/scalikejdbc/interpolation/SQLSyntax.scala
@@ -351,6 +351,9 @@ trait AsteriskProvider {
  */
 object SQLSyntax {
 
+  private val andRegExp = ".+\\s+and\\s+.+".r
+  private val orRegExp = ".+\\s+or\\s+.+".r
+
   import Implicits._
 
   val empty: SQLSyntax = sqls""
@@ -404,8 +407,8 @@ object SQLSyntax {
 
   private[this] def hasAndOr(s: SQLSyntax): Boolean = {
     val statement = s.value.toLowerCase(ENGLISH)
-    statement.matches(".+\\s+and\\s+.+") ||
-    statement.matches(".+\\s+or\\s+.+")
+    andRegExp.pattern.matcher(statement).matches ||
+    orRegExp.pattern.matcher(statement).matches
   }
 
   def joinWithAnd(parts: SQLSyntax*): SQLSyntax =

--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
@@ -11,6 +11,9 @@ import scala.language.dynamics
  */
 object SQLSyntaxSupportFeature extends LogSupport {
 
+  private val whiteSpaceRegExp = ".*\\s+.*".r
+  private val semicolonRegExp = ".*;.*".r
+
   /**
    * Loaded columns for tables.
    */
@@ -41,8 +44,8 @@ object SQLSyntaxSupportFeature extends LogSupport {
     tableNameWithSchema != null
   ) {
     val name = tableNameWithSchema.trim
-    val hasWhiteSpace = name.matches(".*\\s+.*")
-    val hasSemicolon = name.matches(".*;.*")
+    val hasWhiteSpace = whiteSpaceRegExp.pattern.matcher(name).matches
+    val hasSemicolon = semicolonRegExp.pattern.matcher(name).matches
     if (hasWhiteSpace || hasSemicolon) {
       log.warn(
         s"The table name (${name}) might bring you SQL injection vulnerability."
@@ -385,6 +388,8 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
     private val acronymRegExp = acronymRegExpStr.r
     private val endsWithAcronymRegExp = "[A-Z]{2,}$".r
     private val singleUpperCaseRegExp = """[A-Z]""".r
+    private val danglingUnderscoreRegExp = "^_|_$".r
+    private val underscoreRegExp = "_".r
 
     /**
      * Returns the snake_case name after applying nameConverters.
@@ -412,13 +417,13 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
               .toLowerCase(en)
           }
         )
-        val result = singleUpperCaseRegExp
+        val mergedAcronyms = singleUpperCaseRegExp
           .replaceAllIn(
             acronymsFiltered,
             { m => "_" + m.matched.toLowerCase(en) }
           )
-          .replaceFirst("^_", "")
-          .replaceFirst("_$", "")
+
+        val result = danglingUnderscoreRegExp.replaceAllIn(mergedAcronyms, "")
 
         if (str.startsWith("_")) "_" + result
         else if (str.endsWith("_")) result + "_"
@@ -437,7 +442,7 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
       columns: collection.Seq[String]
     ): String = {
       def shorten(s: String): String =
-        s.split("_").map(_.take(1)).mkString
+        underscoreRegExp.split(s).map(_.take(1)).mkString
 
       val shortenedName = shorten(toAlphabetOnly(name))
       val shortenedNames = columns.map(c => shorten(toAlphabetOnly(c)))


### PR DESCRIPTION
>We create the regex once and than repeatedly use it, saving on performance at scale.
>
>© Bold Security Technology B.V. Licensed under Apache 2.0

---

See https://github.com/scalikejdbc/scalikejdbc/pull/2303 for details