### PR TITLE
fix autoConstruct macro

### DIFF
--- a/scalikejdbc-syntax-support-macro/src/main/scala-2/scalikejdbc/autoConstruct.scala
+++ b/scalikejdbc-syntax-support-macro/src/main/scala-2/scalikejdbc/autoConstruct.scala
@@ -16,7 +16,7 @@ object autoConstruct {
         field =>
           val fieldType = field.typeSignature
           val name = field.name.decodedName.toString
-          q"${field.name.toTermName} = $rs.get[$fieldType]($rn.field($name))"
+          q"${field.name.toTermName} = $rs.get[$fieldType]($rn.field($name).value)"
       }
     c.Expr[A](q"new ${weakTypeTag[A].tpe}(..$constParams)")
   }


### PR DESCRIPTION
## before

with `-Xsource:3-cross` option

```
Welcome to Scala 2.13.16 -Xsource:3.0.0 (OpenJDK 64-Bit Server VM, Java 1.8.0_442).
Type in expressions for evaluation. Or try :help.

scala> case class A(x: Int, y: String); object A extends scalikejdbc.SQLSyntaxSupport[A] { def apply(rn: scalikejdbc.ResultName[A])(rs: scalikejdbc.WrappedResultSet): A = scalikejdbc.autoConstruct(rs, rn) }
                                                                                                                                                                                                    ^
       error: overloaded method get with alternatives:
         (columnLabel: String)(implicit evidence$2: scalikejdbc.TypeBinder[Int]): Int <and>
         (columnIndex: Int)(implicit evidence$1: scalikejdbc.TypeBinder[Int]): Int
        cannot be applied to (scalikejdbc.interpolation.SQLSyntax)

scala> import scalikejdbc.scalikejdbcSQLSyntaxToStringImplicitDef
import scalikejdbc.scalikejdbcSQLSyntaxToStringImplicitDef

scala> case class A(x: Int, y: String); object A extends scalikejdbc.SQLSyntaxSupport[A] { def apply(rn: scalikejdbc.ResultName[A])(rs: scalikejdbc.WrappedResultSet): A = scalikejdbc.autoConstruct(rs, rn) }
class A
object A
```

> package-prefix-implicits: an implicit for type p.A is found in the package prefix p | fatal warning | the package prefix p is no longer part of the implicit search scope

![image](https://github.com/user-attachments/assets/f61fd8f8-1030-4b1e-8118-47a27fcdebe3)


- https://github.com/scala/scala/pull/10621


## After

```
Welcome to Scala 2.13.16 -Xsource:3.0.0 (OpenJDK 64-Bit Server VM, Java 1.8.0_442).
Type in expressions for evaluation. Or try :help.

scala> case class A(x: Int, y: String); object A extends scalikejdbc.SQLSyntaxSupport[A] { def apply(rn: scalikejdbc.ResultName[A])(rs: scalikejdbc.WrappedResultSet): A = scalikejdbc.autoConstruct(rs, rn) }
class A
object A
```