### PR TITLE
Class name regex improvement

### DIFF
--- a/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
+++ b/scalikejdbc-interpolation/src/main/scala/scalikejdbc/SQLSyntaxSupportFeature.scala
@@ -110,6 +110,9 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
    */
   trait SQLSyntaxSupport[A] {
 
+    // This regex removes trailing $, as well as anything until the first $ or .
+    private val classNameRegExp = "\\$$|^.*[.$](?=.+)".r
+
     private val dotRegExp = "\\.".r
 
     protected[this] def settings: SettingsProvider =
@@ -134,12 +137,12 @@ trait SQLSyntaxSupportFeature { self: SQLInterpolationFeature =>
      * Table name (default: the snake_case name from this companion object's name).
      */
     def tableName: String = {
+
       val className = getClassSimpleName(this)
-        .replaceFirst("\\$$", "")
-        .replaceFirst("^.+\\.", "")
-        .replaceFirst("^.+\\$", "")
+      val formattedName = classNameRegExp.replaceAllIn(className, "")
+
       SQLSyntaxProvider.toColumnName(
-        className,
+        formattedName,
         nameConverters,
         useSnakeCaseColumnName
       )

--- a/scalikejdbc-syntax-support-macro/src/main/scala-2/scalikejdbc/SQLSyntaxSupportFactory.scala
+++ b/scalikejdbc-syntax-support-macro/src/main/scala-2/scalikejdbc/SQLSyntaxSupportFactory.scala
@@ -5,6 +5,9 @@ import scala.reflect.macros.blackbox.Context
 
 object SQLSyntaxSupportFactory {
 
+  // This regex removes trailing $, as well as anything until the first $ or .
+  private val classNameRegExp = "\\$$|^.*[.$](?=.+)".r
+
   def apply_impl[A: c.WeakTypeTag](
     c: Context
   )(excludes: c.Expr[String]*): c.Expr[SQLSyntaxSupportImpl[A]] = {
@@ -33,10 +36,7 @@ object SQLSyntaxSupportFactory {
   }
 
   def camelToSnake(className: String): String = {
-    val clazz = className
-      .replaceFirst("\\$$", "")
-      .replaceFirst("^.+\\.", "")
-      .replaceFirst("^.+\\$", "")
+    val clazz = classNameRegExp.replaceAllIn(className, "")
     SQLSyntaxProvider.toColumnName(clazz, Map.empty, true)
   }
 

--- a/scalikejdbc-syntax-support-macro/src/main/scala-3/scalikejdbc/SQLSyntaxSupportFactory.scala
+++ b/scalikejdbc-syntax-support-macro/src/main/scala-3/scalikejdbc/SQLSyntaxSupportFactory.scala
@@ -6,11 +6,11 @@ import language.`3.0`
 
 object SQLSyntaxSupportFactory {
 
+  // This regex removes trailing $, as well as anything until the first $ or .
+  private val classNameRegExp = "\\$$|^.*[.$](?=.+)".r
+
   def camelToSnake(className: String): String = {
-    val clazz = className
-      .replaceFirst("\\$$", "")
-      .replaceFirst("^.+\\.", "")
-      .replaceFirst("^.+\\$", "")
+    val clazz = classNameRegExp.replaceAllIn(className, "")
     SQLSyntaxProvider.toColumnName(clazz, Map.empty, true)
   }
 

--- a/scalikejdbc-syntax-support-macro/src/test/scala/foo/ClassNameCamelToSnakeSpec.scala
+++ b/scalikejdbc-syntax-support-macro/src/test/scala/foo/ClassNameCamelToSnakeSpec.scala
@@ -1,0 +1,49 @@
+package foo
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.language.postfixOps
+import scala.util.matching.Regex
+
+class ClassNameCamelToSnakeSpec extends AnyFlatSpec with Matchers {
+
+  // This regex removes trailing $, as well as anything until the first $ or .
+  val classNameRegExp: Regex = "\\$$|^.*[.$](?=.+)".r
+
+  def newImplementation(className: String): String = {
+    classNameRegExp.replaceAllIn(className, "")
+  }
+
+  def oldImplementation(className: String): String = {
+    className
+      .replaceFirst("\\$$", "")
+      .replaceFirst("^.+\\.", "")
+      .replaceFirst("^.+\\$", "")
+  }
+
+  behavior of "ClassName CamelToSpec"
+
+  it should "match" in {
+    val inputs = Set(
+      "className",
+      "prefix.className",
+      "prefix$className",
+      "className$",
+      "prefix.className$",
+      "prefix$className$",
+      "className$postfix",
+      "prefix.className$postfix",
+      "prefix$className$postfix",
+      "additional.prefix.className$postfix",
+      "additional$prefix$className$postfix",
+      "additional.prefix.className$postfix$superfluous",
+      "additional$prefix$className$postfix$superfluous",
+    )
+
+    inputs.map(name => {
+      newImplementation(name) shouldBe oldImplementation(name)
+    })
+  }
+
+}


### PR DESCRIPTION
We collapse multiple regex, and we create the regex once and than repeatedly use it. Both changes save on performance at scale.

© Bold Security Technology B.V. Licensed under Apache 2.0

----

I've created a test-class to demonstrate the correctness of my change.