### PR TITLE
add `readOnlyStream` extension method for ConnectionPool

### DIFF
--- a/scalikejdbc-streams/src/main/scala/scalikejdbc/streams/package.scala
+++ b/scalikejdbc-streams/src/main/scala/scalikejdbc/streams/package.scala
@@ -32,6 +32,23 @@ package object streams {
     )
   }
 
+  implicit class EnableConnectionPoolCodeBlockToProvideDatabasePublisher(
+    private val pool: ConnectionPool
+  ) extends AnyVal {
+
+    def readOnlyStream[A](sql: StreamReadySQL[A])(implicit
+      executionContext: ExecutionContext,
+      settings: SettingsProvider = SettingsProvider.default
+    ): DatabasePublisher[A] = {
+
+      createDatabasePublisher(sql, ConnectionPool.DEFAULT_NAME)(
+        executionContext,
+        MultipleConnectionPoolContext(ConnectionPool.DEFAULT_NAME -> pool),
+        settings
+      )
+    }
+  }
+
   /**
    * An implicit to enable the `DB.readOnlyStream` method:
    *


### PR DESCRIPTION
Hi,

I prefer not relying on global mutable state like the global map for named connection pools, and so I like just being able to call `readOnlyStream` on a `ConnectionPool` object. 